### PR TITLE
fix: scope collateral damage to related files only

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -530,11 +530,26 @@ runs:
           exit 0
         fi
 
-        # Build the review payload
-        REVIEW_PAYLOAD=$(python3 "${ACTION_DIR}/scripts/build-review.py" \
-          "$ANNOTATIONS_DIR" "$CHANGED_FILES_FILE" "$PR_HEAD_SHA" 2>/dev/null || true)
+        # Find files related to the changed files (call sites, importers)
+        # Only errors in these files qualify as collateral damage
+        RELATED_FILES_FILE=$(mktemp)
+        echo "Tracing symbol references from changed files..."
+        python3 "${ACTION_DIR}/scripts/find-related-files.py" \
+          "$(pwd)" "$CHANGED_FILES_FILE" > "$RELATED_FILES_FILE" || true
 
-        rm -f "$CHANGED_FILES_FILE"
+        RELATED_COUNT=$(wc -l < "$RELATED_FILES_FILE" | tr -d ' ')
+        echo "Found ${RELATED_COUNT} related file(s)"
+
+        # Build the review payload (pass related files for collateral scoping)
+        REVIEW_ARGS=("$ANNOTATIONS_DIR" "$CHANGED_FILES_FILE" "$PR_HEAD_SHA")
+        if [ -s "$RELATED_FILES_FILE" ]; then
+          REVIEW_ARGS+=("$RELATED_FILES_FILE")
+        fi
+
+        REVIEW_PAYLOAD=$(python3 "${ACTION_DIR}/scripts/build-review.py" \
+          "${REVIEW_ARGS[@]}" 2>/dev/null || true)
+
+        rm -f "$CHANGED_FILES_FILE" "$RELATED_FILES_FILE"
 
         if [ -z "$REVIEW_PAYLOAD" ]; then
           echo "No annotations to post — skipping inline review"
@@ -543,7 +558,7 @@ runs:
 
         # Dismiss previous homeboy reviews to avoid stacking
         EXISTING_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-          --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("Homeboy found"))) | .id] | .[]' \
+          --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("Homeboy found|Collateral damage"))) | .id] | .[]' \
           2>/dev/null || true)
 
         for REVIEW_ID in $EXISTING_REVIEWS; do

