### PR TITLE
fix: scope baseline update to changed files in autofix

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -82,12 +82,20 @@ for FIX_CMD in "${FIX_ARRAY[@]}"; do
   fi
 done
 
-# Update baseline so it stays current when this commit merges to main.
-# Full (unscoped) audit ensures the baseline reflects the entire codebase,
-# not just changed files. Tolerate failure — baseline update is best-effort.
+# Update baseline for changed files so it stays current when this commit merges.
+# Uses --changed-since to scope the update to PR files only, preventing
+# CI/local environment parity from causing baseline churn on untouched files.
+# Falls back to full baseline if HOMEBOY_CHANGED_SINCE is not set.
 echo "Updating audit baseline..."
 set +e
-homeboy audit "${COMP_ID}" --baseline --path "${WORKSPACE}"
+BASELINE_CMD="homeboy audit ${COMP_ID} --baseline --path ${WORKSPACE}"
+if [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+  BASELINE_CMD="${BASELINE_CMD} --changed-since ${HOMEBOY_CHANGED_SINCE}"
+  echo "Scoped baseline update (--changed-since ${HOMEBOY_CHANGED_SINCE})"
+else
+  echo "Full baseline update (no --changed-since available)"
+fi
+eval "${BASELINE_CMD}"
 BASELINE_EXIT=$?
 set -e
 if [ "${BASELINE_EXIT}" -ne 0 ]; then


### PR DESCRIPTION
## Summary

Passes `--changed-since` to `homeboy audit --baseline` during the CI autofix step so only fingerprints for PR-changed files are updated. This prevents the full baseline regeneration that was causing massive `homeboy.json` diffs and merge conflicts on every PR.

## Changes

- Updated `apply-autofix-commit.sh` to use `HOMEBOY_CHANGED_SINCE` (already set by `determine-pr-base-ref.sh`) when running the baseline update
- Falls back to full baseline if `HOMEBOY_CHANGED_SINCE` is not available (non-PR contexts)

## Depends on

- Extra-Chill/homeboy#590 (adds `save_scoped()` / `save_baseline_scoped()` to homeboy core)