### PR TITLE
fix: rename bot identity from homeboy-ci-bot to homeboy-ci

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -22,7 +22,7 @@ if [ "${PR_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
   exit 0
 fi
 
-if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "homeboy-ci-bot[bot]" ]; then
+if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "homeboy-ci[bot]" ]; then
   echo "Skipping autofix: workflow actor is ${GITHUB_ACTOR} (bot loop guard)"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
@@ -107,8 +107,8 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
-git config user.name "homeboy-ci-bot[bot]"
-git config user.email "266378653+homeboy-ci-bot[bot]@users.noreply.github.com"
+git config user.name "homeboy-ci[bot]"
+git config user.email "266378653+homeboy-ci[bot]@users.noreply.github.com"
 git commit -m "chore(ci): apply homeboy autofixes"
 
 # Use GitHub App token for push if available — pushes from a GitHub App

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -16,7 +16,7 @@ if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
   exit 0
 fi
 
-if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "homeboy-ci-bot[bot]" ]; then
+if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "homeboy-ci[bot]" ]; then
   echo "Skipping non-PR autofix: workflow actor is ${GITHUB_ACTOR} (bot loop guard)"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
@@ -102,8 +102,8 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
-git config user.name "homeboy-ci-bot[bot]"
-git config user.email "266378653+homeboy-ci-bot[bot]@users.noreply.github.com"
+git config user.name "homeboy-ci[bot]"
+git config user.email "266378653+homeboy-ci[bot]@users.noreply.github.com"
 git commit -m "chore(ci): apply homeboy autofixes"
 
 # Use GitHub App token for push if available — pushes from a GitHub App

--- a/scripts/pr/post-inline-review.sh
+++ b/scripts/pr/post-inline-review.sh
@@ -14,7 +14,7 @@ fi
 dismiss_existing_bot_reviews() {
   local existing_reviews
   existing_reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-    --jq '[.[] | select((.user.login == "github-actions[bot]" or .user.login == "homeboy-ci-bot[bot]") and (.body | test("Homeboy found"))) | .id] | .[]' \
+    --jq '[.[] | select((.user.login == "github-actions[bot]" or .user.login == "homeboy-ci[bot]") and (.body | test("Homeboy found"))) | .id] | .[]' \
     2>/dev/null || true)
 
   for review_id in ${existing_reviews}; do

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -154,8 +154,8 @@ echo ""
 
 # --- Step 4: Configure git identity ---
 
-git config user.name "homeboy-ci-bot[bot]"
-git config user.email "266378653+homeboy-ci-bot[bot]@users.noreply.github.com"
+git config user.name "homeboy-ci[bot]"
+git config user.email "266378653+homeboy-ci[bot]@users.noreply.github.com"
 
 # --- Step 5: Generate changelog from conventional commits ---
 


### PR DESCRIPTION
## Summary
- Renames all CI bot identity references from `homeboy-ci-bot[bot]` to `homeboy-ci[bot]` to match the GitHub App's actual slug (`homeboy-ci`)
- The app was originally created as `homeboy-ci-bot` but renamed to `homeboy-ci` to avoid the redundant `homeboy-ci-bot[bot]` display name

## Changes
- `apply-autofix-commit.sh`: commit author + actor loop guard
- `prepare-autofix-branch.sh`: commit author + actor loop guard  
- `run-release.sh`: commit author
- `post-inline-review.sh`: dismissal pattern matches both old and new bot names