### PR TITLE
fix: scope autofix commit count to PR branch only

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -9,7 +9,16 @@ if ! [[ "${AUTOFIX_MAX_COMMITS}" =~ ^[0-9]+$ ]]; then
   AUTOFIX_MAX_COMMITS=2
 fi
 
-AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep '^chore(ci): apply homeboy autofixes$' | wc -l | xargs)
+# Count autofix commits on this branch only (not full repo history).
+# HOMEBOY_CHANGED_SINCE holds the merge base ref when set by the action.
+# Fall back to origin/main..HEAD if not set, then full log as last resort.
+if [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
+  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep '^chore(ci): apply homeboy autofixes$' "${HOMEBOY_CHANGED_SINCE}..HEAD" 2>/dev/null | wc -l | xargs)
+elif [ -n "${GITHUB_BASE_REF:-}" ]; then
+  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep '^chore(ci): apply homeboy autofixes$' "origin/${GITHUB_BASE_REF}..HEAD" 2>/dev/null | wc -l | xargs)
+else
+  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep '^chore(ci): apply homeboy autofixes$' | wc -l | xargs)
+fi
 if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
   echo "Skipping autofix: reached max autofix commits (${AUTOFIX_COMMIT_COUNT}/${AUTOFIX_MAX_COMMITS})"
   echo "committed=false" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

The `autofix-max-commits` guard searched the full git history for autofix commit messages, so commits merged from older PRs inflated the count and exhausted the budget prematurely.

Now scopes the count to the current PR branch only using `HOMEBOY_CHANGED_SINCE` (merge base ref) or `GITHUB_BASE_REF` as fallback.

## Root Cause

```bash
# Before: searches full history — old merged autofix commits count
git log --oneline --grep '^chore(ci): apply homeboy autofixes$'

# After: only counts commits since PR diverged from base
git log --oneline --grep '...' "${HOMEBOY_CHANGED_SINCE}..HEAD"
```

This was contributing to autofix failures where the budget showed 2/2 after only 1 actual autofix on the current PR.