--- a/scripts/build-review.py
+++ b/scripts/build-review.py
@@ -2,12 +2,17 @@
 """Build a GitHub PR review payload from Homeboy annotation sidecar JSON files.
 
 Usage:
-    build-review.py <annotations_dir> <changed_files_path> <commit_sha>
+    build-review.py <annotations_dir> <changed_files_path> <commit_sha> [<related_files_path>]
 
 Reads all *.json files from <annotations_dir> (written by homeboy extension
 lint scripts), splits annotations into inline (in PR diff) vs collateral
 (in untouched files), and prints a JSON payload suitable for the GitHub
 Pull Request Reviews API.
+
+Collateral damage is scoped: only errors in files that reference symbols
+from the changed files are reported. If <related_files_path> is provided,
+only those files are eligible for collateral. If not provided, collateral
+damage is skipped entirely (no way to distinguish pre-existing vs new).
 
 Exits 0 with no output if there are no annotations to post.
 
@@ -49,8 +54,8 @@ def load_annotations(annotations_dir: str) -> list[dict]:
     return annotations
 
 
-def load_changed_files(path: str) -> set[str]:
-    """Load the set of changed file paths from a newline-delimited file."""
+def load_file_set(path: str) -> set[str]:
+    """Load a set of file paths from a newline-delimited file."""
     with open(path, 'r') as f:
         return set(line.strip() for line in f if line.strip())
 
@@ -68,8 +73,13 @@ def format_comment_body(source: str, code: str, severity: str, message: str) -> 
 def build_collateral_section(collateral: list[dict]) -> list[str]:
     """Build markdown lines for the collateral damage section."""
     lines = []
-    lines.append(f'\n### Collateral damage ({len(collateral)} issue(s) in untouched files)\n')
-    lines.append('These errors are in files you did not modify but may be caused by your changes:\n')
+    lines.append(
+        f'\n### Collateral damage ({len(collateral)} issue(s) in related files)\n'
+    )
+    lines.append(
+        'These errors are in files that reference symbols you changed '
+        'but were not part of this PR:\n'
+    )
 
     by_file: dict[str, list[dict]] = {}
     for c in collateral:
@@ -80,7 +90,9 @@ def build_collateral_section(collateral: list[dict]) -> list[str]:
         for issue in issues[:5]:
             icon = ':x:' if issue['severity'] == 'error' else ':warning:'
             code_str = f' `{issue["code"]}`' if issue.get('code') else ''
-            lines.append(f'- {icon} L{issue["line"]}: {issue["message"]}{code_str}')
+            lines.append(
+                f'- {icon} L{issue["line"]}: {issue["message"]}{code_str}'
+            )
         if len(issues) > 5:
             lines.append(f'- _...and {len(issues) - 5} more_')
         lines.append('')
@@ -89,23 +101,31 @@ def build_collateral_section(collateral: list[dict]) -> list[str]:
 
 
 def main():
-    if len(sys.argv) != 4:
-        print(f"Usage: {sys.argv[0]} <annotations_dir> <changed_files_path> <commit_sha>",
-              file=sys.stderr)
+    if len(sys.argv) < 4 or len(sys.argv) > 5:
+        print(
+            f"Usage: {sys.argv[0]} <annotations_dir> <changed_files_path> "
+            f"<commit_sha> [<related_files_path>]",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     annotations_dir = sys.argv[1]
     changed_files_path = sys.argv[2]
     commit_sha = sys.argv[3]
+    related_files_path = sys.argv[4] if len(sys.argv) > 4 else None
 
     # Load inputs
-    changed_files = load_changed_files(changed_files_path)
+    changed_files = load_file_set(changed_files_path)
     all_annotations = load_annotations(annotations_dir)
+    related_files = load_file_set(related_files_path) if related_files_path else set()
 
     if not all_annotations:
         sys.exit(0)
 
-    # Split into inline (in diff) vs collateral (not in diff)
+    # Split annotations into three buckets:
+    #   1. inline — in changed files (posted as inline PR review comments)
+    #   2. collateral — in related files (shown in review body)
+    #   3. unrelated — in files with no symbol link to changes (dropped)
     inline_comments = []
     collateral = []
     seen: set[str] = set()
@@ -132,7 +152,7 @@ def main():
                 'line': int(line),
                 'body': format_comment_body(source, code, severity, message),
             })
-        else:
+        elif file_path in related_files:
             collateral.append({
                 'file': file_path,
                 'line': int(line),
@@ -141,6 +161,7 @@ def main():
                 'code': code,
                 'severity': severity,
             })
+        # else: unrelated pre-existing error — silently dropped
 
     # Nothing to post
     if not inline_comments and not collateral:
@@ -151,7 +172,10 @@ def main():
     if len(inline_comments) > 50:
         overflow = len(inline_comments) - 50
         inline_comments = inline_comments[:50]
-        overflow_note = f'\n\n_...and {overflow} more annotations not shown (GitHub limits reviews to 50 comments)._'
+        overflow_note = (
+            f'\n\n_...and {overflow} more annotations not shown '
+            f'(GitHub limits reviews to 50 comments)._'
+        )
 
     # Build review body
     review_body_parts = []

--- a/scripts/find-related-files.py
+++ b/scripts/find-related-files.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Find files related to a set of changed files by tracing symbol references.
+
+Usage:
+    find-related-files.py <workspace_dir> <changed_files_path>
+
+Reads the list of changed files, extracts exported symbols (class names,
+function names, trait/interface names, struct/enum names) from each file,
+then searches the codebase for files that reference those symbols.
+
+Outputs one related file path per line (repo-relative). Changed files
+themselves are NOT included in the output — only their dependents.
+
+Strategy:
+    1. Read each changed file and extract symbol definitions via regex
+    2. For each symbol, grep the workspace for files referencing it
+    3. Deduplicate and output the union of all referencing files
+
+Supported languages (by file extension):
+    - PHP (.php): class, interface, trait, function, const
+    - Rust (.rs): pub fn, pub struct, pub enum, pub trait, pub type, pub const
+    - Python (.py): class, def (top-level only)
+    - JavaScript/TypeScript (.js, .ts, .jsx, .tsx): export class, export function,
+      export const, export default
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+# Symbol extraction patterns per language
+PATTERNS = {
+    '.php': [
+        re.compile(r'^\s*(?:abstract\s+|final\s+)?class\s+(\w+)', re.MULTILINE),
+        re.compile(r'^\s*interface\s+(\w+)', re.MULTILINE),
+        re.compile(r'^\s*trait\s+(\w+)', re.MULTILINE),
+        re.compile(r'^\s*(?:public\s+|protected\s+|private\s+)?(?:static\s+)?function\s+(\w+)', re.MULTILINE),
+    ],
+    '.rs': [
+        re.compile(r'^\s*pub\s+(?:async\s+)?fn\s+(\w+)', re.MULTILINE),
+        re.compile(r'^\s*pub\s+struct\s+(\w+)', re.MULTILINE),
+        re.compile(r'^\s*pub\s+enum\s+(\w+)', re.MULTILINE),
+        re.compile(r'^\s*pub\s+trait\s+(\w+)', re.MULTILINE),
+        re.compile(r'^\s*pub\s+type\s+(\w+)', re.MULTILINE),
+        re.compile(r'^\s*pub\s+const\s+(\w+)', re.MULTILINE),
+    ],
+    '.py': [
+        re.compile(r'^class\s+(\w+)', re.MULTILINE),
+        re.compile(r'^def\s+(\w+)', re.MULTILINE),
+    ],
+    '.js': [
+        re.compile(r'export\s+(?:default\s+)?class\s+(\w+)', re.MULTILINE),
+        re.compile(r'export\s+(?:default\s+)?function\s+(\w+)', re.MULTILINE),
+        re.compile(r'export\s+(?:const|let|var)\s+(\w+)', re.MULTILINE),
+    ],
+}
+# Aliases: same patterns for related extensions
+PATTERNS['.ts'] = PATTERNS['.js']
+PATTERNS['.jsx'] = PATTERNS['.js']
+PATTERNS['.tsx'] = PATTERNS['.js']
+
+# Symbols too common to be useful as search terms
+NOISE_SYMBOLS = frozenset({
+    # PHP lifecycle/magic
+    '__construct', '__destruct', '__get', '__set', '__call', '__toString',
+    '__invoke', '__clone', '__sleep', '__wakeup', '__serialize', '__unserialize',
+    # Common method names
+    'get', 'set', 'run', 'init', 'load', 'save', 'delete', 'update', 'create',
+    'register', 'render', 'handle', 'process', 'execute', 'validate', 'parse',
+    'format', 'build', 'setup', 'teardown', 'reset', 'clear', 'close', 'open',
+    'read', 'write', 'start', 'stop', 'test', 'main', 'new', 'from', 'into',
+    # Rust common
+    'default', 'fmt', 'clone', 'drop', 'eq', 'hash', 'cmp', 'partial_cmp',
+    'deref', 'as_ref', 'as_mut', 'try_from', 'try_into',
+    # Python common
+    '__init__', '__repr__', '__str__', '__eq__', '__hash__', '__len__',
+    # Too short
+    'a', 'b', 'c', 'e', 'f', 'i', 'k', 'n', 'p', 'r', 's', 't', 'v', 'x',
+    'id', 'ok', 'to', 'do', 'is', 'on', 'of', 'up',
+})
+
+# Minimum symbol length to avoid false positives
+MIN_SYMBOL_LENGTH = 3
+
+
+def extract_symbols(filepath: str) -> set[str]:
+    """Extract exported symbol names from a source file."""
+    _, ext = os.path.splitext(filepath)
+    patterns = PATTERNS.get(ext.lower(), [])
+    if not patterns:
+        return set()
+
+    try:
+        with open(filepath, 'r', errors='replace') as f:
+            content = f.read()
+    except (IOError, OSError):
+        return set()
+
+    symbols = set()
+    for pattern in patterns:
+        for match in pattern.finditer(content):
+            name = match.group(1)
+            if (name not in NOISE_SYMBOLS
+                    and len(name) >= MIN_SYMBOL_LENGTH
+                    and not name.startswith('_')):
+                symbols.add(name)
+    return symbols
+
+
+def find_referencing_files(workspace: str, symbols: set[str],
+                           changed_files: set[str]) -> set[str]:
+    """Find files that reference any of the given symbols via grep."""
+    if not symbols:
+        return set()
+
+    related = set()
+
+    # Build a grep pattern that matches any of the symbols as whole words
+    # Use grep -rl for speed (just list matching files, don't show lines)
+    # Process in batches to avoid ARG_MAX limits
+    symbol_list = sorted(symbols)
+    batch_size = 50
+
+    for i in range(0, len(symbol_list), batch_size):
+        batch = symbol_list[i:i + batch_size]
+        # Build alternation pattern: \bSymbol1\b|\bSymbol2\b|...
+        pattern = '|'.join(rf'\b{re.escape(s)}\b' for s in batch)
+
+        try:
+            result = subprocess.run(
+                ['grep', '-rlE', '--include=*.php', '--include=*.rs',
+                 '--include=*.py', '--include=*.js', '--include=*.ts',
+                 '--include=*.jsx', '--include=*.tsx',
+                 '--exclude-dir=vendor', '--exclude-dir=node_modules',
+                 '--exclude-dir=target', '--exclude-dir=.git',
+                 '--exclude-dir=build', '--exclude-dir=dist',
+                 pattern, workspace],
+                capture_output=True, text=True, timeout=30
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+
+        for line in result.stdout.strip().split('\n'):
+            line = line.strip()
+            if not line:
+                continue
+            # Convert absolute path to repo-relative
+            if line.startswith(workspace):
+                rel = line[len(workspace):].lstrip('/')
+            else:
+                rel = line
+            # Exclude changed files themselves — we only want dependents
+            if rel not in changed_files:
+                related.add(rel)
+
+    return related
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <workspace_dir> <changed_files_path>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    workspace = sys.argv[1].rstrip('/')
+    changed_files_path = sys.argv[2]
+
+    with open(changed_files_path, 'r') as f:
+        changed_files = set(line.strip() for line in f if line.strip())
+
+    if not changed_files:
+        sys.exit(0)
+
+    # Extract symbols from all changed files
+    all_symbols: set[str] = set()
+    for cf in changed_files:
+        full_path = os.path.join(workspace, cf)
+        symbols = extract_symbols(full_path)
+        if symbols:
+            print(f"  {cf}: {len(symbols)} symbols ({', '.join(sorted(symbols)[:5])}{'...' if len(symbols) > 5 else ''})",
+                  file=sys.stderr)
+        all_symbols.update(symbols)
+
+    if not all_symbols:
+        print(f"No symbols extracted from {len(changed_files)} changed file(s)",
+              file=sys.stderr)
+        sys.exit(0)
+
+    print(f"Searching for {len(all_symbols)} symbol(s) across workspace...",
+          file=sys.stderr)
+
+    # Find files referencing those symbols
+    related = find_referencing_files(workspace, all_symbols, changed_files)
+
+    print(f"Found {len(related)} related file(s)", file=sys.stderr)
+
+    # Output related files, one per line
+    for f in sorted(related):
+        print(f)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Problem

The inline PR review posted **417 collateral damage findings** on Data Machine PR #526 — that's every pre-existing PHPCS + PHPStan error in the entire codebase. The PR only changed a workflow file and `homeboy.json`. Zero of those errors were actually caused by the PR.

## Fix

Collateral damage is now scoped to **files that reference symbols defined in the changed files**. The flow:

```
Changed files (PR diff)
       │
       ▼
Extract exported symbols
(class Foo, pub fn bar, trait Baz)
       │
       ▼
grep -rl workspace for references
       │
       ▼
Related files set (call sites, importers)
       │
       ▼
Only errors in related files = collateral
```

### New: `scripts/find-related-files.py`

Extracts symbols from changed files via regex and greps the workspace:

- **PHP**: class, interface, trait, function
- **Rust**: pub fn, pub struct, pub enum, pub trait, pub type, pub const
- **Python**: class, def (top-level)
- **JS/TS**: export class, export function, export const

Includes noise filtering (skips `__construct`, `get`, `set`, `run`, etc.) and min length (3 chars).

### Updated: `scripts/build-review.py`

Now accepts an optional 4th arg `<related_files_path>`. Annotations are split into 3 buckets:
1. **Inline** — in changed files → PR review comments on diff
2. **Collateral** — in related files → shown in review body
3. **Unrelated** — pre-existing errors → silently dropped

### Example

PR changes `inc/ChatAbilities.php`:
- `find-related-files.py` extracts `ChatAbilities` symbol
- Greps workspace → finds `inc/Pipeline.php` uses it
- PHPStan error in `Pipeline.php` → collateral damage ✅
- PHPStan error in `inc/Analytics.php` → dropped (no symbol link) ✅

### Tested

```
# homeboy codebase: change dead_code.rs
$ find-related-files.py /workspace changed.txt
  dead_code.rs: 1 symbols (analyze_dead_code)
  Found 1 related file(s)
  src/core/code_audit/mod.rs    ← only file that calls it

# homeboy codebase: change conventions.rs (more connected)
$ find-related-files.py /workspace changed.txt
  conventions.rs: 8 symbols (Convention, Deviation, DeviationKind...)
  Found 12 related file(s)                ← correct call graph
```