### PR TITLE
feat(ci): add primary failure triage and tooling metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,16 @@ On failed runs, Homeboy Action now emits a compact **Failure Digest** to:
 
 Digest includes:
 
+- tooling versions (Homeboy CLI, extension source/revision, action ref)
 - failed test count + top failed tests
 - audit summary (drift/outliers/top findings when structured output is available)
 - links back to the full workflow run logs
+
+Auto-filed failure issues on non-PR runs also include:
+
+- **Primary failure** (first failed command + first fatal/error line)
+- **Secondary findings** (additional failed commands)
+- **Triage order** to reduce debugging time
 
 Machine-readable files are written to the action output directory:
 

--- a/action.yml
+++ b/action.yml
@@ -174,6 +174,15 @@ runs:
         EXTENSION_SOURCE: ${{ inputs.extension-source }}
       run: bash ${{ github.action_path }}/scripts/install-extension.sh
 
+    - name: Capture tooling metadata
+      shell: bash
+      env:
+        EXTENSION_ID: ${{ inputs.extension }}
+        EXTENSION_SOURCE: ${{ inputs.extension-source }}
+        ACTION_REF: ${{ github.action_ref }}
+        ACTION_REPOSITORY: ${{ github.action_repository }}
+      run: bash ${{ github.action_path }}/scripts/capture-tooling-metadata.sh
+
     - name: Register component
       shell: bash
       env:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to Homeboy Action will be documented in this file.
 - add capability probe for `test-scope: changed` with automatic fallback to `full` when Homeboy test changed-since support is unavailable
 - add `test-scope-effective` action output and PR comment note showing resolved test scope
 - document recommended two-workflow CI profile (PR scoped checks + main full suite with auto-issue)
+- add tooling metadata capture (Homeboy CLI version, extension source/revision, action ref) and include it in failure digest, PR comments, and auto-filed issues
+- add primary-vs-secondary failure sections with triage order in auto-filed CI issues
 
 ### Refactored
 - decompose composite action logic into scripts and add Homeboy metadata/changelog/version files

--- a/scripts/auto-file-issue.sh
+++ b/scripts/auto-file-issue.sh
@@ -9,6 +9,13 @@ RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 WORKFLOW_NAME="${GITHUB_WORKFLOW:-workflow}"
 REF_LABEL="${GITHUB_REF_NAME:-${GITHUB_SHA:0:8}}"
 
+HOMEBOY_CLI_VERSION="${HOMEBOY_CLI_VERSION:-unknown}"
+HOMEBOY_EXTENSION_ID="${HOMEBOY_EXTENSION_ID:-auto}"
+HOMEBOY_EXTENSION_SOURCE="${HOMEBOY_EXTENSION_SOURCE:-auto}"
+HOMEBOY_EXTENSION_REVISION="${HOMEBOY_EXTENSION_REVISION:-unknown}"
+HOMEBOY_ACTION_REF="${HOMEBOY_ACTION_REF:-unknown}"
+HOMEBOY_ACTION_REPOSITORY="${HOMEBOY_ACTION_REPOSITORY:-unknown}"
+
 REPO_NAME="${REPO##*/}"
 if [ "${COMP_ID}" = "${REPO_NAME}" ]; then
   SCOPE_LABEL="${REPO}"
@@ -22,15 +29,48 @@ else
   TRIGGER_CONTEXT="commit \`${GITHUB_SHA:0:8}\`"
 fi
 
-FAILED_CMDS=""
 IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
-for CMD in "${CMD_ARRAY[@]}"; do
-  CMD=$(echo "${CMD}" | xargs)
+
+FAILED_COMMANDS=()
+PRIMARY_COMMAND=""
+PRIMARY_LOG_FILE=""
+PRIMARY_FATAL_LINE=""
+
+for RAW_CMD in "${CMD_ARRAY[@]}"; do
+  CMD="$(echo "${RAW_CMD}" | xargs)"
   STATUS=$(echo "${RESULTS}" | jq -r --arg cmd "${CMD}" '.[$cmd] // "unknown"' 2>/dev/null || echo "unknown")
   if [ "${STATUS}" = "fail" ]; then
-    FAILED_CMDS+="- \`homeboy ${CMD}\`"$'\n'
+    FAILED_COMMANDS+=("${CMD}")
+    if [ -z "${PRIMARY_COMMAND}" ]; then
+      PRIMARY_COMMAND="${CMD}"
+      PRIMARY_LOG_FILE="${OUTPUT_DIR}/${CMD}.log"
+    fi
   fi
 done
