### PR TITLE
fix: use compact JSON for GITHUB_OUTPUT to prevent multi-line parse errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -308,10 +308,10 @@ runs:
 
           if [ $CMD_EXIT -eq 0 ]; then
             echo "::notice::homeboy ${CMD}: PASSED"
-            RESULTS=$(echo "$RESULTS" | jq --arg cmd "$CMD" '. + {($cmd): "pass"}')
+            RESULTS=$(echo "$RESULTS" | jq -c --arg cmd "$CMD" '. + {($cmd): "pass"}')
           else
             echo "::error::homeboy ${CMD}: FAILED (exit code ${CMD_EXIT})"
-            RESULTS=$(echo "$RESULTS" | jq --arg cmd "$CMD" '. + {($cmd): "fail"}')
+            RESULTS=$(echo "$RESULTS" | jq -c --arg cmd "$CMD" '. + {($cmd): "fail"}')
             OVERALL_EXIT=1
           fi
         done


### PR DESCRIPTION
## Summary

- Adds `-c` flag to `jq` calls that build the `RESULTS` JSON object
- Without `-c`, `jq` outputs pretty-printed multi-line JSON which breaks `echo "results=${RESULTS}" >> $GITHUB_OUTPUT` since GitHub Actions expects single-line values for that syntax
- This caused the action step to fail even when the homeboy command succeeded: `Invalid format '  "audit": "pass"'`

Fixes the exit code bug identified during homeboy CI dogfooding.