### PR TITLE
feat: support GitHub App token for autofix pushes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,10 @@ inputs:
     description: 'Optional PR label required to allow autofix (e.g. "autofix")'
     required: false
     default: ''
+  app-token:
+    description: 'GitHub App token for autofix pushes. Pushes from a GitHub App trigger workflow re-runs (GITHUB_TOKEN pushes do not). Generate with actions/create-github-app-token.'
+    required: false
+    default: ''
   comment-key:
     description: 'Optional shared PR comment key. Defaults to workflow + component so separate jobs aggregate into one comment.'
     required: false
@@ -276,6 +280,7 @@ runs:
         AUTOFIX_MAX_COMMITS: ${{ inputs.autofix-max-commits }}
         PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        APP_TOKEN: ${{ inputs.app-token }}
       run: bash ${{ github.action_path }}/scripts/autofix/apply-autofix-commit.sh
 
     - name: Prepare non-PR autofix branch
@@ -288,6 +293,7 @@ runs:
         EXTRA_ARGS: ${{ inputs.args }}
         AUTOFIX_COMMANDS: ${{ inputs.autofix-commands }}
         AUTOFIX_MAX_COMMITS: ${{ inputs.autofix-max-commits }}
+        APP_TOKEN: ${{ inputs.app-token }}
       run: bash ${{ github.action_path }}/scripts/autofix/prepare-autofix-branch.sh
 
     - name: Re-run Homeboy commands after autofix

--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -22,8 +22,8 @@ if [ "${PR_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
   exit 0
 fi
 
-if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ]; then
-  echo "Skipping autofix: workflow actor is github-actions[bot]"
+if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "homeboy-ci-bot[bot]" ]; then
+  echo "Skipping autofix: workflow actor is ${GITHUB_ACTOR} (bot loop guard)"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi
@@ -110,6 +110,17 @@ fi
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git commit -m "chore(ci): apply homeboy autofixes"
-git push origin "HEAD:${GITHUB_HEAD_REF}"
+
+# Use GitHub App token for push if available — pushes from a GitHub App
+# trigger workflow re-runs, while GITHUB_TOKEN pushes do not.
+if [ -n "${APP_TOKEN:-}" ]; then
+  echo "Pushing with GitHub App token (will trigger CI re-run)"
+  git -c "http.https://github.com/.extraheader=" \
+    push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+    "HEAD:${GITHUB_HEAD_REF}"
+else
+  echo "Pushing with default token (will NOT trigger CI re-run)"
+  git push origin "HEAD:${GITHUB_HEAD_REF}"
+fi
 
 echo "committed=true" >> "${GITHUB_OUTPUT}"

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -16,8 +16,8 @@ if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
   exit 0
 fi
 
-if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ]; then
-  echo "Skipping non-PR autofix: workflow actor is github-actions[bot]"
+if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "homeboy-ci-bot[bot]" ]; then
+  echo "Skipping non-PR autofix: workflow actor is ${GITHUB_ACTOR} (bot loop guard)"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi
@@ -105,7 +105,18 @@ fi
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git commit -m "chore(ci): apply homeboy autofixes"
-git push origin "${AUTOFIX_BRANCH}"
+
+# Use GitHub App token for push if available — pushes from a GitHub App
+# trigger workflow re-runs, while GITHUB_TOKEN pushes do not.
+if [ -n "${APP_TOKEN:-}" ]; then
+  echo "Pushing with GitHub App token (will trigger CI re-run)"
+  git -c "http.https://github.com/.extraheader=" \
+    push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+    "${AUTOFIX_BRANCH}"
+else
+  echo "Pushing with default token (will NOT trigger CI re-run)"
+  git push origin "${AUTOFIX_BRANCH}"
+fi
 
 echo "committed=true" >> "${GITHUB_OUTPUT}"
 echo "autofix-branch=${AUTOFIX_BRANCH}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

Pushes from `GITHUB_TOKEN` never trigger workflow re-runs — this is a hardcoded GitHub anti-loop rule. This means autofix commits currently don't get CI'd, breaking the feedback loop.

**Solution**: Accept an optional `app-token` input (generated from a GitHub App via `actions/create-github-app-token`). When provided, autofix pushes use the app token instead of `GITHUB_TOKEN`, which triggers workflow re-runs.

## Changes

- **`action.yml`**: New `app-token` input, passed as `APP_TOKEN` env to both autofix scripts
- **`apply-autofix-commit.sh`**: When `APP_TOKEN` is set, push via `x-access-token` auth (clears `extraheader` to prevent `GITHUB_TOKEN` leaking). Falls back to default push when not set.
- **`prepare-autofix-branch.sh`**: Same app-token push logic for non-PR autofix
- **Loop guard**: Added `homeboy-ci-bot[bot]` alongside `github-actions[bot]` in actor detection to prevent infinite loops

## Usage

```yaml
- uses: actions/create-github-app-token@v1
  id: app-token
  with:
    app-id: ${{ secrets.HOMEBOY_APP_ID }}
    private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}

- uses: Extra-Chill/homeboy-action@v1
  with:
    commands: audit
    autofix: 'true'
    app-token: ${{ steps.app-token.outputs.token }}
```

## Prerequisites

1. Install `homeboy-ci-bot` GitHub App on the org
2. Set org secrets: `HOMEBOY_APP_ID`, `HOMEBOY_APP_PRIVATE_KEY`

Closes the autofix feedback loop — autofix commits will now trigger CI re-runs automatically.