+
+if [ -n "${PRIMARY_LOG_FILE}" ] && [ -f "${PRIMARY_LOG_FILE}" ]; then
+  PRIMARY_FATAL_LINE=$(grep -m1 -E "(PHP Fatal error:|Fatal error:|Unhandled exception|panic:|BUILD FAILED:)" "${PRIMARY_LOG_FILE}" || true)
+fi
+
+FAILED_CMDS_MD=""
+for CMD in "${FAILED_COMMANDS[@]}"; do
+  FAILED_CMDS_MD+="- \`homeboy ${CMD}\`"$'\n'
+done
+
+SECONDARY_CMDS_MD=""
+if [ "${#FAILED_COMMANDS[@]}" -gt 1 ]; then
+  for CMD in "${FAILED_COMMANDS[@]}"; do
+    if [ "${CMD}" != "${PRIMARY_COMMAND}" ]; then
+      SECONDARY_CMDS_MD+="- \`homeboy ${CMD}\`: failed (treat as secondary until primary is resolved)"$'\n'
+    fi
+  done
+fi
+
+TOOLING_MD=""
+TOOLING_MD+="- Homeboy CLI: \`${HOMEBOY_CLI_VERSION}\`"$'\n'
+TOOLING_MD+="- Extension: \`${HOMEBOY_EXTENSION_ID}\` from \`${HOMEBOY_EXTENSION_SOURCE}\`"$'\n'
+TOOLING_MD+="- Extension revision: \`${HOMEBOY_EXTENSION_REVISION}\`"$'\n'
+TOOLING_MD+="- Action: \`${HOMEBOY_ACTION_REPOSITORY}@${HOMEBOY_ACTION_REF}\`"$'\n'
 
 ISSUE_TITLE="CI failure: ${SCOPE_LABEL} • ${WORKFLOW_NAME} • ${GITHUB_EVENT_NAME} • ${REF_LABEL}"
 
@@ -42,12 +82,35 @@ if [ -n "${EXISTING_ISSUE}" ]; then
   echo "Found existing open issue #${EXISTING_ISSUE} — adding comment instead of creating new issue"
 
   COMMENT="### CI failure on ${TRIGGER_CONTEXT}"$'\n\n'
+  COMMENT+="### Primary failure"$'\n\n'
+  if [ -n "${PRIMARY_COMMAND}" ]; then
+    COMMENT+="- Command: \`homeboy ${PRIMARY_COMMAND}\`"$'\n'
+  fi
+  if [ -n "${PRIMARY_FATAL_LINE}" ]; then
+    COMMENT+="- First fatal/error: \`${PRIMARY_FATAL_LINE}\`"$'\n'
+  else
+    COMMENT+="- First fatal/error: not detected in log tail"$'\n'
+  fi
+
+  if [ -n "${SECONDARY_CMDS_MD}" ]; then
+    COMMENT+=$'\n'"### Secondary findings"$'\n\n'
+    COMMENT+="${SECONDARY_CMDS_MD}"
+  fi
+
+  COMMENT+=$'\n'"### Tooling versions"$'\n\n'
+  COMMENT+="${TOOLING_MD}"$'\n'
+
+  COMMENT+="### Triage order"$'\n\n'
+  COMMENT+="1. Fix \`${PRIMARY_COMMAND:-first failing command}\`"$'\n'
+  COMMENT+="2. Re-run CI"$'\n'
+  COMMENT+="3. Re-evaluate secondary failures"$'\n\n'
+
   COMMENT+="**Failed commands:**"$'\n'
-  COMMENT+="${FAILED_CMDS}"$'\n'
+  COMMENT+="${FAILED_CMDS_MD}"$'\n'
   COMMENT+="**Run:** ${RUN_URL}"$'\n'
 
-  for CMD in "${CMD_ARRAY[@]}"; do
-    CMD=$(echo "${CMD}" | xargs)
+  for RAW_CMD in "${CMD_ARRAY[@]}"; do
+    CMD="$(echo "${RAW_CMD}" | xargs)"
     STATUS=$(echo "${RESULTS}" | jq -r --arg cmd "${CMD}" '.[$cmd] // "unknown"' 2>/dev/null || echo "unknown")
     if [ "${STATUS}" = "fail" ] && [ -f "${OUTPUT_DIR}/${CMD}.log" ]; then
       LOG_TAIL=$(tail -30 "${OUTPUT_DIR}/${CMD}.log")
