### PR TITLE
feat: add changed-scope fallback and CI profile guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If your repo has a `homeboy.json` file, you don't even need to specify the exten
 | `autofix-commands` | No | | Override autofix commands (comma-separated, e.g. `lint --fix,test --fix`) |
 | `autofix-label` | No | | Optional PR label required before autofix runs (e.g. `autofix`) |
 | `test-scope` | No | `full` | Test scope for PRs: `full` or `changed` (requires Homeboy test changed-since support) |
+| `auto-issue` | No | `false` | Auto-file issue on non-PR failures (e.g. `push` to `main`) |
 
 ## Outputs
 
@@ -134,6 +135,37 @@ Machine-readable files are written to the action output directory:
 
 > `test-scope: changed` requires Homeboy support for `homeboy test --changed-since`.
 > If unsupported in your pinned Homeboy version, keep `test-scope: full`.
+
+Homeboy Action now performs a capability probe for `test-scope: changed` on PRs.
+If your installed Homeboy CLI does not support `--changed-since` for tests yet, the action automatically falls back to `full` test scope and emits a warning.
+
+### Recommended org-wide CI profile
+
+Use two workflows for clear signal:
+
+1. **PR workflow** (fast + scoped)
+   - `commands: lint,test,audit`
+   - `lint-changed-only: 'true'`
+   - `test-scope: 'changed'` (auto-falls back to `full` if unsupported)
+
+2. **Main workflow** (authoritative)
+   - trigger on `push` to `main` (or release/version bump branches)
+   - `commands: lint,test,audit`
+   - `test-scope: 'full'`
+   - `auto-issue: 'true'`
+
+Example main workflow step:
+
+```yaml
+- uses: Extra-Chill/homeboy-action@v1
+  with:
+    extension: wordpress
+    commands: lint,test,audit
+    test-scope: 'full'
+    auto-issue: 'true'
+    php-version: '8.2'
+    node-version: '20'
+```
 
 ### Auto-apply Fixable CI Issues (PRs)
 

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,9 @@ outputs:
   binary-source:
     description: 'How the binary was obtained: "source", "fallback", or "release"'
     value: ${{ steps.resolve-binary.outputs.binary-source }}
+  test-scope-effective:
+    description: 'Effective test scope used by the action (full or changed)'
+    value: ${{ steps.resolve-test-scope.outputs.effective-test-scope }}
 
 runs:
   using: 'composite'
@@ -181,11 +184,19 @@ runs:
 
     - name: Determine PR base ref
       id: changed-files
-      if: github.event_name == 'pull_request' && inputs.lint-changed-only == 'true'
+      if: github.event_name == 'pull_request' && (inputs.lint-changed-only == 'true' || inputs.test-scope == 'changed')
       shell: bash
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
       run: bash ${{ github.action_path }}/scripts/determine-pr-base-ref.sh
+
+    - name: Resolve effective test scope
+      id: resolve-test-scope
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        TEST_SCOPE: ${{ inputs.test-scope }}
+      run: bash ${{ github.action_path }}/scripts/resolve-test-scope.sh
 
     - name: Run Homeboy commands
       id: run-commands
@@ -195,7 +206,7 @@ runs:
         COMMANDS: ${{ inputs.commands }}
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
-        TEST_SCOPE: ${{ inputs.test-scope }}
+        TEST_SCOPE: ${{ steps.resolve-test-scope.outputs.effective-test-scope || inputs.test-scope }}
         RUN_GROUP_PREFIX: homeboy
       run: bash ${{ github.action_path }}/scripts/run-homeboy-commands.sh
 
@@ -222,7 +233,7 @@ runs:
         COMMANDS: ${{ inputs.commands }}
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
-        TEST_SCOPE: ${{ inputs.test-scope }}
+        TEST_SCOPE: ${{ steps.resolve-test-scope.outputs.effective-test-scope || inputs.test-scope }}
         RUN_GROUP_PREFIX: homeboy rerun
       run: bash ${{ github.action_path }}/scripts/run-homeboy-commands.sh
 
@@ -261,6 +272,7 @@ runs:
         BINARY_SOURCE: ${{ steps.resolve-binary.outputs.binary-source }}
         AUTOFIX_ENABLED: ${{ inputs.autofix }}
         AUTOFIX_COMMITTED: ${{ steps.autofix-commit.outputs.committed }}
