### PR TITLE
fix: centralize homeboy command path handling in CI

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -69,15 +69,7 @@ fi
 echo "Applying autofixes..."
 for FIX_CMD in "${FIX_ARRAY[@]}"; do
   FIX_CMD=$(echo "${FIX_CMD}" | xargs)
-  BASE_CMD="homeboy ${FIX_CMD} ${COMP_ID} --path ${WORKSPACE}"
-
-  if echo "${FIX_CMD}" | grep -q '^lint' && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
-    BASE_CMD="homeboy ${FIX_CMD} ${COMP_ID} --path ${WORKSPACE} --changed-since ${HOMEBOY_CHANGED_SINCE}"
-  fi
-
-  if [ -n "${EXTRA_ARGS:-}" ]; then
-    BASE_CMD="${BASE_CMD} ${EXTRA_ARGS}"
-  fi
+  BASE_CMD="$(build_autofix_command "${FIX_CMD}" "${COMP_ID}" "${WORKSPACE}")"
 
   echo "Running autofix: ${BASE_CMD}"
   set +e

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -60,15 +60,7 @@ git checkout -b "${AUTOFIX_BRANCH}"
 echo "Applying non-PR autofixes..."
 for FIX_CMD in "${FIX_ARRAY[@]}"; do
   FIX_CMD=$(echo "${FIX_CMD}" | xargs)
