### PR TITLE
fix: surface actionable audit findings in PR comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Digest includes:
 - tooling versions (Homeboy CLI, extension source/revision, action ref)
 - failed test count + top failed tests
 - audit summary (drift/outliers/top findings when structured output is available)
+- actionable audit details directly in the PR comment (new baseline drift + top findings), not just artifact filenames
 - links back to the full workflow run logs
 
 Auto-filed failure issues on non-PR runs also include:

--- a/scripts/digest/parsers.py
+++ b/scripts/digest/parsers.py
@@ -166,6 +166,28 @@ def extract_audit_digest(
     if not isinstance(conventions, list):
         conventions = []
 
+    def normalize_file_value(raw: Any, fallback: str = "unknown") -> str:
+        file_value = raw
+        if isinstance(file_value, dict):
+            file_value = file_value.get("path") or file_value.get("file")
+        return str(file_value or fallback)
+
+    def normalize_rule_value(item: dict[str, Any], fallback: str = "outlier") -> str:
+        return str(
+            item.get("rule")
+            or item.get("kind")
+            or item.get("category")
+            or item.get("type")
+            or item.get("status")
+            or fallback
+        )
+
+    def normalize_message_value(item: dict[str, Any], fallback: str = "(outlier)") -> str:
+        message = item.get("description") or item.get("message")
+        if not message:
+            message = item.get("expected_namespace") or item.get("expected_pattern") or fallback
+        return str(message)
+
     outlier_items: list[dict[str, Any]] = []
     for conv in conventions:
         if not isinstance(conv, dict):
@@ -187,11 +209,22 @@ def extract_audit_digest(
             item.setdefault("context_label", context_label)
             outlier_items.append(item)
 
-    source_items = new_items if new_items else findings
-    if not source_items and outlier_items:
-        source_items = outlier_items
     severity_counts: dict[str, int] = {}
     top_findings: list[dict[str, str]] = []
+    new_findings: list[dict[str, str]] = []
+
+    for item in new_items:
+        if not isinstance(item, dict):
+            continue
+        new_findings.append(
+            {
+                "context": str(item.get("context_label") or item.get("file") or item.get("path") or "unknown"),
+                "message": normalize_message_value(item, "(new finding)"),
+                "fingerprint": str(item.get("fingerprint") or ""),
+            }
+        )
+
+    source_items = findings + outlier_items
 
     for item in source_items:
         if not isinstance(item, dict):
@@ -199,25 +232,23 @@ def extract_audit_digest(
         severity = str(item.get("severity") or item.get("level") or "unknown").lower()
         severity_counts[severity] = severity_counts.get(severity, 0) + 1
 
-        file_value = item.get("file")
-        if isinstance(file_value, dict):
-            file_value = file_value.get("path") or file_value.get("file")
-
-        message = item.get("description") or item.get("message")
-        if not message:
-            message = item.get("expected_namespace") or item.get("expected_pattern") or "(outlier)"
-
         top_findings.append(
             {
-                "file": str(file_value or item.get("path") or item.get("context_label") or "unknown"),
-                "rule": str(item.get("rule") or item.get("category") or item.get("type") or item.get("status") or "outlier"),
-                "message": str(message),
+                "file": normalize_file_value(
+                    item.get("file") or item.get("path") or item.get("context_label"),
+                    str(item.get("context_label") or "unknown"),
+                ),
+                "rule": normalize_rule_value(item),
+                "message": normalize_message_value(item),
                 "suggested_fix": str(item.get("suggested_fix") or item.get("suggestion") or ""),
             }
         )
 
     return {
         "drift_increased": bool(baseline.get("drift_increased", False)),
+        "new_findings_count": len(new_findings),
+        "new_findings": new_findings[:100],
+        "alignment_score": summary.get("alignment_score") if isinstance(summary, dict) else None,
         "outliers_found": summary.get("outliers_found") if isinstance(summary, dict) else None,
         "parsed_outlier_items": len(outlier_items),
         "severity_counts": severity_counts,

--- a/scripts/digest/render-audit-summary.py
+++ b/scripts/digest/render-audit-summary.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""Render actionable markdown from Homeboy audit JSON output in a log file.
-
-Reads a Homeboy command log, extracts the last parseable JSON object that looks
-like an audit payload, and prints concise markdown suitable for PR comments.
-"""
+"""Render actionable markdown from Homeboy audit JSON output in a log file."""
 
 from __future__ import annotations
 
@@ -37,11 +33,9 @@ def extract_json_candidates(text: str) -> list[dict]:
 
 
 def normalize_log_text(raw_text: str) -> str:
-    """Strip GitHub log prefixes so multiline JSON can be reconstructed."""
     normalized_lines: list[str] = []
     for line in raw_text.splitlines():
         if "Z " in line:
-            # GitHub log lines usually end the timestamp with `Z `.
             normalized_lines.append(line.rsplit("Z ", 1)[1])
         else:
             normalized_lines.append(line)
@@ -53,11 +47,120 @@ def is_audit_payload(obj: dict) -> bool:
     if not isinstance(data, dict):
         return False
 
-    if "baseline_comparison" in data:
+    if "baseline_comparison" in data or "summary" in data or "findings" in data:
         return True
 
     command = str(data.get("command", ""))
     return command.startswith("audit")
+
+
+def normalize_file_value(raw: object, fallback: str = "unknown") -> str:
+    if isinstance(raw, dict):
+        raw = raw.get("path") or raw.get("file")
+    return str(raw or fallback)
+
+
+def normalize_rule_value(item: dict, fallback: str = "outlier") -> str:
+    return str(
+        item.get("rule")
+        or item.get("kind")
+        or item.get("category")
+        or item.get("type")
+        or item.get("status")
+        or fallback
+    )
+
+
+def normalize_message_value(item: dict, fallback: str = "(outlier)") -> str:
+    message = item.get("description") or item.get("message")
+    if not message:
+        message = item.get("expected_namespace") or item.get("expected_pattern") or fallback
+    return str(message)
+
+
+def build_audit_summary(log_text: str) -> dict:
+    payloads = [
+        p for p in extract_json_candidates(normalize_log_text(log_text)) if is_audit_payload(p)
+    ]
+    if not payloads:
+        return {}
+
+    payload = payloads[-1]
+    data = payload.get("data", {}) if isinstance(payload, dict) else {}
+    baseline = data.get("baseline_comparison", {}) if isinstance(data, dict) else {}
+    summary = data.get("summary", {}) if isinstance(data, dict) else {}
+    findings = data.get("findings", []) if isinstance(data, dict) else []
+    conventions = data.get("conventions", []) if isinstance(data, dict) else []
+    new_items = baseline.get("new_items", []) if isinstance(baseline, dict) else []
+
+    if not isinstance(findings, list):
+        findings = []
+    if not isinstance(conventions, list):
+        conventions = []
+    if not isinstance(new_items, list):
+        new_items = []
+
+    outlier_items: list[dict] = []
+    for conv in conventions:
+        if not isinstance(conv, dict):
+            continue
+        context_label = str(
+            conv.get("context_label")
+            or conv.get("name")
+            or conv.get("rule")
+            or conv.get("pattern")
+            or "unknown"
+        )
+        outliers = conv.get("outliers", [])
+        if not isinstance(outliers, list):
+            continue
+        for outlier in outliers:
+            if not isinstance(outlier, dict):
+                continue
+            item = dict(outlier)
+            item.setdefault("context_label", context_label)
+            outlier_items.append(item)
+
+    severity_counts: dict[str, int] = {}
+    top_findings: list[dict[str, str]] = []
+    for item in findings + outlier_items:
+        if not isinstance(item, dict):
+            continue
+        severity = str(item.get("severity") or item.get("level") or "unknown").lower()
+        severity_counts[severity] = severity_counts.get(severity, 0) + 1
+        top_findings.append(
+            {
+                "file": normalize_file_value(
+                    item.get("file") or item.get("path") or item.get("context_label"),
+                    str(item.get("context_label") or "unknown"),
+                ),
+                "rule": normalize_rule_value(item),
+                "message": normalize_message_value(item),
+                "suggested_fix": str(item.get("suggested_fix") or item.get("suggestion") or ""),
+            }
+        )
+
+    new_findings: list[dict[str, str]] = []
+    for item in new_items:
+        if not isinstance(item, dict):
+            continue
+        new_findings.append(
+            {
+                "context": str(item.get("context_label") or item.get("file") or item.get("path") or "unknown"),
+                "message": normalize_message_value(item, "(new finding)"),
+                "fingerprint": str(item.get("fingerprint") or ""),
+            }
+        )
+
+    return {
+        "alignment_score": summary.get("alignment_score") if isinstance(summary, dict) else None,
+        "drift_increased": bool(baseline.get("drift_increased", False)),
+        "outliers_found": summary.get("outliers_found") if isinstance(summary, dict) else None,
+        "parsed_outlier_items": len(outlier_items),
+        "severity_counts": severity_counts,
+        "new_findings": new_findings[:100],
+        "top_findings": top_findings[:100],
+    }
 
 
 def main() -> int:
@@ -72,54 +175,52 @@ def main() -> int:
     except OSError:
         return 1
 
-    payloads = [
-        p for p in extract_json_candidates(normalize_log_text(text)) if is_audit_payload(p)
-    ]
-    if not payloads:
+    summary = build_audit_summary(text)
+    if not summary:
         return 2
 
-    payload = payloads[-1]
-    data = payload.get("data", {})
-    baseline = data.get("baseline_comparison", {}) if isinstance(data, dict) else {}
+    alignment_score = summary.get("alignment_score")
+    if isinstance(alignment_score, (int, float)):
+        print(f"- Alignment score: **{alignment_score:.3f}**")
 
-    drift_increased = bool(baseline.get("drift_increased", False))
-    new_items = baseline.get("new_items", [])
-    if not isinstance(new_items, list):
-        new_items = []
+    severity_counts = summary.get("severity_counts", {}) or {}
+    if severity_counts:
+        sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(severity_counts.items()))
+        print(f"- Severity counts: **{sev_text}**")
 
-    resolved = baseline.get("resolved_fingerprints", [])
-    if not isinstance(resolved, list):
-        resolved = []
+    print(f"- Drift increased: **{'yes' if summary.get('drift_increased') else 'no'}**")
 
-    summary = data.get("summary", {}) if isinstance(data, dict) else {}
-    outliers_found = summary.get("outliers_found") if isinstance(summary, dict) else None
-
-    if drift_increased:
-        print(f"- Drift increased: **{len(new_items)}** new finding(s)")
-    else:
-        print("- Drift increased: **no**")
-
+    outliers_found = summary.get("outliers_found")
     if isinstance(outliers_found, int):
         print(f"- Outliers in current run: **{outliers_found}**")
 
-    if resolved:
-        print(f"- Resolved findings since baseline: **{len(resolved)}**")
+    parsed_outlier_items = summary.get("parsed_outlier_items")
+    if isinstance(parsed_outlier_items, int) and parsed_outlier_items > 0:
+        print(f"- Parsed outlier entries: **{parsed_outlier_items}**")
 
-    if new_items:
-        print("\n<details><summary>New findings (actionable)</summary>\n")
-        for idx, item in enumerate(new_items[:10], start=1):
-            if not isinstance(item, dict):
-                continue
-            context = item.get("context_label", "unknown")
-            desc = item.get("description", "(no description)")
-            fp = item.get("fingerprint", "")
-            fp_part = f" (`{fp}`)" if fp else ""
-            print(f"{idx}. **{context}** — {desc}{fp_part}")
+    new_findings = summary.get("new_findings", []) or []
+    if new_findings:
+        print(f"- New findings since baseline: **{len(new_findings)}**")
+        for idx, item in enumerate(new_findings[:5], start=1):
+            context = str(item.get("context", "unknown"))
+            message = str(item.get("message", ""))
+            fingerprint = str(item.get("fingerprint", ""))
+            line = f"  {idx}. **{context}**"
+            if message:
+                line += f" — {message}"
+            if fingerprint:
+                line += f" (`{fingerprint}`)"
+            print(line)
 
-        if len(new_items) > 10:
-            print(f"\n_...and {len(new_items) - 10} more new finding(s)._")
-
-        print("\n</details>")
+    top_findings = summary.get("top_findings", []) or []
+    if top_findings:
+        print("- Top actionable findings:")
+        for idx, item in enumerate(top_findings[:5], start=1):
+            line = f"  {idx}. **{item.get('file', 'unknown')}** — {item.get('rule', 'unknown')}"
+            message = str(item.get("message", ""))
+            if message:
+                line += f" — {message}"
+            print(line)
 
     return 0
 

--- a/scripts/digest/render.py
+++ b/scripts/digest/render.py
@@ -3,6 +3,16 @@ from __future__ import annotations
 from typing import Any
 
 
+def _format_audit_finding(finding: dict[str, Any]) -> str:
+    file_value = str(finding.get("file", "unknown"))
+    rule_value = str(finding.get("rule", "unknown"))
+    message_value = str(finding.get("message", ""))
+    parts = [f"**{file_value}**", rule_value]
+    if message_value:
+        parts.append(message_value)
+    return " — ".join(parts)
+
+
 def render_markdown(
     lint_digest: dict[str, Any],
     test_digest: dict[str, Any],
@@ -90,6 +100,9 @@ def render_markdown(
 
     if "audit" in results:
         lines.append("### Audit Failure Digest")
+        alignment_score = audit_digest.get("alignment_score")
+        if isinstance(alignment_score, (int, float)):
+            lines.append(f"- Alignment score: **{alignment_score:.3f}**")
         severity_counts = audit_digest.get("severity_counts", {}) or {}
         if severity_counts:
             sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(severity_counts.items()))
@@ -102,15 +115,26 @@ def render_markdown(
             lines.append(f"- Parsed outlier entries: **{parsed_outliers}**")
         lines.append(f"- Drift increased: **{'yes' if audit_digest.get('drift_increased') else 'no'}**")
 
+        new_findings = audit_digest.get("new_findings", []) or []
+        new_findings_count = audit_digest.get("new_findings_count", 0)
+        if isinstance(new_findings_count, int) and new_findings_count > 0:
+            lines.append(f"- New findings since baseline: **{new_findings_count}**")
+            for idx, finding in enumerate(new_findings[:5], start=1):
+                context = str(finding.get("context", "unknown"))
+                message = str(finding.get("message", ""))
+                fingerprint = str(finding.get("fingerprint", ""))
+                line = f"  {idx}. **{context}**"
+                if message:
+                    line += f" — {message}"
+                if fingerprint:
+                    line += f" (`{fingerprint}`)"
+                lines.append(line)
+
         top_findings = audit_digest.get("top_findings", []) or []
         if top_findings:
             lines.append("- Top actionable findings:")
             for idx, finding in enumerate(top_findings[:5], start=1):
-                line = (
-                    f"  {idx}. **{finding.get('file','unknown')}** — "
-                    f"{finding.get('rule','unknown')} — {finding.get('message','')}"
-                )
-                lines.append(line)
+                lines.append(f"  {idx}. {_format_audit_finding(finding)}")
 
             lines.append("")
             lines.append(
@@ -122,11 +146,7 @@ def render_markdown(
             if len(full_findings) > max_full_findings:
                 full_findings = full_findings[:max_full_findings]
             for idx, finding in enumerate(full_findings, start=1):
-                line = (
-                    f"{idx}. **{finding.get('file','unknown')}** — "
-                    f"{finding.get('rule','unknown')} — {finding.get('message','')}"
-                )
-                lines.append(line)
+                lines.append(f"{idx}. {_format_audit_finding(finding)}")
             if len(top_findings) > max_full_findings:
                 lines.append("")
                 lines.append(
@@ -164,7 +184,13 @@ def render_markdown(
         for cmd in human:
             lines.append(f"  - `{cmd}`")
     if not fixable and not human:
-        lines.append("- No failed commands to classify.")
+        failed_commands = autofixability.get("failed_commands", []) or []
+        if failed_commands:
+            lines.append("- Failed commands:")
+            for cmd in failed_commands:
+                lines.append(f"  - `{cmd}`")
+        else:
+            lines.append("- No failed commands to classify.")
 
     if potential_fixable_failed:
         lines.append("- Potentially auto-fixable failed commands (if autofix enabled):")

--- a/scripts/digest/test-audit-comment-render.py
+++ b/scripts/digest/test-audit-comment-render.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REAL_LOG = Path("/root/.local/share/opencode/tool-output/tool_cc14c67d8001kLeyRdnG0KabT0")
+
+
+def assert_contains(text: str, needle: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"missing expected text: {needle!r}\n---\n{text}")
+
+
+def main() -> int:
+    if not REAL_LOG.is_file():
+        print("skipping: real audit log fixture not available")
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        audit_log = tmpdir / "audit.log"
+        audit_log.write_text(REAL_LOG.read_text(encoding="utf-8", errors="replace"), encoding="utf-8")
+
+        digest_md = subprocess.check_output(
+            [
+                sys.executable,
+                str(ROOT / "scripts/digest/build-failure-digest.py"),
+                str(tmpdir),
+                json.dumps({"audit": "fail"}),
+                "https://github.com/Extra-Chill/homeboy/actions/runs/22747992649",
+                "homeboy 0.59.0",
+                "rust",
+                "https://github.com/Extra-Chill/homeboy-extensions",
+                "unknown",
+                "Extra-Chill/homeboy-action",
+                "v1",
+                "audit",
+                "false",
+                "false",
+                "",
+            ],
+            text=True,
+        ).strip()
+
+        digest_text = Path(digest_md).read_text(encoding="utf-8")
+        audit_json = json.loads((tmpdir / "homeboy-audit-summary.json").read_text(encoding="utf-8"))
+        audit_summary = subprocess.check_output(
+            [
+                sys.executable,
+                str(ROOT / "scripts/digest/render-audit-summary.py"),
+                str(audit_log),
+            ],
+            text=True,
+        )
+
+        assert audit_json["outliers_found"] == 3
+        assert audit_json["new_findings_count"] == 1
+        assert audit_json["new_findings"][0]["context"] == "structural"
+
+        assert_contains(digest_text, "### Audit Failure Digest")
+        assert_contains(digest_text, "- Human-needed failed commands:")
+        assert_contains(digest_text, "- Top actionable findings:")
+        assert_contains(digest_text, "**src/core/changelog/sections.rs** — god_file")
+        assert_contains(digest_text, "**src/core/release/pipeline.rs** — god_file")
+
+        assert_contains(audit_summary, "- New findings since baseline: **1**")
+        assert_contains(audit_summary, "**src/core/changelog/sections.rs** — god_file")
+
+    print("audit comment rendering checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -2,6 +2,68 @@
 
 set -euo pipefail
 
+render_audit_summary_from_log() {
+  local log_file="$1"
+  python3 "${GITHUB_ACTION_PATH}/scripts/digest/render-audit-summary.py" "${log_file}" 2>/dev/null || true
+}
+
+render_audit_summary_from_json() {
+  local json_file="$1"
+  python3 - "$json_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+if not path.is_file():
+    raise SystemExit(0)
+
+data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+
+alignment_score = data.get("alignment_score")
+if isinstance(alignment_score, (int, float)):
+    print(f"- Alignment score: **{alignment_score:.3f}**")
+
+severity_counts = data.get("severity_counts") or {}
+if severity_counts:
+    sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(severity_counts.items()))
+    print(f"- Severity counts: **{sev_text}**")
+
+print(f"- Drift increased: **{'yes' if data.get('drift_increased') else 'no'}**")
+
+outliers_found = data.get("outliers_found")
+if isinstance(outliers_found, int):
+    print(f"- Outliers in current run: **{outliers_found}**")
+
+new_findings_count = data.get("new_findings_count")
+new_findings = data.get("new_findings") or []
+if isinstance(new_findings_count, int) and new_findings_count > 0:
+    print(f"- New findings since baseline: **{new_findings_count}**")
+    for idx, item in enumerate(new_findings[:5], start=1):
+        context = str(item.get("context", "unknown"))
+        message = str(item.get("message", ""))
+        fingerprint = str(item.get("fingerprint", ""))
+        line = f"  {idx}. **{context}**"
+        if message:
+            line += f" — {message}"
+        if fingerprint:
+            line += f" (`{fingerprint}`)"
+        print(line)
+
+top_findings = data.get("top_findings") or []
+if top_findings:
+    print("- Top actionable findings:")
+    for idx, item in enumerate(top_findings[:5], start=1):
+        file_value = str(item.get("file", "unknown"))
+        rule_value = str(item.get("rule", "unknown"))
+        message = str(item.get("message", ""))
+        line = f"  {idx}. **{file_value}** — {rule_value}"
+        if message:
+            line += f" — {message}"
+        print(line)
+PY
+}
+
 OUTPUT_DIR="${HOMEBOY_OUTPUT_DIR:-}"
 REPO="${GITHUB_REPOSITORY}"
 COMP_ID="${COMPONENT_NAME:-$(basename "${GITHUB_REPOSITORY}")}"
@@ -38,6 +100,8 @@ else
   COMMENT_BODY+="- Action: \`${HOMEBOY_ACTION_REPOSITORY:-unknown}@${HOMEBOY_ACTION_REF:-unknown}\`"$'\n\n'
 fi
 
+AUDIT_SUMMARY_JSON="${OUTPUT_DIR}/homeboy-audit-summary.json"
+
 if [ "${TEST_SCOPE_EFFECTIVE:-}" = "full" ] && [ "${HOMEBOY_CHANGED_SINCE:-}" != "" ]; then
   COMMENT_BODY+="> :information_source: PR test scope resolved to **full** for compatibility with installed Homeboy CLI"$'\n\n'
 elif [ "${TEST_SCOPE_EFFECTIVE:-}" = "changed" ]; then
@@ -66,6 +130,17 @@ for CMD in "${CMD_ARRAY[@]}"; do
   fi
 
   COMMENT_BODY+=":${ICON}: **${CMD}**${SCOPE_NOTE}"$'\n'
+
+  if [ "${CMD}" = "audit" ] && [ -f "${AUDIT_SUMMARY_JSON}" ]; then
+    COMMENT_BODY+="- Actionable audit summary:"$'\n'
+    COMMENT_BODY+="$(render_audit_summary_from_json "${AUDIT_SUMMARY_JSON}")"$'\n'
+  elif [ "${CMD}" = "audit" ] && [ -f "${LOG_FILE}" ]; then
+    AUDIT_MD="$(render_audit_summary_from_log "${LOG_FILE}")"
+    if [ -n "${AUDIT_MD}" ]; then
+      COMMENT_BODY+="- Actionable audit summary:"$'\n'
+      COMMENT_BODY+="${AUDIT_MD}"$'\n'
+    fi
+  fi
 
   if [ -f "${LOG_FILE}" ] && [ "${HAS_DIGEST}" != "true" ]; then
     PHPCS_SUMMARY=$(grep -o "LINT SUMMARY: .*" "${LOG_FILE}" | head -1 || true)
@@ -100,14 +175,6 @@ for CMD in "${CMD_ARRAY[@]}"; do
       COMMENT_BODY+=$'\n'"<details><summary>Fatal error</summary>"$'\n\n'"\`\`\`"$'\n'
       COMMENT_BODY+="${FATAL}"$'\n'
       COMMENT_BODY+="\`\`\`"$'\n'"</details>"$'\n'
-    fi
-
-    if [ "${CMD}" = "audit"; then
-      AUDIT_MD=$(python3 "${GITHUB_ACTION_PATH}/scripts/digest/render-audit-summary.py" "${LOG_FILE}" 2>/dev/null || true)
-      if [ -n "${AUDIT_MD}" ]; then
-        COMMENT_BODY+=$'\n'"### Audit summary"$'\n'
-        COMMENT_BODY+="${AUDIT_MD}"$'\n'
-      fi
     fi
 
     CARGO_ERRORS=$(grep -c "^error\[" "${LOG_FILE}" 2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary
- preserve full structured audit findings and baseline drift details in the failure digest instead of collapsing audit failures down to artifact names
- render actionable audit summaries directly in PR comments so reviewers see the top files, rules, and messages without hunting through artifacts
- add a regression test that rebuilds the digest from a real failed audit log and asserts the comment-facing summary stays useful

## Testing
- python3 scripts/digest/test-audit-comment-render.py
- python3 -m py_compile scripts/digest/build-failure-digest.py scripts/digest/render.py scripts/digest/parsers.py scripts/digest/render-audit-summary.py scripts/digest/test-audit-comment-render.py
- bash -n scripts/pr/post-pr-comment.sh