+        TEST_SCOPE_EFFECTIVE: ${{ steps.resolve-test-scope.outputs.effective-test-scope || inputs.test-scope }}
       run: bash ${{ github.action_path }}/scripts/post-pr-comment.sh
 
     - name: Post inline review

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Homeboy Action will be documented in this file.
 
 ### Added
 - add compact CI failure digest with top failed tests and audit findings in job summary and PR comment
+- add capability probe for `test-scope: changed` with automatic fallback to `full` when Homeboy test changed-since support is unavailable
+- add `test-scope-effective` action output and PR comment note showing resolved test scope
+- document recommended two-workflow CI profile (PR scoped checks + main full suite with auto-issue)
 
 ### Refactored
 - decompose composite action logic into scripts and add Homeboy metadata/changelog/version files

--- a/scripts/post-pr-comment.sh
+++ b/scripts/post-pr-comment.sh
@@ -32,6 +32,12 @@ if [ -n "${DIGEST_FILE}" ] && [ -f "${DIGEST_FILE}" ]; then
   COMMENT_BODY+="$(cat "${DIGEST_FILE}")"$'\n\n'
 fi
 
+if [ "${TEST_SCOPE_EFFECTIVE:-}" = "full" ] && [ "${HOMEBOY_CHANGED_SINCE:-}" != "" ]; then
+  COMMENT_BODY+="> :information_source: PR test scope resolved to **full** for compatibility with installed Homeboy CLI"$'\n\n'
+elif [ "${TEST_SCOPE_EFFECTIVE:-}" = "changed" ]; then
+  COMMENT_BODY+="> :zap: PR test scope resolved to **changed**"$'\n\n'
+fi
+
 IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
 
 for CMD in "${CMD_ARRAY[@]}"; do

--- a/scripts/resolve-test-scope.sh
+++ b/scripts/resolve-test-scope.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REQUESTED_SCOPE="${TEST_SCOPE:-full}"
+
+if [ "${REQUESTED_SCOPE}" != "changed" ]; then
+  echo "effective-test-scope=${REQUESTED_SCOPE}" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+if [ -z "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+  echo "::warning::test-scope=changed requested but no PR base ref was detected; using full test scope"
+  echo "effective-test-scope=full" >> "${GITHUB_OUTPUT}"
+  echo "HOMEBOY_TEST_SCOPE_EFFECTIVE=full" >> "${GITHUB_ENV}"
+  exit 0
+fi
+
+if homeboy test --help 2>/dev/null | grep -q -- '--changed-since'; then
+  echo "effective-test-scope=changed" >> "${GITHUB_OUTPUT}"
+  echo "HOMEBOY_TEST_SCOPE_EFFECTIVE=changed" >> "${GITHUB_ENV}"
+  exit 0
+fi
+
+echo "::warning::homeboy test does not support --changed-since yet; falling back to full test scope"
+echo "effective-test-scope=full" >> "${GITHUB_OUTPUT}"
+echo "HOMEBOY_TEST_SCOPE_EFFECTIVE=full" >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Summary
- add PR-time capability probe for `test-scope: changed` and auto-fallback to `full` when `homeboy test --changed-since` is not supported
- expose `test-scope-effective` output and include resolved scope notes in PR comments
- document recommended CI strategy: scoped PR checks and full-suite main builds with `auto-issue: true`

## Why
Action users can request changed-scope tests before the installed Homeboy CLI supports `--changed-since`. Today that causes brittle failures. This PR makes changed-scope adoption safe and self-documenting, while preserving full-suite reliability on `main`.

## Details
- `action.yml`
  - adds output: `test-scope-effective`
  - resolves base SHA when either lint-changed-only or test-scope=changed is requested
  - adds `resolve-test-scope` step before command execution
- `scripts/resolve-test-scope.sh`
  - checks CLI capability (`homeboy test --help` contains `--changed-since`)
  - falls back to full scope with warning if unsupported
- `scripts/post-pr-comment.sh`
  - posts resolved test scope note to PR summary comment
- `README.md`
  - adds `auto-issue` input docs
  - adds two-workflow recommended CI profile
- `docs/CHANGELOG.md`
  - records new behavior

## Related
- https://github.com/Extra-Chill/homeboy/issues/483
- https://github.com/Extra-Chill/homeboy-action/issues/23
- https://github.com/Extra-Chill/homeboy-action/issues/24