-  BASE_CMD="homeboy ${FIX_CMD} ${COMP_ID} --path ${WORKSPACE}"
-
-  if [ "${FIX_CMD}" = "audit --fix --write" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
-    BASE_CMD="homeboy audit ${COMP_ID} --path ${WORKSPACE} --fix --write --changed-since ${HOMEBOY_CHANGED_SINCE}"
-  fi
-
-  if [ -n "${EXTRA_ARGS:-}" ]; then
-    BASE_CMD="${BASE_CMD} ${EXTRA_ARGS}"
-  fi
+  BASE_CMD="$(build_autofix_command "${FIX_CMD}" "${COMP_ID}" "${WORKSPACE}")"
 
   echo "Running autofix: ${BASE_CMD}"
   set +e

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -38,3 +38,60 @@ has_lint_command() {
 
   printf '%s\n' "false"
 }
+
+build_run_command() {
+  local cmd="$1"
+  local component_id="$2"
+  local workspace="$3"
+  local full_cmd="homeboy ${cmd} ${component_id} --path ${workspace}"
+
+  case "${cmd}" in
+    audit)
+      if [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+        full_cmd="${full_cmd} --changed-since ${HOMEBOY_CHANGED_SINCE}"
+      fi
+      ;;
+    lint)
+      if [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+        full_cmd="${full_cmd} --changed-since ${HOMEBOY_CHANGED_SINCE}"
+      fi
+      ;;
+    test)
+      if [ "${TEST_SCOPE:-full}" = "changed" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+        full_cmd="${full_cmd} --changed-since ${HOMEBOY_CHANGED_SINCE}"
+      fi
+      ;;
+  esac
+
+  if [ -n "${EXTRA_ARGS:-}" ]; then
+    full_cmd="${full_cmd} ${EXTRA_ARGS}"
+  fi
+
+  printf '%s\n' "${full_cmd}"
+}
+
+build_autofix_command() {
+  local fix_cmd="$1"
+  local component_id="$2"
+  local workspace="$3"
+  local full_cmd="homeboy ${fix_cmd} ${component_id} --path ${workspace}"
+
+  case "${fix_cmd}" in
+    lint*)
+      if [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+        full_cmd="${full_cmd} --changed-since ${HOMEBOY_CHANGED_SINCE}"
+      fi
+      ;;
+    audit*)
+      if [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+        full_cmd="${full_cmd} --changed-since ${HOMEBOY_CHANGED_SINCE}"
+      fi
+      ;;
+  esac
+
+  if [ -n "${EXTRA_ARGS:-}" ]; then
+    full_cmd="${full_cmd} ${EXTRA_ARGS}"
+  fi
+
+  printf '%s\n' "${full_cmd}"
+}

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -23,33 +23,19 @@ HAS_LINT_COMMAND="$(has_lint_command "${COMMANDS}")"
 for CMD in "${CMD_ARRAY[@]}"; do
   CMD=$(echo "${CMD}" | xargs)
 
-  echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "  Running: homeboy ${CMD} ${COMP_ID}"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo ""
-
   if [ "${CMD}" = "test" ] && [ "${HAS_LINT_COMMAND}" = "true" ]; then
     export HOMEBOY_SKIP_LINT=1
   else
     unset HOMEBOY_SKIP_LINT 2>/dev/null || true
   fi
 
-  if [ "${CMD}" = "audit" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
-    FULL_CMD="homeboy audit ${COMP_ID} --path ${WORKSPACE} --changed-since ${HOMEBOY_CHANGED_SINCE}"
-  elif [ "${CMD}" = "audit" ]; then
-    FULL_CMD="homeboy audit ${COMP_ID} --path ${WORKSPACE}"
-  elif [ "${CMD}" = "lint" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
-    FULL_CMD="homeboy lint ${COMP_ID} --path ${WORKSPACE} --changed-since ${HOMEBOY_CHANGED_SINCE}"
-  elif [ "${CMD}" = "test" ] && [ "${TEST_SCOPE:-full}" = "changed" ] && [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
-    FULL_CMD="homeboy test ${COMP_ID} --path ${WORKSPACE} --changed-since ${HOMEBOY_CHANGED_SINCE}"
-  else
-    FULL_CMD="homeboy ${CMD} ${COMP_ID} --path ${WORKSPACE}"
-  fi
+  FULL_CMD="$(build_run_command "${CMD}" "${COMP_ID}" "${WORKSPACE}")"
 
-  if [ -n "${EXTRA_ARGS:-}" ]; then
-    FULL_CMD="${FULL_CMD} ${EXTRA_ARGS}"
-  fi
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Running: ${FULL_CMD}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
 
   echo "::group::${GROUP_PREFIX} ${CMD}"
   CMD_EXIT=0

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+WORKSPACE="/tmp/workspace"
+COMPONENT="data-machine"
+
+unset HOMEBOY_CHANGED_SINCE TEST_SCOPE EXTRA_ARGS || true
+assert_equals \
+  "homeboy lint data-machine --path /tmp/workspace" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
+  "lint includes workspace path"
+
+HOMEBOY_CHANGED_SINCE="origin/main"
+assert_equals \
+  "homeboy lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
+  "lint keeps path with changed-since"
+
+TEST_SCOPE="changed"
+assert_equals \
+  "homeboy test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
+  "test keeps path with changed scope"
+
+assert_equals \
+  "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
+  "audit keeps path with changed-since"
+
+EXTRA_ARGS="--format json"
+assert_equals \
+  "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
+  "run command appends extra args"
+
+assert_equals \
+  "homeboy lint --fix data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_autofix_command "lint --fix" "${COMPONENT}" "${WORKSPACE}")" \
+  "autofix lint keeps path and changed-since"
+
+assert_equals \
+  "homeboy audit --fix --write data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_autofix_command "audit --fix --write" "${COMPONENT}" "${WORKSPACE}")" \
+  "autofix audit keeps path and changed-since"
+
+unset HOMEBOY_CHANGED_SINCE TEST_SCOPE EXTRA_ARGS || true
+assert_equals \
+  "homeboy test --fix data-machine --path /tmp/workspace" \
+  "$(build_autofix_command "test --fix" "${COMPONENT}" "${WORKSPACE}")" \
+  "autofix test keeps workspace path"
+
+printf 'All command builder checks passed.\n'


### PR DESCRIPTION
## Summary
- centralize Homeboy command building so every CI invocation keeps `--path` pointed at the checked-out workspace
- reuse the same path-aware builder for normal runs and autofix flows so changed-since handling stays consistent
- add a shell regression script that asserts the generated commands always include the workspace path

## Testing
- bash scripts/core/test-command-builders.sh
- bash -n scripts/core/lib.sh
- bash -n scripts/core/run-homeboy-commands.sh
- bash -n scripts/autofix/apply-autofix-commit.sh
- bash -n scripts/autofix/prepare-autofix-branch.sh
- bash -n scripts/core/test-command-builders.sh