### PR TITLE
fix(ci): tolerate fork token limits for PR comment/review publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ If your repo has a `homeboy.json` file, you don't even need to specify the exten
 | `test-scope` | No | `full` | Test scope for PRs: `full` or `changed` (requires Homeboy test changed-since support) |
 | `auto-issue` | No | `false` | Auto-file issue on non-PR failures (e.g. `push` to `main`) |
 
+### Fork PR note
+
+On fork-based pull requests, GitHub may provide a restricted `GITHUB_TOKEN` that cannot write PR comments or inline reviews.
+Homeboy Action treats those publish steps as best-effort in that context:
+
+- lint/test/audit execution still runs and determines job pass/fail
+- PR comment/inline review publishing is skipped with a warning when token permissions are insufficient
+
+This keeps CI reliable for external contributors while preserving strict token safety defaults.
+
 ## Outputs
 
 | Output | Description |

--- a/scripts/post-inline-review.sh
+++ b/scripts/post-inline-review.sh
@@ -64,9 +64,12 @@ for REVIEW_ID in ${EXISTING_REVIEWS}; do
     --field event="DISMISS" > /dev/null 2>&1 || true
 done
 
-echo "${REVIEW_PAYLOAD}" | gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+if ! echo "${REVIEW_PAYLOAD}" | gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
   --method POST \
-  --input - > /dev/null 2>&1
+  --input - > /dev/null 2>&1; then
+  echo "::warning::Could not post inline review (likely restricted token for fork PR). Skipping inline review publish."
+  exit 0
+fi
 
 COMMENT_COUNT=$(echo "${REVIEW_PAYLOAD}" | jq '.comments | length' 2>/dev/null || echo "0")
 echo "Posted inline review with ${COMMENT_COUNT} comment(s)"

--- a/scripts/post-pr-comment.sh
+++ b/scripts/post-pr-comment.sh
@@ -133,14 +133,20 @@ EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
 
 if [ -n "${EXISTING_COMMENT_ID}" ]; then
   echo "Updating existing comment ${EXISTING_COMMENT_ID}..."
-  gh api "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
+  if ! gh api "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
     --method PATCH \
-    --field body="${COMMENT_BODY}" > /dev/null
+    --field body="${COMMENT_BODY}" > /dev/null 2>&1; then
+    echo "::warning::Could not update PR comment (likely restricted token for fork PR). Skipping comment publish."
+    exit 0
+  fi
 else
   echo "Creating new comment..."
-  gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+  if ! gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
     --method POST \
-    --field body="${COMMENT_BODY}" > /dev/null
+    --field body="${COMMENT_BODY}" > /dev/null 2>&1; then
+    echo "::warning::Could not create PR comment (likely restricted token for fork PR). Skipping comment publish."
+    exit 0
+  fi
 fi
 
 echo "PR comment posted successfully"


### PR DESCRIPTION
## Summary
- make PR comment publishing best-effort when token cannot write (fork PR restricted token)
- make inline review publishing best-effort under same conditions
- document fork PR permission behavior in README

## Why
Fork-based PRs can run checks with restricted `GITHUB_TOKEN` permissions. In that context, comment/review publish calls can fail with `403 Resource not accessible by integration`, which previously failed the action even when lint/test/audit execution succeeded.

This change preserves CI signal quality:
- command execution still determines pass/fail
- publish steps now warn-and-skip when permissions are insufficient

Closes #30
