### PR TITLE
feat: optional CI autofix commit + rerun flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ If your repo has a `homeboy.json` file, you don't even need to specify the exten
 | `node-version` | No | | Node.js version (sets up via `actions/setup-node`) |
 | `autofix` | No | `false` | On PR failures, run safe autofixes, commit, push, and re-run checks |
 | `autofix-commands` | No | | Override autofix commands (comma-separated, e.g. `lint --fix,test --fix`) |
+| `autofix-label` | No | | Optional PR label required before autofix runs (e.g. `autofix`) |
 
 ## Outputs
 
@@ -119,6 +120,20 @@ When enabled, the action will:
 5. Re-run checks and report final status
 
 > Autofix mode is PR-only and never force-pushes or amends commits.
+
+Optional label gate:
+
+```yaml
+- uses: Extra-Chill/homeboy-action@v1
+  with:
+    extension: wordpress
+    commands: lint,test
+    php-version: '8.2'
+    autofix: 'true'
+    autofix-label: 'autofix'
+```
+
+With `autofix-label`, no bot commit will be created unless that label is present on the PR.
 
 ### Test with Custom Settings
 

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: 'Comma-separated autofix commands to run when autofix is enabled (e.g. "lint --fix,test --fix")'
     required: false
     default: ''
+  autofix-label:
+    description: 'Optional PR label required to allow autofix (e.g. "autofix")'
+    required: false
+    default: ''
 
 outputs:
   results:
@@ -449,8 +453,42 @@ runs:
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
         AUTOFIX_COMMANDS: ${{ inputs.autofix-commands }}
+        AUTOFIX_LABEL: ${{ inputs.autofix-label }}
+        PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
       run: |
         set -euo pipefail
+
+        # Safety guard: only auto-push on same-repo PRs (not forks)
+        if [ "${PR_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
+          echo "Skipping autofix: PR head repo (${PR_HEAD_REPO}) differs from target repo (${GITHUB_REPOSITORY})"
+          echo "committed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Loop guard: don't autofix if workflow was triggered by a prior bot autofix push
+        if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ]; then
+          echo "Skipping autofix: workflow actor is github-actions[bot]"
+          echo "committed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Loop guard: don't chain autofix commits on top of autofix commits
+        LAST_SUBJECT=$(git log -1 --pretty=%s 2>/dev/null || true)
+        if [ "$LAST_SUBJECT" = "chore(ci): apply homeboy autofixes" ]; then
+          echo "Skipping autofix: HEAD already an autofix commit"
+          echo "committed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # Optional label gate
+        if [ -n "${AUTOFIX_LABEL:-}" ]; then
+          if ! echo "$PR_LABELS_JSON" | jq -e --arg label "$AUTOFIX_LABEL" 'index($label) != null' > /dev/null; then
+            echo "Skipping autofix: required label '${AUTOFIX_LABEL}' not present"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        fi
 
         if [ -n "$COMPONENT_NAME" ]; then
           COMP_ID="$COMPONENT_NAME"


### PR DESCRIPTION
Closes #15

## Summary
- add opt-in `autofix` mode for pull requests in `homeboy-action`
- on failed checks, run safe autofix commands, commit as a new bot commit, push to PR branch, then rerun checks
- add `autofix-commands` override input for custom fix pipelines
- use final-results selection (`rerun` if present, otherwise initial run) for outputs, comments, and failure gating
- update README with autofix usage and behavior

## Inputs added
- `autofix` (default `false`)
- `autofix-commands` (default empty)

## Behavior
When `autofix: 'true'` on PR events:
1. Initial commands run (non-blocking step)
2. If any fail, autofix step runs (defaults: `lint --fix`, `test --fix` if those commands are present)
3. If files changed: commit `chore(ci): apply homeboy autofixes` and push to `GITHUB_HEAD_REF`
4. Commands rerun once
5. Final status enforced from selected final results

## Safety constraints implemented
- PR-only autofix execution
- normal commit only (no amend)
- normal push only (no force)
- single autofix attempt per workflow run
- explicit status enforcement after rerun

## Notes
- PR comments now include autofix status messaging
- auto-issue step now keys off final selected results

## Follow-ups
- add optional label-gate for autofix
- add dry-run report mode for autofix commands