### PR TITLE
fix: aggregate Cargo test results instead of taking last line

### DIFF
--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -240,9 +240,31 @@ for CMD in "${CMD_ARRAY[@]}"; do
       SECTION_BODY+="- Cargo: ${CARGO_ERRORS} error(s), ${CARGO_WARNINGS} warning(s)"$'\n'
     fi
 
-    CARGO_TEST_SUMMARY=$(grep -oE "test result: .*\. [0-9]+ passed" "${LOG_FILE}" | tail -1 || true)
-    if [ -n "${CARGO_TEST_SUMMARY}" ]; then
-      SECTION_BODY+="- ${CARGO_TEST_SUMMARY}"$'\n'
+    # Aggregate all Cargo "test result:" lines (unit + integration + doc-tests).
+    # Cargo emits one line per test binary; the last is often doc-tests with
+    # 0 passed, so we aggregate instead of taking tail -1.
+    CARGO_TEST_LINES=$(grep -E "^test result:" "${LOG_FILE}" 2>/dev/null || true)
+    if [ -n "${CARGO_TEST_LINES}" ]; then
+      CARGO_TOTAL_PASSED=$(echo "${CARGO_TEST_LINES}" | grep -oP '\d+ passed' | awk '{s+=$1} END {print s+0}')
+      CARGO_TOTAL_FAILED=$(echo "${CARGO_TEST_LINES}" | grep -oP '\d+ failed' | awk '{s+=$1} END {print s+0}')
+      CARGO_TOTAL_IGNORED=$(echo "${CARGO_TEST_LINES}" | grep -oP '\d+ ignored' | awk '{s+=$1} END {print s+0}')
+      if [ "${CARGO_TOTAL_PASSED}" -gt 0 ] || [ "${CARGO_TOTAL_FAILED}" -gt 0 ]; then
+        CARGO_STATUS="ok"
+        if [ "${CARGO_TOTAL_FAILED}" -gt 0 ]; then
+          CARGO_STATUS="FAILED"
+        fi
+        SECTION_BODY+="- test result: ${CARGO_STATUS}. ${CARGO_TOTAL_PASSED} passed; ${CARGO_TOTAL_FAILED} failed; ${CARGO_TOTAL_IGNORED} ignored"$'\n'
+      fi
+    fi
+
+    # PHPUnit test results: "OK (N tests, N assertions)" or
+    # "Tests: N, Assertions: N, Failures: N, Errors: N, Skipped: N."
+    PHPUNIT_OK=$(grep -oP "OK \(\d+ tests?, \d+ assertions?\)" "${LOG_FILE}" | tail -1 || true)
+    PHPUNIT_SUMMARY=$(grep -oP "Tests: \d+.*" "${LOG_FILE}" | tail -1 || true)
+    if [ -n "${PHPUNIT_OK}" ]; then
+      SECTION_BODY+="- ${PHPUNIT_OK}"$'\n'
+    elif [ -n "${PHPUNIT_SUMMARY}" ]; then
+      SECTION_BODY+="- ${PHPUNIT_SUMMARY}"$'\n'
     fi
   fi
 


### PR DESCRIPTION
## Summary

- **Bug**: PR comments showed `test result: ok. 0 passed` because the grep took `tail -1` of Cargo's `test result:` lines — the last binary is always doc-tests with 0 passed
- **Fix**: Aggregate all `test result:` lines (same approach as `parse-test-results.sh` in homeboy-extensions) for correct totals (e.g. 900 passed across unit + integration + doc-tests)
- **Bonus**: Added PHPUnit result parsing (`OK (N tests, N assertions)` and `Tests: N, ...Failures: N.`) for WordPress projects

## Before
```
:white_check_mark: **test**
- test result: ok. 0 passed
```

## After
```
:white_check_mark: **test**
- test result: ok. 900 passed; 0 failed; 16 ignored
```