### PR TITLE
feat: inline PR review comments with collateral damage detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+scripts/__pycache__/

--- a/action.yml
+++ b/action.yml
@@ -277,9 +277,13 @@ runs:
         RESULTS="{}"
         OVERALL_EXIT=0
 
-        # Create temp dir for capturing output
+        # Create temp dirs for capturing output and annotations
         HOMEBOY_OUTPUT_DIR=$(mktemp -d)
         echo "HOMEBOY_OUTPUT_DIR=${HOMEBOY_OUTPUT_DIR}" >> "$GITHUB_ENV"
+
+        HOMEBOY_ANNOTATIONS_DIR=$(mktemp -d)
+        echo "HOMEBOY_ANNOTATIONS_DIR=${HOMEBOY_ANNOTATIONS_DIR}" >> "$GITHUB_ENV"
+        export HOMEBOY_ANNOTATIONS_DIR
 
         # Parse comma-separated commands
         IFS=',' read -ra CMD_ARRAY <<< "$COMMANDS"
@@ -484,3 +488,80 @@ runs:
         fi
 
         echo "PR comment posted successfully"
+
+    # ── Step 8: Post inline PR review comments ──
+    - name: Post inline review
+      if: always() && github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        set -euo pipefail
+
+        ANNOTATIONS_DIR="${HOMEBOY_ANNOTATIONS_DIR:-}"
+        REPO="${GITHUB_REPOSITORY}"
+        ACTION_DIR="${GITHUB_ACTION_PATH}"
+
+        if [ -z "$ANNOTATIONS_DIR" ] || [ -z "$PR_NUMBER" ]; then
+          echo "Skipping inline review — missing annotations dir or PR number"
+          exit 0
+        fi
+
+        # Check if any annotation files exist
+        ANNOTATION_COUNT=$(find "$ANNOTATIONS_DIR" -name "*.json" -type f 2>/dev/null | wc -l)
+        if [ "$ANNOTATION_COUNT" -eq 0 ]; then
+          echo "No annotation files found — skipping inline review"
+          exit 0
+        fi
+
+        echo "Found ${ANNOTATION_COUNT} annotation file(s):"
+        ls -la "$ANNOTATIONS_DIR"/*.json 2>/dev/null || true
+
+        # Get list of changed files from the PR
+        CHANGED_FILES_FILE=$(mktemp)
+        gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+          --paginate --jq '.[].filename' > "$CHANGED_FILES_FILE" 2>/dev/null || true
+
+        if [ ! -s "$CHANGED_FILES_FILE" ]; then
+          echo "Could not fetch PR changed files — skipping inline review"
+          rm -f "$CHANGED_FILES_FILE"
+          exit 0
+        fi
+
+        # Build the review payload
+        REVIEW_PAYLOAD=$(python3 "${ACTION_DIR}/scripts/build-review.py" \
+          "$ANNOTATIONS_DIR" "$CHANGED_FILES_FILE" "$PR_HEAD_SHA" 2>/dev/null || true)
+
+        rm -f "$CHANGED_FILES_FILE"
+
+        if [ -z "$REVIEW_PAYLOAD" ]; then
+          echo "No annotations to post — skipping inline review"
+          exit 0
+        fi
+
+        # Dismiss previous homeboy reviews to avoid stacking
+        EXISTING_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+          --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("Homeboy found"))) | .id] | .[]' \
+          2>/dev/null || true)
+
+        for REVIEW_ID in $EXISTING_REVIEWS; do
+          echo "Dismissing previous review ${REVIEW_ID}..."
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}/dismissals" \
+            --method PUT \
+            --field message="Superseded by new Homeboy review" \
+            --field event="DISMISS" > /dev/null 2>&1 || true
+        done
+
+        # Post the review
+        echo "$REVIEW_PAYLOAD" | gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+          --method POST \
+          --input - > /dev/null 2>&1
+
+        COMMENT_COUNT=$(echo "$REVIEW_PAYLOAD" | python3 -c "
+        import json, sys
+        d = json.load(sys.stdin)
+        print(len(d.get('comments', [])))
+        " 2>/dev/null || echo "0")
+        echo "Posted inline review with ${COMMENT_COUNT} comment(s)"

--- a/scripts/build-review.py
+++ b/scripts/build-review.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Build a GitHub PR review payload from Homeboy annotation sidecar JSON files.
+
+Usage:
+    build-review.py <annotations_dir> <changed_files_path> <commit_sha>
+
+Reads all *.json files from <annotations_dir> (written by homeboy extension
+lint scripts), splits annotations into inline (in PR diff) vs collateral
+(in untouched files), and prints a JSON payload suitable for the GitHub
+Pull Request Reviews API.
+
+Exits 0 with no output if there are no annotations to post.
+
+Annotation JSON format (array of objects):
+    [
+        {
+            "file": "inc/Foo.php",
+            "line": 42,
+            "message": "Parameter expects int, string given.",
+            "source": "phpstan",
+            "severity": "error",
+            "code": "argument.type"
+        }
+    ]
+
+Supported sources: phpcs, phpstan, clippy, rustfmt
+"""
+
+import json
+import os
+import sys
+
+
+def load_annotations(annotations_dir: str) -> list[dict]:
+    """Load all annotation JSON files from the directory."""
+    annotations = []
+    for fname in sorted(os.listdir(annotations_dir)):
+        if not fname.endswith('.json'):
+            continue
+        fpath = os.path.join(annotations_dir, fname)
+        try:
+            with open(fpath, 'r') as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                annotations.extend(data)
+        except (json.JSONDecodeError, IOError) as e:
+            print(f"Warning: failed to read {fname}: {e}", file=sys.stderr)
+            continue
+    return annotations
+
+
+def load_changed_files(path: str) -> set[str]:
+    """Load the set of changed file paths from a newline-delimited file."""
+    with open(path, 'r') as f:
+        return set(line.strip() for line in f if line.strip())
+
+
+def format_comment_body(source: str, code: str, severity: str, message: str) -> str:
+    """Format a single inline comment body."""
+    icon = ':x:' if severity == 'error' else ':warning:'
+    body = f'{icon} **{source}**'
+    if code:
+        body += f' `{code}`'
+    body += f'\n{message}'
+    return body
+
+
+def build_collateral_section(collateral: list[dict]) -> list[str]:
+    """Build markdown lines for the collateral damage section."""
+    lines = []
+    lines.append(f'\n### Collateral damage ({len(collateral)} issue(s) in untouched files)\n')
+    lines.append('These errors are in files you did not modify but may be caused by your changes:\n')
+
+    by_file: dict[str, list[dict]] = {}
+    for c in collateral:
+        by_file.setdefault(c['file'], []).append(c)
+
+    for fpath, issues in sorted(by_file.items()):
+        lines.append(f'**{fpath}**')
+        for issue in issues[:5]:
+            icon = ':x:' if issue['severity'] == 'error' else ':warning:'
+            code_str = f' `{issue["code"]}`' if issue.get('code') else ''
+            lines.append(f'- {icon} L{issue["line"]}: {issue["message"]}{code_str}')
+        if len(issues) > 5:
+            lines.append(f'- _...and {len(issues) - 5} more_')
+        lines.append('')
+
+    return lines
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <annotations_dir> <changed_files_path> <commit_sha>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    annotations_dir = sys.argv[1]
+    changed_files_path = sys.argv[2]
+    commit_sha = sys.argv[3]
+
+    # Load inputs
+    changed_files = load_changed_files(changed_files_path)
+    all_annotations = load_annotations(annotations_dir)
+
+    if not all_annotations:
+        sys.exit(0)
+
+    # Split into inline (in diff) vs collateral (not in diff)
+    inline_comments = []
+    collateral = []
+    seen: set[str] = set()
+
+    for ann in all_annotations:
+        file_path = ann.get('file', '')
+        line = ann.get('line', 0)
+        message = ann.get('message', '')
+        source = ann.get('source', '')
+        code = ann.get('code', '')
+        severity = ann.get('severity', 'error')
+
+        if not file_path or not line or not message:
+            continue
+
+        dedup_key = f'{file_path}:{line}:{source}:{code}'
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+
+        if file_path in changed_files:
+            inline_comments.append({
+                'path': file_path,
+                'line': int(line),
+                'body': format_comment_body(source, code, severity, message),
+            })
+        else:
+            collateral.append({
+                'file': file_path,
+                'line': int(line),
+                'message': message,
+                'source': source,
+                'code': code,
+                'severity': severity,
+            })
+
+    # Nothing to post
+    if not inline_comments and not collateral:
+        sys.exit(0)
+
+    # Cap inline comments at 50 (GitHub API limit per review)
+    overflow_note = ''
+    if len(inline_comments) > 50:
+        overflow = len(inline_comments) - 50
+        inline_comments = inline_comments[:50]
+        overflow_note = f'\n\n_...and {overflow} more annotations not shown (GitHub limits reviews to 50 comments)._'
+
+    # Build review body
+    review_body_parts = []
+    if inline_comments:
+        review_body_parts.append(
+            f'Homeboy found **{len(inline_comments)}** issue(s) in changed files.'
+        )
+    if collateral:
+        review_body_parts.extend(build_collateral_section(collateral))
+    if overflow_note:
+        review_body_parts.append(overflow_note)
+
+    payload = {
+        'commit_id': commit_sha,
+        'body': '\n'.join(review_body_parts),
+        'event': 'COMMENT',
+        'comments': inline_comments,
+    }
+
+    print(json.dumps(payload))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds inline PR review comments to the homeboy-action, posting lint/analysis findings directly on the diff lines like a human code reviewer. Also detects **collateral damage** — errors in files the PR didn't touch but may have broken.

Closes #2

### How it works

```
Extensions (lint scripts)          Action (action.yml)
┌─────────────────────┐     ┌──────────────────────────────┐
│ PHPCS → phpcs.json  │     │ Step 9: Run Homeboy commands │
│ PHPStan → phpstan.json ──→│   sets HOMEBOY_ANNOTATIONS_DIR│
│ Clippy → clippy.json│     │                              │
│ Rustfmt → rustfmt.json    │ Step 10: Post PR comment     │
└─────────────────────┘     │   (existing summary comment) │
                            │                              │
                            │ Step 11: Post inline review  │
                            │   1. Read annotation JSONs   │
                            │   2. Get PR changed files    │
                            │   3. Split: inline vs        │
                            │      collateral              │
                            │   4. Post review via API     │
                            └──────────────────────────────┘
```

### Changes

- **action.yml** — Creates `HOMEBOY_ANNOTATIONS_DIR` temp dir and exports it before running commands. New Step 11 "Post inline review" reads annotation files, fetches PR diff, and posts review.
- **scripts/build-review.py** — Standalone Python script that processes annotation JSONs into a GitHub Reviews API payload. Handles deduplication, 50-comment cap, and collateral damage grouping.
- **.gitignore** — Ignore `__pycache__`

### Features

- **Inline comments** on changed files — PHPCS, PHPStan, clippy, rustfmt findings appear right on the diff
- **Collateral damage detection** — PHPStan runs full codebase (via companion extensions PR), so broken call sites in untouched files appear in the review body
- **Deduplication** by file:line:source:code
- **50-comment cap** per review (GitHub API limit), with overflow note
- **Review dismissal** — previous homeboy reviews are dismissed to avoid stacking
- **Fail-safe** — gracefully skips if no annotations, no changed files, or API errors

### Example output

**Inline comment on a changed file:**
> :x: **phpstan** `argument.type`
> Parameter #1 $new_blog_id of function switch_to_blog expects int, string given.

**Collateral damage in review body:**
> ### Collateral damage (3 issue(s) in untouched files)
> These errors are in files you did not modify but may be caused by your changes:
>
> **inc/Untouched.php**
> - :x: L100: Call to undefined method. `method.notFound`

### Dependencies

Requires companion PR: Extra-Chill/homeboy-extensions#74 (annotation sidecar JSON output from lint scripts)