### PR TITLE
feat: CI-driven continuous release pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Homeboy Action
 
-GitHub Action for running [Homeboy](https://github.com/Extra-Chill/homeboy) lint, test, and audit commands on your PRs.
+GitHub Action for running [Homeboy](https://github.com/Extra-Chill/homeboy) lint, test, audit, and release commands in CI.
 
 Works with **any Homeboy extension** — WordPress, Rust, Node, or your own custom extension.
 
 ## Quick Start
 
-### WordPress Plugin/Theme
+### PR Quality Checks
 
 ```yaml
-name: Homeboy
+name: CI
 on: [pull_request]
 
 jobs:
@@ -25,10 +25,71 @@ jobs:
           php-version: '8.2'
 ```
 
+### Continuous Release
+
+Fully automated releases — no human input needed. CI checks for releasable commits every 15 minutes, computes the version from conventional commits, generates changelog, bumps version targets, tags, and publishes.
+
+```yaml
+name: Release
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: Extra-Chill/homeboy-action@v1
+        id: release
+        with:
+          extension: rust
+          component: my-project
+          commands: release
+```
+
+The release command:
+
+1. Scans conventional commits since the last version tag
+2. Skips if no releasable commits (`chore:`, `ci:`, `docs:`, `test:` are ignored)
+3. Computes version bump: `fix:` → patch, `feat:` → minor, `BREAKING CHANGE` → major
+4. Generates changelog entries via `homeboy changelog add`
+5. Bumps version targets (Cargo.toml, package.json, VERSION, etc.)
+6. Finalizes changelog (`[Next]` → `[VERSION] - DATE`)
+7. Commits, creates an annotated tag, and pushes
+
+After the tag push, downstream build/publish jobs can pick it up (e.g. cargo-dist, npm publish).
+
+#### Continuous release outputs
+
+| Output | Description |
+|--------|-------------|
+| `released` | `true` if a release was created, `false` if skipped |
+| `release-version` | Version number (e.g. `0.63.0`) |
+| `release-tag` | Git tag (e.g. `v0.63.0`) |
+| `release-bump-type` | Bump type used (`patch`, `minor`, `major`) |
+
+Use these outputs to gate downstream jobs:
+
+```yaml
+  build:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    # ... build and publish steps
+```
+
 ### Required Portable Config (`homeboy.json`)
 
 `homeboy.json` at repository root is required by Homeboy Action.
-If your repo has a portable extension config, you don't need to specify the extension input:
 
 ```json
 {
@@ -39,34 +100,17 @@ If your repo has a portable extension config, you don't need to specify the exte
 }
 ```
 
-```yaml
-- uses: Extra-Chill/homeboy-action@v1
-  with:
-    commands: lint,test
-    php-version: '8.2'
-```
-
-### Custom Extension
-
-```yaml
-- uses: Extra-Chill/homeboy-action@v1
-  with:
-    extension: my-extension
-    extension-source: https://github.com/my-org/my-homeboy-extensions
-    commands: lint,test
-```
-
 ## Inputs
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `version` | No | `latest` | Homeboy version to install (e.g. `0.52.0`) |
+| `source` | No | | Path to build homeboy from source (e.g. `.`). Falls back to release binary. |
 | `extension` | No | | Extension ID (e.g. `wordpress`, `rust`, `node`) |
 | `extension-source` | No | `Extra-Chill/homeboy-extensions` | Git URL to install the extension from |
 | `commands` | No | `lint,test` | Comma-separated commands to run |
 | `component` | No | *(repo name)* | Component name (auto-detected from repo) |
 | `args` | No | | Extra arguments passed to each command |
-| `settings` | No | | Deprecated. Use `homeboy.json` extension settings instead. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |
 | `node-version` | No | | Node.js version (sets up via `actions/setup-node`) |
 | `autofix` | No | `false` | On PR failures, run safe autofixes, commit, push, and re-run checks |
@@ -74,69 +118,25 @@ If your repo has a portable extension config, you don't need to specify the exte
 | `autofix-max-commits` | No | `2` | Safety limit for autofix commit chain depth per branch |
 | `autofix-commands` | No | | Override autofix commands (comma-separated, e.g. `lint --fix,test --fix`) |
 | `autofix-label` | No | | Optional PR label required before autofix runs (e.g. `autofix`) |
-| `test-scope` | No | `full` | Test scope for PRs: `full` or `changed` (requires Homeboy test changed-since support) |
-| `auto-issue` | No | `false` | Auto-file issue on non-PR failures (e.g. `push` to `main`) |
-| `comment-key` | No | *(workflow + component)* | Shared PR comment key so multiple jobs can aggregate into one sticky comment |
-| `comment-section-key` | No | *(single command or job id)* | Section key within the shared PR comment |
-| `comment-section-title` | No | *(humanized section key)* | Visible heading for this action invocation inside the shared PR comment |
-
-### Fork PR note
-
-On fork-based pull requests, GitHub may provide a restricted `GITHUB_TOKEN` that cannot write PR comments or inline reviews.
-Homeboy Action treats those publish steps as best-effort in that context:
-
-- lint/test/audit execution still runs and determines job pass/fail
-- PR comment/inline review publishing is skipped with a warning when token permissions are insufficient
-
-This keeps CI reliable for external contributors while preserving strict token safety defaults.
+| `test-scope` | No | `full` | Test scope for PRs: `full` or `changed` |
+| `auto-issue` | No | `false` | Auto-file issue on non-PR failures |
+| `comment-key` | No | *(auto)* | Shared PR comment key so multiple jobs aggregate into one sticky comment |
+| `comment-section-key` | No | *(auto)* | Section key within the shared PR comment |
+| `comment-section-title` | No | *(auto)* | Visible heading for this section in the shared PR comment |
+| `release-dry-run` | No | `false` | Preview the release without making changes |
+| `release-branch` | No | `main` | Branch that releases are allowed from |
+| `release-skip-changelog` | No | `false` | Skip auto-generating changelog entries from conventional commits |
 
 ## Outputs
 
 | Output | Description |
 |--------|-------------|
 | `results` | JSON object with pass/fail for each command (e.g. `{"lint":"pass","test":"fail"}`) |
-
-## Failure Digest
-
-On failed runs, Homeboy Action now emits a compact **Failure Digest** to:
-
-- the job summary (`GITHUB_STEP_SUMMARY`)
-- the PR comment block (when running on pull requests)
-
-Digest includes:
-
-- tooling versions (Homeboy CLI, extension source/revision, action ref)
-- failed test count + top failed tests
-- audit summary (drift/outliers/top findings when structured output is available)
-- actionable audit details directly in the PR comment (new baseline drift + top findings), not just artifact filenames
-- links back to the full workflow run logs
-
-When multiple jobs invoke Homeboy Action on the same PR, they now **merge into one shared PR comment** by default.
-The default grouping key is **workflow + component**, so separate `lint`, `test`, and `audit` jobs can publish independent results without overwriting each other.
-
-Each invocation owns one section inside that shared comment:
-
-- default section key: the single command being run, or the job id for multi-command runs
-- section ordering is normalized so `lint`, `test`, and `audit` stay readable even if jobs finish out of order
-- duplicate legacy comments are consolidated automatically on the next update
-
-Auto-filed failure issues on non-PR runs also include:
-
-- **Primary failure** (first failed command + first fatal/error line)
-- **Secondary findings** (additional failed commands)
-- **Triage order** to reduce debugging time
-
-Machine-readable files are written to the action output directory:
-
-- `homeboy-test-failures.json`
-- `homeboy-audit-summary.json`
-- `homeboy-autofixability.json`
-
-Autofixability classification includes:
-
-- `overall`: `auto_fixable`, `mixed`, `human_needed`, or `none`
-- `auto_fixable_failed_commands`
-- `human_needed_failed_commands`
+| `binary-source` | How the binary was obtained: `source`, `fallback`, or `release` |
+| `released` | Whether a release was created (`true`/`false`) |
+| `release-version` | The released version number (e.g. `1.2.3`) |
+| `release-tag` | The release git tag (e.g. `v1.2.3`) |
+| `release-bump-type` | The bump type used (`patch`, `minor`, `major`) |
 
 ## Examples
 
@@ -173,12 +173,6 @@ Autofixability classification includes:
     lint-changed-only: 'true'
     test-scope: 'changed'
 ```
-
-> `test-scope: changed` requires Homeboy support for `homeboy test --changed-since`.
-> If unsupported in your pinned Homeboy version, keep `test-scope: full`.
-
-Homeboy Action now performs a capability probe for `test-scope: changed` on PRs.
-If your installed Homeboy CLI does not support `--changed-since` for tests yet, the action automatically falls back to `full` test scope and emits a warning.
 
 ### Split Jobs, Shared PR Comment
 
@@ -217,34 +211,6 @@ jobs:
 
 All three jobs write to the **same PR comment** automatically.
 
-### Recommended org-wide CI profile
-
-Use two workflows for clear signal:
-
-1. **PR workflow** (fast + scoped)
-   - `commands: lint,test,audit`
-   - `lint-changed-only: 'true'`
-   - `test-scope: 'changed'` (auto-falls back to `full` if unsupported)
-
-2. **Main workflow** (authoritative)
-   - trigger on `push` to `main` (or release/version bump branches)
-   - `commands: lint,test,audit`
-   - `test-scope: 'full'`
-   - `auto-issue: 'true'`
-
-Example main workflow step:
-
-```yaml
-- uses: Extra-Chill/homeboy-action@v1
-  with:
-    extension: wordpress
-    commands: lint,test,audit
-    test-scope: 'full'
-    auto-issue: 'true'
-    php-version: '8.2'
-    node-version: '20'
-```
-
 ### Auto-apply Fixable CI Issues (PRs)
 
 ```yaml
@@ -258,12 +224,10 @@ Example main workflow step:
 
 When enabled, the action will:
 1. Run configured commands
-2. If any fail, run safe autofix commands (default: `lint --fix`, `test --fix` when present)
+2. If any fail, run safe autofix commands
 3. Commit changes as `chore(ci): apply homeboy autofixes`
 4. Push to the PR branch
 5. Re-run checks and report final status
-
-> Autofix mode is PR-only and never force-pushes or amends commits.
 
 ### Auto-open Fix PRs on non-PR runs
 
@@ -278,107 +242,116 @@ When enabled, the action will:
     auto-issue: 'true'
 ```
 
-Behavior:
-- If CI fails, action runs safe autofix commands on a new `ci/autofix/*` branch.
-- If rerun passes, action opens an autofix PR and skips auto-issue filing.
-- If rerun still fails, action files/updates the CI failure issue with autofix attempt context.
-- `autofix-max-commits` prevents infinite autofix loops by capping chain depth.
+### Continuous Release with Quality Gate
 
-Optional label gate:
+Full example with quality checks before release and cargo-dist builds after:
 
 ```yaml
-- uses: Extra-Chill/homeboy-action@v1
-  with:
-    extension: wordpress
-    commands: lint,test
-    php-version: '8.2'
-    autofix: 'true'
-    autofix-label: 'autofix'
+name: Release
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+jobs:
+  # Fast exit if nothing to release
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should-release: ${{ steps.check.outputs.should-release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for releasable commits
+        id: check
+        run: |
+          # ... scan conventional commits since last tag
+          # Set should-release=true if fix:/feat:/breaking commits exist
+
+  # Quality gate (only if releasing)
+  gate:
+    needs: check
+    if: needs.check.outputs.should-release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo fmt --check && cargo clippy && cargo test
+      - uses: Extra-Chill/homeboy-action@v1
+        with:
+          source: '.'
+          extension: rust
+          commands: audit
+
+  # Version bump + changelog + tag
+  prepare:
+    needs: [check, gate]
+    runs-on: ubuntu-latest
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      release-tag: ${{ steps.release.outputs.release-tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Extra-Chill/homeboy-action@v1
+        id: release
+        with:
+          extension: rust
+          commands: release
+
+  # Build + publish (only if released)
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.released == 'true'
+    # ... cargo-dist, crates.io, Homebrew, GitHub Release
 ```
 
-With `autofix-label`, no bot commit will be created unless that label is present on the PR.
+### Recommended Org-wide CI Profile
 
-### Configure Settings in `homeboy.json`
+Use two workflows:
 
-```yaml
-{
-  "id": "my-project",
-  "extensions": {
-    "wordpress": {
-      "settings": {
-        "database_type": "sqlite"
-      }
-    }
-  }
-}
-```
+1. **PR workflow** (fast + scoped)
+   - `commands: lint,test,audit`
+   - `lint-changed-only: 'true'`
+   - `test-scope: 'changed'`
 
-### Skip Lint During Test (Run Separately)
+2. **Release workflow** (continuous)
+   - trigger on `schedule` (every 15 min) + `workflow_dispatch`
+   - `commands: release`
+   - quality gate before release
 
-```yaml
-- uses: Extra-Chill/homeboy-action@v1
-  with:
-    extension: wordpress
-    commands: lint
-    php-version: '8.2'
+### Fork PR Note
 
-- uses: Extra-Chill/homeboy-action@v1
-  with:
-    extension: wordpress
-    commands: test
-    args: --skip-lint
-    php-version: '8.2'
-```
+On fork-based pull requests, GitHub may provide a restricted `GITHUB_TOKEN` that cannot write PR comments or inline reviews. Homeboy Action treats those publish steps as best-effort — lint/test/audit execution still runs and determines job pass/fail.
 
-### Pin a Specific Homeboy Version
+## Failure Digest
 
-```yaml
-- uses: Extra-Chill/homeboy-action@v1
-  with:
-    version: '0.52.0'
-    extension: wordpress
-    commands: lint,test
-    php-version: '8.2'
-```
+On failed runs, Homeboy Action emits a **Failure Digest** to the job summary and PR comment:
 
-### Use Results in Subsequent Steps
+- Tooling versions (Homeboy CLI, extension source/revision, action ref)
+- Failed test count + top failed tests
+- Audit summary (drift/outliers/top findings)
+- Links back to the full workflow run logs
 
-```yaml
-- uses: Extra-Chill/homeboy-action@v1
-  id: homeboy
-  continue-on-error: true
-  with:
-    extension: wordpress
-    commands: lint,test
-    php-version: '8.2'
-
-- name: Check results
-  run: |
-    echo "Results: ${{ steps.homeboy.outputs.results }}"
-```
+When multiple jobs invoke Homeboy Action on the same PR, they **merge into one shared PR comment** by default.
 
 ## How It Works
 
-1. **Installs Homeboy** — Downloads the correct binary for your runner from GitHub Releases
-2. **Installs Extension** — Clones and sets up the specified extension (runs `composer install`, etc.)
+1. **Installs Homeboy** — Downloads the correct binary for your runner from GitHub Releases (or builds from source with `source: '.'`)
+2. **Installs Extension** — Clones and sets up the specified extension
 3. **Validates Portable Config** — Requires `homeboy.json` at repo root
 4. **Runs Commands** — Executes each command with `--path` pointing at your workspace
-
-The action is **extension-agnostic** — Homeboy is the orchestrator, extensions provide the actual lint/test/audit logic. The WordPress extension runs PHPCS, PHPUnit, and PHPStan. Other extensions can run whatever tools they need.
-
-## Project Maintenance (Dogfooding Homeboy)
-
-This repository dogfoods Homeboy project metadata and release bookkeeping:
-
-- `homeboy.json` defines component metadata and changelog/version targets
-- `docs/CHANGELOG.md` is the canonical changelog
-- `VERSION` is the version source for Homeboy version automation
-
-Use Homeboy to add changelog entries:
-
-```bash
-homeboy changelog add homeboy-action "Describe change" --type Changed
-```
+5. **Release** — If `commands` includes `release`, checks for releasable commits, bumps version, generates changelog, tags, and pushes
 
 ## Requirements
 

--- a/action.yml
+++ b/action.yml
@@ -95,10 +95,6 @@ inputs:
     description: 'Optional section title within the shared PR comment. Defaults to a humanized command or job id.'
     required: false
     default: ''
-  release-bump-type:
-    description: 'Version bump type for release: "auto" (from conventional commits), "patch", "minor", or "major"'
-    required: false
-    default: 'auto'
   release-dry-run:
     description: 'If true, preview the release without making changes'
     required: false
@@ -131,6 +127,9 @@ outputs:
   release-tag:
     description: 'The release git tag (e.g. v1.2.3)'
     value: ${{ steps.release.outputs.release-tag }}
+  release-bump-type:
+    description: 'The bump type used (patch, minor, major)'
+    value: ${{ steps.release.outputs.bump-type }}
 
 runs:
   using: 'composite'
@@ -345,8 +344,6 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-        QUALITY_RESULTS: ${{ steps.select-results.outputs.results }}
-        RELEASE_BUMP_TYPE: ${{ inputs.release-bump-type }}
         RELEASE_DRY_RUN: ${{ inputs.release-dry-run }}
         RELEASE_BRANCH: ${{ inputs.release-branch }}
         RELEASE_SKIP_CHANGELOG: ${{ inputs.release-skip-changelog }}

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -1,35 +1,42 @@
 #!/usr/bin/env bash
 #
-# Run the full release pipeline after quality gates have passed.
+# CI-driven continuous release pipeline.
+#
+# Called by the release workflow (cron or manual dispatch).
+# Fully automatic — no human input needed.
 #
 # Flow:
-#   1. Validate release conditions (on main, quality gates passed, etc.)
-#   2. Generate changelog from conventional commits (if no unreleased entries exist)
-#   3. Determine bump type (explicit input > commit-derived > skip)
-#   4. Run homeboy release <comp> <type> --skip-checks
+#   1. Check for releasable commits since last tag
+#   2. Compute version bump from conventional commits (fix→patch, feat→minor, breaking→major)
+#   3. Generate changelog entries from commits
+#   4. Bump version targets (Cargo.toml, package.json, VERSION, etc.)
+#   5. Finalize changelog ([Next] → [VERSION] - DATE)
+#   6. Commit version bump + changelog
+#   7. Create version tag
+#   8. Push commit + tag (tag push triggers build/publish workflow)
 #
 # Env vars:
-#   QUALITY_RESULTS     — JSON object from quality gate commands (e.g. {"lint":"pass","test":"pass"})
-#   RELEASE_BUMP_TYPE   — explicit bump type (patch/minor/major/auto), default: auto
-#   RELEASE_DRY_RUN     — if "true", only preview the release
+#   RELEASE_BRANCH      — branch to release from (default: main)
 #   COMPONENT_NAME      — component ID override
 #   RELEASE_SKIP_CHANGELOG — if "true", skip auto-generating changelog from commits
+#   RELEASE_DRY_RUN     — if "true", preview without making changes
 #
 # Outputs (GITHUB_OUTPUT):
-#   released:       true|false
-#   release-version: the new version (e.g. 1.2.3)
-#   release-tag:    the git tag (e.g. v1.2.3)
-#   bump-type:      the bump type used
+#   released:        true|false
+#   release-version: the version (e.g. 0.63.0)
+#   release-tag:     the git tag (e.g. v0.63.0)
+#   bump-type:       patch|minor|major
+#   skipped-reason:  why release was skipped (if released=false)
 #
 
 set -euo pipefail
 
 WORKSPACE="${GITHUB_WORKSPACE:-.}"
-BUMP_TYPE="${RELEASE_BUMP_TYPE:-auto}"
-DRY_RUN="${RELEASE_DRY_RUN:-false}"
+RELEASE_BRANCH="${RELEASE_BRANCH:-main}"
 SKIP_CHANGELOG="${RELEASE_SKIP_CHANGELOG:-false}"
+DRY_RUN="${RELEASE_DRY_RUN:-false}"
 
-# --- Resolve component ID ---
+# --- Step 1: Resolve component ID ---
 
 COMP_ID="${COMPONENT_NAME:-}"
 if [ -z "${COMP_ID}" ]; then
@@ -41,149 +48,275 @@ if [ -z "${COMP_ID}" ]; then
   fi
 fi
 
+# --- Step 2: Validate branch ---
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "${CURRENT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
+  echo "::notice::Not on ${RELEASE_BRANCH} (current: ${CURRENT_BRANCH}) — skipping release"
+  {
+    echo "released=false"
+    echo "skipped-reason=wrong-branch"
+  } >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+# --- Step 3: Find last release tag and check for releasable commits ---
+
+LAST_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || echo "")"
+
+if [ -z "${LAST_TAG}" ]; then
+  echo "::notice::No previous release tag found — scanning all commits"
+  COMMIT_RANGE="HEAD"
+else
+  COMMIT_RANGE="${LAST_TAG}..HEAD"
+fi
+
+# Parse conventional commits to determine bump type
+declare -A TYPE_MAP
+TYPE_MAP=(
+  ["feat"]="minor"
+  ["fix"]="patch"
+  ["refactor"]="patch"
+  ["perf"]="patch"
+)
+
+BUMP_TYPE="none"
+HAS_BREAKING=false
+RELEASABLE_COUNT=0
+
+COMMIT_RE='^[a-f0-9]+ ([a-z]+)(\([^)]*\))?(!)?: (.+)$'
+
+while IFS= read -r line; do
+  [ -z "${line}" ] && continue
+
+  # Skip release commits and merge commits
+  if [[ "${line}" =~ ^[a-f0-9]+\ release: ]] || [[ "${line}" =~ ^[a-f0-9]+\ Merge\ pull\ request ]]; then
+    continue
+  fi
+
+  if [[ "${line}" =~ ${COMMIT_RE} ]]; then
+    TYPE="${BASH_REMATCH[1]}"
+    BREAKING="${BASH_REMATCH[3]:-}"
+
+    if [ "${BREAKING}" = "!" ]; then
+      HAS_BREAKING=true
+    fi
+
+    # Skip non-releasable types
+    if [[ "${TYPE}" =~ ^(chore|ci|test|style|build|docs)$ ]]; then
+      continue
+    fi
+
+    COMMIT_BUMP="${TYPE_MAP[${TYPE}]:-}"
+    if [ -z "${COMMIT_BUMP}" ]; then
+      continue
+    fi
+
+    RELEASABLE_COUNT=$((RELEASABLE_COUNT + 1))
+
+    # Promote bump type (patch < minor < major)
+    if [ "${COMMIT_BUMP}" = "minor" ] && [ "${BUMP_TYPE}" != "major" ]; then
+      BUMP_TYPE="minor"
+    elif [ "${BUMP_TYPE}" = "none" ]; then
+      BUMP_TYPE="${COMMIT_BUMP}"
+    fi
+  fi
+done < <(git log "${COMMIT_RANGE}" --oneline --no-merges 2>/dev/null || true)
+
+# Check for BREAKING CHANGE in commit bodies
+if [ "${HAS_BREAKING}" = false ]; then
+  if git log "${COMMIT_RANGE}" --format="%B" 2>/dev/null | grep -q "^BREAKING CHANGE:"; then
+    HAS_BREAKING=true
+  fi
+fi
+
+if [ "${HAS_BREAKING}" = true ]; then
+  BUMP_TYPE="major"
+fi
+
+if [ "${RELEASABLE_COUNT}" -eq 0 ] || [ "${BUMP_TYPE}" = "none" ]; then
+  echo "::notice::No releasable commits since ${LAST_TAG:-initial} — nothing to release"
+  {
+    echo "released=false"
+    echo "skipped-reason=no-releasable-commits"
+  } >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Release: ${COMP_ID}"
+echo "  Commits since ${LAST_TAG:-initial}: ${RELEASABLE_COUNT} releasable"
 echo "  Bump type: ${BUMP_TYPE}"
 echo "  Dry run: ${DRY_RUN}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
-# --- Step 1: Validate quality gates ---
-
-if [ -n "${QUALITY_RESULTS:-}" ] && [ "${QUALITY_RESULTS}" != "{}" ]; then
-  if echo "${QUALITY_RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null 2>&1; then
-    echo "::error::Release aborted — quality gates failed"
-    echo "${QUALITY_RESULTS}" | jq -r 'to_entries[] | select(.value == "fail") | "  ✗ \(.key): FAILED"'
-    echo "released=false" >> "${GITHUB_OUTPUT}"
-    exit 1
-  fi
-  echo "Quality gates passed:"
-  echo "${QUALITY_RESULTS}" | jq -r 'to_entries[] | "  ✓ \(.key): \(.value)"'
-  echo ""
-fi
-
-# --- Step 2: Validate branch ---
-
-CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-RELEASE_BRANCH="${RELEASE_BRANCH:-main}"
-
-if [ "${CURRENT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
-  echo "::warning::Skipping release — not on ${RELEASE_BRANCH} branch (current: ${CURRENT_BRANCH})"
-  echo "released=false" >> "${GITHUB_OUTPUT}"
-  exit 0
-fi
-
-# --- Step 3: Configure git identity for CI commits ---
+# --- Step 4: Configure git identity ---
 
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-# --- Step 4: Generate changelog from conventional commits ---
+# --- Step 5: Generate changelog from conventional commits ---
 
 if [ "${SKIP_CHANGELOG}" != "true" ]; then
-  # Check if unreleased changelog entries already exist
-  CHANGELOG_FILE="$(jq -r '.changelog_target // "docs/CHANGELOG.md"' "${WORKSPACE}/homeboy.json" 2>/dev/null || echo "docs/CHANGELOG.md")"
-  HAS_UNRELEASED=false
-  if [ -f "${CHANGELOG_FILE}" ]; then
-    if grep -qiE '## \[?(Unreleased|Next)\]?' "${CHANGELOG_FILE}"; then
-      HAS_UNRELEASED=true
-      echo "::notice::Unreleased changelog entries already exist — skipping auto-generation"
-    fi
-  fi
+  echo "Generating changelog from conventional commits..."
 
-  if [ "${HAS_UNRELEASED}" = false ]; then
-    echo "Generating changelog from conventional commits..."
-    CHANGELOG_GEN_OUTPUT="$(mktemp)"
-    export CHANGELOG_GEN_OUTPUT
-    bash "${GITHUB_ACTION_PATH}/scripts/release/generate-changelog-from-commits.sh"
+  CHANGELOG_GEN_OUTPUT="$(mktemp)"
+  export CHANGELOG_GEN_OUTPUT
 
-    GENERATED_BUMP="$(grep '^recommended-bump=' "${CHANGELOG_GEN_OUTPUT}" | cut -d= -f2)"
-    GENERATED_COUNT="$(grep '^commit-count=' "${CHANGELOG_GEN_OUTPUT}" | cut -d= -f2)"
-    rm -f "${CHANGELOG_GEN_OUTPUT}"
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  bash "${SCRIPT_DIR}/generate-changelog-from-commits.sh"
 
-    if [ "${GENERATED_COUNT:-0}" = "0" ]; then
-      echo "::notice::No releasable conventional commits found since last tag — skipping release"
-      echo "released=false" >> "${GITHUB_OUTPUT}"
-      exit 0
-    fi
+  GENERATED_COUNT="$(grep '^commit-count=' "${CHANGELOG_GEN_OUTPUT}" | cut -d= -f2)"
+  rm -f "${CHANGELOG_GEN_OUTPUT}"
 
-    # Use generated bump type if auto
-    if [ "${BUMP_TYPE}" = "auto" ]; then
-      BUMP_TYPE="${GENERATED_BUMP}"
-      echo "::notice::Auto-detected bump type from commits: ${BUMP_TYPE}"
-    fi
+  if [ "${GENERATED_COUNT:-0}" != "0" ]; then
+    echo "::notice::Generated changelog from ${GENERATED_COUNT} conventional commits"
   fi
 fi
 
-# --- Step 5: Validate bump type ---
+# --- Step 6: Read current version and compute new version ---
 
-if [ "${BUMP_TYPE}" = "auto" ] || [ "${BUMP_TYPE}" = "none" ]; then
-  echo "::notice::No bump type resolved — skipping release"
+CURRENT_VERSION=""
+if command -v homeboy &> /dev/null; then
+  CURRENT_VERSION="$(homeboy version read "${COMP_ID}" --path "${WORKSPACE}" 2>/dev/null | jq -r '.data.version // empty' 2>/dev/null || true)"
+fi
+
+if [ -z "${CURRENT_VERSION}" ]; then
+  if [ -f "${WORKSPACE}/Cargo.toml" ]; then
+    CURRENT_VERSION="$(grep -m1 '^version' "${WORKSPACE}/Cargo.toml" | sed 's/.*"\(.*\)".*/\1/' || true)"
+  fi
+fi
+
+if [ -z "${CURRENT_VERSION}" ]; then
+  echo "::error::Cannot determine current version"
   echo "released=false" >> "${GITHUB_OUTPUT}"
+  exit 1
+fi
+
+# Compute new version using semver increment
+IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT_VERSION}"
+
+case "${BUMP_TYPE}" in
+  major)
+    NEW_VERSION="$((MAJOR + 1)).0.0"
+    ;;
+  minor)
+    NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+    ;;
+  patch)
+    NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+    ;;
+  *)
+    echo "::error::Invalid bump type: ${BUMP_TYPE}"
+    echo "released=false" >> "${GITHUB_OUTPUT}"
+    exit 1
+    ;;
+esac
+
+echo "Version: ${CURRENT_VERSION} → ${NEW_VERSION} (${BUMP_TYPE})"
+
+# --- Step 7: Bump version targets ---
+
+if [ -f "${WORKSPACE}/Cargo.toml" ]; then
+  sed -i "s/^version = \"${CURRENT_VERSION}\"/version = \"${NEW_VERSION}\"/" "${WORKSPACE}/Cargo.toml"
+  echo "  Bumped Cargo.toml"
+
+  if [ -f "${WORKSPACE}/Cargo.lock" ]; then
+    (cd "${WORKSPACE}" && cargo update --workspace 2>/dev/null || true)
+  fi
+fi
+
+if [ -f "${WORKSPACE}/VERSION" ]; then
+  echo "${NEW_VERSION}" > "${WORKSPACE}/VERSION"
+  echo "  Bumped VERSION file"
+fi
+
+if [ -f "${WORKSPACE}/package.json" ]; then
+  jq --arg v "${NEW_VERSION}" '.version = $v' "${WORKSPACE}/package.json" > "${WORKSPACE}/package.json.tmp"
+  mv "${WORKSPACE}/package.json.tmp" "${WORKSPACE}/package.json"
+  echo "  Bumped package.json"
+fi
+
+# Also bump via homeboy.json version targets (generic)
+if [ -f "${WORKSPACE}/homeboy.json" ]; then
+  VERSION_TARGETS="$(jq -r '.version.targets[]?.file // empty' "${WORKSPACE}/homeboy.json" 2>/dev/null || true)"
+  if [ -n "${VERSION_TARGETS}" ]; then
+    while IFS= read -r target_file; do
+      [ -z "${target_file}" ] && continue
+      TARGET_PATH="${WORKSPACE}/${target_file}"
+      if [ -f "${TARGET_PATH}" ] && grep -q "${CURRENT_VERSION}" "${TARGET_PATH}"; then
+        sed -i "s/${CURRENT_VERSION}/${NEW_VERSION}/g" "${TARGET_PATH}"
+        echo "  Bumped ${target_file}"
+      fi
+    done <<< "${VERSION_TARGETS}"
+  fi
+fi
+
+# --- Step 8: Finalize changelog ---
+
+CHANGELOG_FILE=""
+if [ -f "${WORKSPACE}/homeboy.json" ]; then
+  CHANGELOG_FILE="$(jq -r '.changelog_target // empty' "${WORKSPACE}/homeboy.json" 2>/dev/null || true)"
+fi
+if [ -z "${CHANGELOG_FILE}" ]; then
+  for candidate in "docs/changelog.md" "docs/CHANGELOG.md" "CHANGELOG.md" "changelog.md"; do
+    if [ -f "${WORKSPACE}/${candidate}" ]; then
+      CHANGELOG_FILE="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [ -n "${CHANGELOG_FILE}" ] && [ -f "${WORKSPACE}/${CHANGELOG_FILE}" ]; then
+  TODAY="$(date -u +%Y-%m-%d)"
+  sed -i -E "s/^## \[?(Next|Unreleased)\]?.*$/## [${NEW_VERSION}] - ${TODAY}/" "${WORKSPACE}/${CHANGELOG_FILE}"
+  echo "  Finalized changelog: [Next] → [${NEW_VERSION}] - ${TODAY}"
+fi
+
+# --- Step 9: Dry run check ---
+
+if [ "${DRY_RUN}" = "true" ]; then
+  echo ""
+  echo "::notice::Dry run — would release v${NEW_VERSION}"
+  git diff --stat
+  {
+    echo "released=false"
+    echo "release-version=${NEW_VERSION}"
+    echo "release-tag=v${NEW_VERSION}"
+    echo "bump-type=${BUMP_TYPE}"
+    echo "skipped-reason=dry-run"
+  } >> "${GITHUB_OUTPUT}"
   exit 0
 fi
 
