### PR TITLE
fix: strip PR references and scope tags from changelog entries

### DIFF
--- a/scripts/release/generate-changelog-from-commits.sh
+++ b/scripts/release/generate-changelog-from-commits.sh
@@ -110,12 +110,11 @@ while IFS= read -r line; do
       continue
     fi
 
-    # Build the entry message (include scope if present)
-    if [ -n "${SCOPE}" ]; then
-      ENTRY="${MESSAGE} (${SCOPE})"
-    else
-      ENTRY="${MESSAGE}"
-    fi
+    # Clean the message for changelog: strip trailing PR/issue refs like (#123)
+    CLEAN_MSG="$(echo "${MESSAGE}" | sed -E 's/ *\(#[0-9]+\) *$//')"
+
+    # Use the cleaned message as-is (scope is for categorization, not display)
+    ENTRY="${CLEAN_MSG}"
 
     # Accumulate entries by type
     if [ -z "${TYPE_ENTRIES[${CHANGELOG_TYPE}]:-}" ]; then


### PR DESCRIPTION
## Summary

- Strips trailing PR/issue references like `(#577)` from changelog entries
- Drops the conventional commit scope suffix like `(audit)` — scope is for categorization, not display

## Before
```
- improve test coverage precision (#577) (audit)
- add server health metrics (#575) (fleet)
```

## After
```
- improve test coverage precision
- add server health metrics
```