### PR TITLE
fix: skip test runner's internal lint when lint is a separate command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -272,6 +272,17 @@ runs:
         # Parse comma-separated commands
         IFS=',' read -ra CMD_ARRAY <<< "$COMMANDS"
 
+        # Check if lint is a separate command — if so, skip the test runner's
+        # internal lint step to avoid redundant repo-wide PHPCS/PHPStan runs.
+        # The action's lint command already handles --changed-since scoping.
+        HAS_LINT_COMMAND=false
+        for c in "${CMD_ARRAY[@]}"; do
+          if [ "$(echo "$c" | xargs)" = "lint" ]; then
+            HAS_LINT_COMMAND=true
+            break
+          fi
+        done
+
         for CMD in "${CMD_ARRAY[@]}"; do
           # Trim whitespace
           CMD=$(echo "$CMD" | xargs)
@@ -281,6 +292,15 @@ runs:
           echo "  Running: homeboy ${CMD} ${COMP_ID}"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
+
+          # When running test and lint is already a separate command, tell the
+          # test runner to skip its internal lint step (avoids duplicate repo-wide
+          # PHPCS that ignores --changed-since scoping)
+          if [ "$CMD" = "test" ] && [ "$HAS_LINT_COMMAND" = "true" ]; then
+            export HOMEBOY_SKIP_LINT=1
+          else
+            unset HOMEBOY_SKIP_LINT 2>/dev/null || true
+          fi
 
           # Build the command
           if [ "$CMD" = "audit" ]; then


### PR DESCRIPTION
## Summary

When `commands: lint,test,audit` is configured, the test runner's embedded lint step runs PHPCS/PHPStan against the **full repo** — ignoring the `--changed-since` scoping that the action applies to the standalone `lint` command. This causes CI comments to show hundreds of repo-wide errors under the test section, making it look like the PR introduced them.

**Root cause:** The action runs `homeboy lint` with `--changed-since` (correctly scoped to PR files), then runs `homeboy test` which internally calls `lint-runner.sh` against the full component path without any file scoping.

**Fix:** Export `HOMEBOY_SKIP_LINT=1` when running `test` and `lint` is already in the commands list. The WordPress extension's test-runner.sh already respects this env var — it just wasn't being set by the action.

## Before

```
:x: lint (changed files only)
:x: test
- PHPCS: LINT SUMMARY: 233 errors, 203 warnings     ← repo-wide!
- Files with issues: 109 of 346                       ← all files, not PR files
```

## After

```
:white_check_mark: lint (changed files only)
:x: test
- BUILD FAILED: PHPUnit tests                         ← only actual test failures
```

## Changes

- Detect if `lint` is in the commands list before the loop
- When running `test` with lint already present, set `HOMEBOY_SKIP_LINT=1`
- Clean up the env var for non-test commands