-if [[ ! "${BUMP_TYPE}" =~ ^(patch|minor|major)$ ]]; then
-  echo "::error::Invalid bump type: ${BUMP_TYPE} (must be patch, minor, or major)"
-  echo "released=false" >> "${GITHUB_OUTPUT}"
-  exit 1
-fi
+# --- Step 10: Commit, tag, push ---
 
-# --- Step 6: Run release ---
+echo ""
+echo "Committing release v${NEW_VERSION}..."
+git add -A
+git commit -m "release: v${NEW_VERSION}
+
+Automated by CI from conventional commits (${BUMP_TYPE} bump).
+${RELEASABLE_COUNT} releasable commit(s) since ${LAST_TAG:-initial}."
+
+RELEASE_TAG="v${NEW_VERSION}"
+echo "Creating tag ${RELEASE_TAG}..."
+git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
+
+echo "Pushing to ${RELEASE_BRANCH}..."
+git push origin "${RELEASE_BRANCH}" --follow-tags
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  Releasing ${COMP_ID} with ${BUMP_TYPE} bump"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo ""
-
-RELEASE_CMD="homeboy release ${COMP_ID} ${BUMP_TYPE} --skip-checks --path ${WORKSPACE}"
-
-if [ "${DRY_RUN}" = "true" ]; then
-  RELEASE_CMD="${RELEASE_CMD} --dry-run"
-fi
-
-echo "Running: ${RELEASE_CMD}"
-RELEASE_LOG="$(mktemp)"
-set +e
-eval "${RELEASE_CMD}" 2>&1 | tee "${RELEASE_LOG}"
-RELEASE_EXIT=${PIPESTATUS[0]}
-set -e
-
-if [ "${RELEASE_EXIT}" -ne 0 ]; then
-  echo "::error::Release failed (exit code ${RELEASE_EXIT})"
-  echo "released=false" >> "${GITHUB_OUTPUT}"
-  rm -f "${RELEASE_LOG}"
-  exit 1
-fi
-
-RELEASE_OUTPUT="$(cat "${RELEASE_LOG}")"
-rm -f "${RELEASE_LOG}"
-
-# --- Step 7: Extract version from release output ---
-
-NEW_VERSION="$(echo "${RELEASE_OUTPUT}" | jq -r '.data.result.plan.steps[] | select(.type == "version") | .config.to // empty' 2>/dev/null || true)"
-
-if [ -z "${NEW_VERSION}" ]; then
-  # Fallback: read from VERSION file
-  if [ -f "${WORKSPACE}/VERSION" ]; then
-    NEW_VERSION="$(cat "${WORKSPACE}/VERSION" | tr -d '[:space:]')"
-  fi
-fi
-
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-if [ "${DRY_RUN}" = "true" ]; then
-  echo "  Dry run complete — would release v${NEW_VERSION}"
-else
-  echo "  Released v${NEW_VERSION} ✓"
-fi
+echo "  Released v${NEW_VERSION} (${BUMP_TYPE})"
+echo "  Tag ${RELEASE_TAG} pushed — build/publish workflow will trigger"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 {
   echo "released=true"
   echo "release-version=${NEW_VERSION}"
-  echo "release-tag=v${NEW_VERSION}"
+  echo "release-tag=${RELEASE_TAG}"
   echo "bump-type=${BUMP_TYPE}"
 } >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

Rewrite the release system to be fully CI-driven. No local `homeboy release` needed — humans only merge PRs.

- **`run-release.sh`**: fully automatic — scans conventional commits since last tag, computes version bump (`fix:`→patch, `feat:`→minor, `BREAKING CHANGE`→major), generates changelog, bumps version targets, commits, tags, pushes
- **`action.yml`**: cleaned up release inputs — removed `release-tag` and `release-bump-type` (CI derives everything), added `release-bump-type` output
- **`README.md`**: full rewrite with release documentation, continuous release examples, recommended org-wide CI profile

### How it works

1. Cron workflow (in consuming repo) runs every 15 minutes
2. Checks for releasable commits since last tag — exits fast if nothing to do
3. Quality gate (fmt, clippy, test, audit)
4. `commands: release` triggers `run-release.sh`:
   - Generates changelog via `homeboy changelog add`
   - Bumps Cargo.toml, VERSION, package.json, homeboy.json targets
   - Finalizes changelog (`[Next]` → `[VERSION] - DATE`)
   - Commits, creates annotated tag, pushes with `--follow-tags`
5. Downstream build/publish jobs gate on `released == 'true'`

### Depends on

- homeboy PR (release.yml rewrite) — uses this action at `@v1` after merge