### PR TITLE
feat: use homeboy-ci-bot identity for all CI commits

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -107,8 +107,8 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config user.name "homeboy-ci-bot[bot]"
+git config user.email "266378653+homeboy-ci-bot[bot]@users.noreply.github.com"
 git commit -m "chore(ci): apply homeboy autofixes"
 
 # Use GitHub App token for push if available — pushes from a GitHub App

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -102,8 +102,8 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config user.name "homeboy-ci-bot[bot]"
+git config user.email "266378653+homeboy-ci-bot[bot]@users.noreply.github.com"
 git commit -m "chore(ci): apply homeboy autofixes"
 
 # Use GitHub App token for push if available — pushes from a GitHub App

--- a/scripts/pr/post-inline-review.sh
+++ b/scripts/pr/post-inline-review.sh
@@ -14,7 +14,7 @@ fi
 dismiss_existing_bot_reviews() {
   local existing_reviews
   existing_reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-    --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("Homeboy found"))) | .id] | .[]' \
+    --jq '[.[] | select((.user.login == "github-actions[bot]" or .user.login == "homeboy-ci-bot[bot]") and (.body | test("Homeboy found"))) | .id] | .[]' \
     2>/dev/null || true)
 
   for review_id in ${existing_reviews}; do

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -154,8 +154,8 @@ echo ""
 
 # --- Step 4: Configure git identity ---
 
-git config user.name "github-actions[bot]"
-git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config user.name "homeboy-ci-bot[bot]"
+git config user.email "266378653+homeboy-ci-bot[bot]@users.noreply.github.com"
 
 # --- Step 5: Generate changelog from conventional commits ---
 


### PR DESCRIPTION
## Summary

All CI-authored commits now use the `homeboy-ci-bot[bot]` identity instead of generic `github-actions[bot]`. Clear provenance for code factory work in git history.

## Changes

- **Autofix commits** (`apply-autofix-commit.sh`, `prepare-autofix-branch.sh`): `homeboy-ci-bot[bot]` as committer
- **Release commits** (`run-release.sh`): `homeboy-ci-bot[bot]` as committer  
- **Inline review** (`post-inline-review.sh`): dismissal query matches both old and new bot identity (backward compatible)

Bot user ID: `266378653` (from `gh api /users/homeboy-ci-bot[bot]`)