@@ -72,11 +135,35 @@ else
   BODY+="**Trigger:** \`${GITHUB_EVENT_NAME}\` on ${TRIGGER_CONTEXT}"$'\n'
   BODY+="**Binary:** ${BINARY_SOURCE}"$'\n'
   BODY+="**Run:** ${RUN_URL}"$'\n\n'
-  BODY+="### Failed Commands"$'\n\n'
-  BODY+="${FAILED_CMDS}"$'\n'
 
-  for CMD in "${CMD_ARRAY[@]}"; do
-    CMD=$(echo "${CMD}" | xargs)
+  BODY+="### Tooling versions"$'\n\n'
+  BODY+="${TOOLING_MD}"$'\n'
+
+  BODY+="### Primary failure"$'\n\n'
+  if [ -n "${PRIMARY_COMMAND}" ]; then
+    BODY+="- Command: \`homeboy ${PRIMARY_COMMAND}\`"$'\n'
+  fi
+  if [ -n "${PRIMARY_FATAL_LINE}" ]; then
+    BODY+="- First fatal/error: \`${PRIMARY_FATAL_LINE}\`"$'\n'
+  else
+    BODY+="- First fatal/error: not detected in log tail"$'\n'
+  fi
+
+  if [ -n "${SECONDARY_CMDS_MD}" ]; then
+    BODY+=$'\n'"### Secondary findings"$'\n\n'
+    BODY+="${SECONDARY_CMDS_MD}"
+  fi
+
+  BODY+=$'\n'"### Triage order"$'\n\n'
+  BODY+="1. Fix \`${PRIMARY_COMMAND:-first failing command}\`"$'\n'
+  BODY+="2. Re-run CI"$'\n'
+  BODY+="3. Re-evaluate secondary failures"$'\n\n'
+
+  BODY+="### Failed Commands"$'\n\n'
+  BODY+="${FAILED_CMDS_MD}"$'\n'
+
+  for RAW_CMD in "${CMD_ARRAY[@]}"; do
+    CMD="$(echo "${RAW_CMD}" | xargs)"
     STATUS=$(echo "${RESULTS}" | jq -r --arg cmd "${CMD}" '.[$cmd] // "unknown"' 2>/dev/null || echo "unknown")
     if [ "${STATUS}" = "fail" ] && [ -f "${OUTPUT_DIR}/${CMD}.log" ]; then
       LOG_TAIL=$(tail -50 "${OUTPUT_DIR}/${CMD}.log")

--- a/scripts/build-failure-digest.py
+++ b/scripts/build-failure-digest.py
@@ -187,10 +187,29 @@ def extract_audit_digest(log_text: str) -> dict[str, Any]:
 
 
 def render_markdown(
-    test_digest: dict[str, Any], audit_digest: dict[str, Any], run_url: str
+    test_digest: dict[str, Any],
+    audit_digest: dict[str, Any],
+    run_url: str,
+    tooling: dict[str, str],
 ) -> str:
     lines: list[str] = []
     lines.append("## Failure Digest")
+    lines.append("")
+
+    lines.append("### Tooling versions")
+    lines.append(f"- Homeboy CLI: **{tooling.get('homeboy_cli_version', 'unknown')}**")
+    lines.append(
+        "- Extension: "
+        f"**{tooling.get('extension_id', 'auto')}** from "
+        f"`{tooling.get('extension_source', 'auto')}`"
+    )
+    lines.append(
+        f"- Extension revision: `{tooling.get('extension_revision', 'unknown')}`"
+    )
+    lines.append(
+        "- Action: "
+        f"`{tooling.get('action_repository', 'unknown')}@{tooling.get('action_ref', 'unknown')}`"
+    )
     lines.append("")
 
     lines.append("### Test Failure Digest")
@@ -251,12 +270,37 @@ def write_json(path: str, payload: dict[str, Any]) -> None:
 
 
 def main() -> int:
-    if len(sys.argv) != 4:
-        print(f"Usage: {sys.argv[0]} <output_dir> <results_json> <run_url>", file=sys.stderr)
+    if len(sys.argv) != 10:
+        print(
+            f"Usage: {sys.argv[0]} "
+            "<output_dir> <results_json> <run_url> "
+            "<homeboy_cli_version> <extension_id> <extension_source> "
+            "<extension_revision> <action_repository> <action_ref>",
+            file=sys.stderr,
+        )
         return 1
 
