### PR TITLE
fix(pr-feedback): always post failure digest as review fallback

### DIFF
--- a/scripts/digest/build-failure-digest.py
+++ b/scripts/digest/build-failure-digest.py
@@ -14,8 +14,12 @@ import subprocess
 from json import JSONDecoder
 from typing import Any
 
-from scripts.digest.parsers import extract_audit_digest, extract_lint_digest, extract_test_failures
-from scripts.digest.render import render_markdown
+# NOTE:
+# This script is executed as a file path from composite actions, so Python sets
+# sys.path to this directory (scripts/digest). Use local imports instead of
+# package-qualified imports to avoid ModuleNotFoundError in CI.
+from parsers import extract_audit_digest, extract_lint_digest, extract_test_failures
+from render import render_markdown
 
 
 def read_text(path: str) -> str:

--- a/scripts/pr/post-inline-review.sh
+++ b/scripts/pr/post-inline-review.sh
@@ -11,9 +11,52 @@ if [ -z "${ANNOTATIONS_DIR}" ] || [ -z "${PR_NUMBER}" ]; then
   exit 0
 fi
 
+post_digest_review_fallback() {
+  local digest_file="${HOMEBOY_FAILURE_DIGEST_FILE:-}"
+  if [ -z "${digest_file}" ] || [ ! -f "${digest_file}" ]; then
+    echo "No failure digest available for inline review fallback"
+    return 0
+  fi
+
+  local review_body
+  review_body=$(python3 - "$digest_file" <<'PY'
+import sys
+from pathlib import Path
+
+digest_path = Path(sys.argv[1])
+text = digest_path.read_text(encoding="utf-8", errors="replace").strip()
+
+# Keep review body bounded so GitHub payloads stay predictable.
+max_chars = 65000
+if len(text) > max_chars:
+    text = text[:max_chars] + "\n\n_Truncated for GitHub review payload size._"
+
+print("## Homeboy Failure Digest")
+print("")
+print(text)
+PY
+)
+
+  if [ -z "${review_body}" ]; then
+    echo "Failure digest fallback produced empty review body"
+    return 0
+  fi
+
+  if ! gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --method POST \
+    --field event="COMMENT" \
+    --field body="${review_body}" > /dev/null 2>&1; then
+    echo "::warning::Could not post digest fallback review"
+    return 0
+  fi
+
+  echo "Posted fallback PR review from failure digest"
+}
+
 ANNOTATION_COUNT=$(find "${ANNOTATIONS_DIR}" -name "*.json" -type f 2>/dev/null | wc -l)
 if [ "${ANNOTATION_COUNT}" -eq 0 ]; then
   echo "No annotation files found — skipping inline review"
+  post_digest_review_fallback
   exit 0
 fi
 
@@ -32,7 +75,7 @@ fi
 
 RELATED_FILES_FILE=$(mktemp)
 echo "Tracing symbol references from changed files..."
-python3 "${ACTION_DIR}/scripts/find-related-files.py" \
+python3 "${ACTION_DIR}/scripts/pr/find-related-files.py" \
   "$(pwd)" "${CHANGED_FILES_FILE}" > "${RELATED_FILES_FILE}" || true
 
 RELATED_COUNT=$(wc -l < "${RELATED_FILES_FILE}" | tr -d ' ')
@@ -43,17 +86,18 @@ if [ -s "${RELATED_FILES_FILE}" ]; then
   REVIEW_ARGS+=("${RELATED_FILES_FILE}")
 fi
 
-REVIEW_PAYLOAD=$(python3 "${ACTION_DIR}/scripts/build-review.py" "${REVIEW_ARGS[@]}" 2>/dev/null || true)
+REVIEW_PAYLOAD=$(python3 "${ACTION_DIR}/scripts/pr/build-review.py" "${REVIEW_ARGS[@]}" 2>/dev/null || true)
 
 rm -f "${CHANGED_FILES_FILE}" "${RELATED_FILES_FILE}"
 
 if [ -z "${REVIEW_PAYLOAD}" ]; then
   echo "No annotations to post — skipping inline review"
+  post_digest_review_fallback
   exit 0
 fi
 
 EXISTING_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-  --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("Homeboy found|Collateral damage"))) | .id] | .[]' \
+  --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("Homeboy found|Collateral damage|Homeboy Failure Digest"))) | .id] | .[]' \
   2>/dev/null || true)
 
 for REVIEW_ID in ${EXISTING_REVIEWS}; do

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -102,8 +102,8 @@ for CMD in "${CMD_ARRAY[@]}"; do
       COMMENT_BODY+="\`\`\`"$'\n'"</details>"$'\n'
     fi
 
-    if [ "${CMD}" = "audit" ]; then
-      AUDIT_MD=$(python3 "${GITHUB_ACTION_PATH}/scripts/render-audit-summary.py" "${LOG_FILE}" 2>/dev/null || true)
+    if [ "${CMD}" = "audit"; then
+      AUDIT_MD=$(python3 "${GITHUB_ACTION_PATH}/scripts/digest/render-audit-summary.py" "${LOG_FILE}" 2>/dev/null || true)
       if [ -n "${AUDIT_MD}" ]; then
         COMMENT_BODY+=$'\n'"### Audit summary"$'\n'
         COMMENT_BODY+="${AUDIT_MD}"$'\n'


### PR DESCRIPTION
## Summary
- fix Python import resolution in `scripts/digest/build-failure-digest.py` so digest generation actually runs in composite action execution context
- make inline review posting resilient: when annotation JSON is missing/empty, post the failure digest as a direct PR review comment instead of silently skipping
- update moved script paths (`scripts/pr/*`, `scripts/digest/*`) so review/comment steps keep working after script reorganization

## Why
PR feedback should surface actionable failures directly in review comments, not disappear behind workflow logs when annotations aren’t produced.