### PR TITLE
feat: add test-scope input for PR changed-since execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If your repo has a `homeboy.json` file, you don't even need to specify the exten
 | `autofix` | No | `false` | On PR failures, run safe autofixes, commit, push, and re-run checks |
 | `autofix-commands` | No | | Override autofix commands (comma-separated, e.g. `lint --fix,test --fix`) |
 | `autofix-label` | No | | Optional PR label required before autofix runs (e.g. `autofix`) |
+| `test-scope` | No | `full` | Test scope for PRs: `full` or `changed` (requires Homeboy test changed-since support) |
 
 ## Outputs
 
@@ -100,6 +101,21 @@ If your repo has a `homeboy.json` file, you don't even need to specify the exten
     php-version: '8.2'
     node-version: '20'
 ```
+
+### PR Scoped Checks (Changed Files)
+
+```yaml
+- uses: Extra-Chill/homeboy-action@v1
+  with:
+    extension: wordpress
+    commands: lint,test,audit
+    php-version: '8.2'
+    lint-changed-only: 'true'
+    test-scope: 'changed'
+```
+
+> `test-scope: changed` requires Homeboy support for `homeboy test --changed-since`.
+> If unsupported in your pinned Homeboy version, keep `test-scope: full`.
 
 ### Auto-apply Fixable CI Issues (PRs)
 

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'Only lint files changed in the PR (default: true for PRs, ignored for non-PR events)'
     required: false
     default: 'true'
+  test-scope:
+    description: 'Test execution scope: "full" or "changed" (PRs only for changed). Default: full'
+    required: false
+    default: 'full'
   auto-issue:
     description: 'Automatically file a GitHub issue on non-PR failures (default: false)'
     required: false
@@ -341,6 +345,7 @@ runs:
         COMMANDS: ${{ inputs.commands }}
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
+        TEST_SCOPE: ${{ inputs.test-scope }}
       run: |
         set -euo pipefail
 
@@ -406,6 +411,9 @@ runs:
           elif [ "$CMD" = "lint" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
             # Scope lint to changed files only (PR mode) using --changed-since
             FULL_CMD="homeboy lint ${COMP_ID} --path ${WORKSPACE} --changed-since ${HOMEBOY_CHANGED_SINCE}"
+          elif [ "$CMD" = "test" ] && [ "$TEST_SCOPE" = "changed" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+            # Scope tests in PR mode (requires homeboy support for --changed-since on test command)
+            FULL_CMD="homeboy test ${COMP_ID} --path ${WORKSPACE} --changed-since ${HOMEBOY_CHANGED_SINCE}"
           else
             FULL_CMD="homeboy ${CMD} ${COMP_ID} --path ${WORKSPACE}"
           fi
@@ -452,6 +460,7 @@ runs:
         COMMANDS: ${{ inputs.commands }}
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
+        TEST_SCOPE: ${{ inputs.test-scope }}
         AUTOFIX_COMMANDS: ${{ inputs.autofix-commands }}
         AUTOFIX_LABEL: ${{ inputs.autofix-label }}
         PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
@@ -628,6 +637,8 @@ runs:
             FULL_CMD="homeboy audit ${COMP_ID}"
           elif [ "$CMD" = "lint" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
             FULL_CMD="homeboy lint ${COMP_ID} --path ${WORKSPACE} --changed-since ${HOMEBOY_CHANGED_SINCE}"
+          elif [ "$CMD" = "test" ] && [ "$TEST_SCOPE" = "changed" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+            FULL_CMD="homeboy test ${COMP_ID} --path ${WORKSPACE} --changed-since ${HOMEBOY_CHANGED_SINCE}"
           else
             FULL_CMD="homeboy ${CMD} ${COMP_ID} --path ${WORKSPACE}"
           fi


### PR DESCRIPTION
## Summary
- add new `test-scope` input to homeboy-action (`full` | `changed`, default `full`)
- when `test-scope=changed` and a PR base SHA is available, run:
  - `homeboy test <component> --path <workspace> --changed-since <base_sha>`
- apply the same logic in rerun path (after optional autofix commit)
- document usage in README with scoped PR example

## Why
This is the action-level wiring needed for the policy:
- PRs: changed files + impacted tests
- Releases: full suite

It keeps lint/audit/test scoping aligned under one CI contract.

## Notes
`test-scope=changed` requires Homeboy test command support for `--changed-since` (tracked in homeboy issue #447).