-    output_dir, results_raw, run_url = sys.argv[1], sys.argv[2], sys.argv[3]
+    (
+        output_dir,
+        results_raw,
+        run_url,
+        homeboy_cli_version,
+        extension_id,
+        extension_source,
+        extension_revision,
+        action_repository,
+        action_ref,
+    ) = sys.argv[1:10]
     os.makedirs(output_dir, exist_ok=True)
+
+    tooling = {
+        "homeboy_cli_version": homeboy_cli_version,
+        "extension_id": extension_id,
+        "extension_source": extension_source,
+        "extension_revision": extension_revision,
+        "action_repository": action_repository,
+        "action_ref": action_ref,
+    }
 
     try:
         results = json.loads(results_raw) if results_raw else {}
@@ -284,7 +328,7 @@ def main() -> int:
     write_json(test_json_path, test_digest)
     write_json(audit_json_path, audit_digest)
 
-    markdown = render_markdown(test_digest, audit_digest, run_url)
+    markdown = render_markdown(test_digest, audit_digest, run_url, tooling)
     with open(md_path, "w", encoding="utf-8") as f:
         f.write(markdown)
         f.write("\n")

--- a/scripts/capture-tooling-metadata.sh
+++ b/scripts/capture-tooling-metadata.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+HOMEBOY_CLI_VERSION="$(homeboy --version 2>/dev/null || echo 'unknown')"
+
+if [ -n "${EXTENSION_ID:-}" ]; then
+  EXTENSION_ID_EFFECTIVE="${EXTENSION_ID}"
+else
+  EXTENSION_ID_EFFECTIVE="auto"
+fi
+
+EXTENSION_SOURCE_EFFECTIVE="${EXTENSION_SOURCE:-auto}"
+EXTENSION_REVISION="unknown"
+
+if [ -n "${EXTENSION_ID:-}" ]; then
+  EXT_DIR="${HOME}/.config/homeboy/extensions/${EXTENSION_ID}"
+  if [ -d "${EXT_DIR}/.git" ]; then
+    EXTENSION_REVISION="$(git -C "${EXT_DIR}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+  fi
+fi
+
+ACTION_REF_USED="${ACTION_REF:-unknown}"
+ACTION_REPOSITORY_USED="${ACTION_REPOSITORY:-unknown}"
+
+echo "HOMEBOY_CLI_VERSION=${HOMEBOY_CLI_VERSION}" >> "${GITHUB_ENV}"
+echo "HOMEBOY_EXTENSION_ID=${EXTENSION_ID_EFFECTIVE}" >> "${GITHUB_ENV}"
+echo "HOMEBOY_EXTENSION_SOURCE=${EXTENSION_SOURCE_EFFECTIVE}" >> "${GITHUB_ENV}"
+echo "HOMEBOY_EXTENSION_REVISION=${EXTENSION_REVISION}" >> "${GITHUB_ENV}"
+echo "HOMEBOY_ACTION_REF=${ACTION_REF_USED}" >> "${GITHUB_ENV}"
+echo "HOMEBOY_ACTION_REPOSITORY=${ACTION_REPOSITORY_USED}" >> "${GITHUB_ENV}"
+
+echo "Tooling metadata captured"
+echo "- Homeboy CLI: ${HOMEBOY_CLI_VERSION}"
+echo "- Extension: ${EXTENSION_ID_EFFECTIVE} (${EXTENSION_SOURCE_EFFECTIVE})"
+echo "- Extension revision: ${EXTENSION_REVISION}"
+echo "- Action ref: ${ACTION_REF_USED}"

--- a/scripts/generate-failure-digest.sh
+++ b/scripts/generate-failure-digest.sh
@@ -5,13 +5,29 @@ set -euo pipefail
 OUTPUT_DIR="${HOMEBOY_OUTPUT_DIR:-}"
 RESULTS_JSON="${RESULTS:-{}}"
 RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+HOMEBOY_CLI_VERSION="${HOMEBOY_CLI_VERSION:-unknown}"
+HOMEBOY_EXTENSION_ID="${HOMEBOY_EXTENSION_ID:-auto}"
+HOMEBOY_EXTENSION_SOURCE="${HOMEBOY_EXTENSION_SOURCE:-auto}"
+HOMEBOY_EXTENSION_REVISION="${HOMEBOY_EXTENSION_REVISION:-unknown}"
+HOMEBOY_ACTION_REF="${HOMEBOY_ACTION_REF:-unknown}"
+HOMEBOY_ACTION_REPOSITORY="${HOMEBOY_ACTION_REPOSITORY:-unknown}"
 
 if [ -z "${OUTPUT_DIR}" ] || [ ! -d "${OUTPUT_DIR}" ]; then
   echo "No output directory available; skipping failure digest"
   exit 0
 fi
 
-DIGEST_FILE=$(python3 "${GITHUB_ACTION_PATH}/scripts/build-failure-digest.py" "${OUTPUT_DIR}" "${RESULTS_JSON}" "${RUN_URL}" 2>/dev/null || true)
+DIGEST_FILE=$(python3 "${GITHUB_ACTION_PATH}/scripts/build-failure-digest.py" \
+  "${OUTPUT_DIR}" \
+  "${RESULTS_JSON}" \
+  "${RUN_URL}" \
+  "${HOMEBOY_CLI_VERSION}" \
+  "${HOMEBOY_EXTENSION_ID}" \
+  "${HOMEBOY_EXTENSION_SOURCE}" \
+  "${HOMEBOY_EXTENSION_REVISION}" \
+  "${HOMEBOY_ACTION_REPOSITORY}" \
+  "${HOMEBOY_ACTION_REF}" \
+  2>/dev/null || true)
 if [ -z "${DIGEST_FILE}" ] || [ ! -f "${DIGEST_FILE}" ]; then
   echo "Failure digest generation returned no file"
   exit 0

--- a/scripts/post-pr-comment.sh
+++ b/scripts/post-pr-comment.sh
@@ -15,6 +15,11 @@ DIGEST_FILE="${HOMEBOY_FAILURE_DIGEST_FILE:-}"
 
 COMMENT_BODY="<!-- homeboy-action-results -->"$'\n'
 COMMENT_BODY+="## Homeboy Results — \`${COMP_ID}\`"$'\n\n'
+COMMENT_BODY+="### Tooling versions"$'\n\n'
+COMMENT_BODY+="- Homeboy CLI: \`${HOMEBOY_CLI_VERSION:-unknown}\`"$'\n'
+COMMENT_BODY+="- Extension: \`${HOMEBOY_EXTENSION_ID:-auto}\` from \`${HOMEBOY_EXTENSION_SOURCE:-auto}\`"$'\n'
+COMMENT_BODY+="- Extension revision: \`${HOMEBOY_EXTENSION_REVISION:-unknown}\`"$'\n'
+COMMENT_BODY+="- Action: \`${HOMEBOY_ACTION_REPOSITORY:-unknown}@${HOMEBOY_ACTION_REF:-unknown}\`"$'\n\n'
 
 if [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_COMMITTED:-}" = "true" ]; then
   COMMENT_BODY+="> :wrench: **Autofix applied** — a CI bot commit was pushed and checks were re-run"$'\n\n'
@@ -120,8 +125,7 @@ for CMD in "${CMD_ARRAY[@]}"; do
 done
 
 COMMENT_BODY+="---"$'\n'
-COMMENT_BODY+="*[Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v1 — "
-COMMENT_BODY+="$(homeboy --version 2>/dev/null || echo 'homeboy')*"
+COMMENT_BODY+="*[Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v1 — ${HOMEBOY_CLI_VERSION:-$(homeboy --version 2>/dev/null || echo 'homeboy')}*"
 
 EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
   --jq '.[] | select(.body | startswith("<!-- homeboy-action-results -->")) | .id' \


### PR DESCRIPTION
## Summary
- add tooling metadata capture (Homeboy CLI version, extension source/revision, action ref) and surface it in failure digest, PR comments, and auto-filed CI issues
- improve auto-filed CI issue formatting with explicit **Primary failure**, **Secondary findings**, and **Triage order** sections
- update docs/changelog to describe the new CI triage and version visibility behavior

## Validation
- bash -n scripts/auto-file-issue.sh scripts/capture-tooling-metadata.sh scripts/generate-failure-digest.sh scripts/post-pr-comment.sh
- python3 -m py_compile scripts/build-failure-digest.py

## Related
- Closes #27
- Closes #28