### PR TITLE
refactor: consume structured JSON instead of scraping logs

### DIFF
--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -50,6 +50,35 @@ for CMD in "${CMD_ARRAY[@]}"; do
   set -e
   echo "::endgroup::"
 
+  # Extract structured JSON from the log output.
+  # Homeboy commands embed JSON objects in their text output. The first
+  # top-level JSON object with a "success" key is the output envelope.
+  # Extract it into a .json file so downstream scripts can read structured
+  # data instead of scraping logs with regex.
+  python3 -c "
+import json, sys
+text = open(sys.argv[1]).read()
+# Strip GitHub Actions timestamp prefixes if present
+lines = []
+for line in text.split('\n'):
+    if ' Z ' in line:
+        line = line.split(' Z ', 1)[-1]
+    lines.append(line)
+text = '\n'.join(lines)
+decoder = json.JSONDecoder()
+for i, c in enumerate(text):
+    if c == '{':
+        try:
+            obj, _ = decoder.raw_decode(text, i)
+            if isinstance(obj, dict) and 'success' in obj:
+                json.dump(obj, open(sys.argv[2], 'w'), indent=2)
+                sys.exit(0)
+        except (json.JSONDecodeError, ValueError):
+            pass
+# No JSON envelope found — write a minimal status-only file
+json.dump({'success': sys.argv[3] == '0', 'data': {}}, open(sys.argv[2], 'w'))
+" "${HOMEBOY_OUTPUT_DIR}/${CMD}.log" "${HOMEBOY_OUTPUT_DIR}/${CMD}.json" "${CMD_EXIT}" 2>/dev/null || true
+
   if [ "${CMD_EXIT}" -eq 0 ]; then
     echo "::notice::homeboy ${CMD}: PASSED"
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${CMD}" '. + {($cmd): "pass"}')

--- a/scripts/digest/build-failure-digest.py
+++ b/scripts/digest/build-failure-digest.py
@@ -136,6 +136,148 @@ def classify_autofixability(
     }
 
 
+def read_json(path: str) -> dict[str, Any] | None:
+    """Read a JSON file, returning None if missing or invalid."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def build_lint_digest_from_json(payload: dict[str, Any]) -> dict[str, Any]:
+    """Build lint digest from structured JSON output."""
+    data = payload.get("data", {})
+    error = payload.get("error", {})
+
+    return {
+        "lint_summary": str(data.get("summary", "")),
+        "phpcs_summary": str(data.get("phpcs_summary", "")),
+        "phpstan_summary": str(data.get("phpstan_summary", "")),
+        "build_failed": str(data.get("build_failed", "")),
+        "error_code": str(error.get("code", "")),
+        "error_message": str(error.get("message", "")),
+        "error_field": str(error.get("details", {}).get("field", "")),
+        "error_hint": "",
+        "top_violations": [str(v) for v in data.get("top_violations", [])][:10],
+        "raw_excerpt": [],
+    }
+
+
+def build_test_digest_from_json(payload: dict[str, Any]) -> dict[str, Any]:
+    """Build test digest from structured JSON output."""
+    data = payload.get("data", {})
+    test_counts = data.get("test_counts", {})
+    failed_tests = data.get("failed_tests", [])
+
+    top_failed = []
+    for t in failed_tests[:10]:
+        if isinstance(t, dict):
+            top_failed.append({
+                "name": str(t.get("name", "")),
+                "detail": str(t.get("detail", t.get("message", ""))),
+                "location": str(t.get("location", t.get("file", ""))),
+            })
+        else:
+            top_failed.append({"name": str(t), "detail": "", "location": ""})
+
+    failed_count = int(test_counts.get("failed", 0)) + int(test_counts.get("errors", 0))
+    if not failed_count:
+        failed_count = len(top_failed)
+
+    return {
+        "failed_tests_count": failed_count,
+        "top_failed_tests": top_failed,
+        "raw_excerpt": [],
+    }
+
+
+def build_audit_digest_from_json(payload: dict[str, Any]) -> dict[str, Any]:
+    """Build audit digest from structured JSON output.
+
+    The JSON envelope has the same structure that extract_audit_digest()
+    scraped from logs — baseline_comparison, summary, findings, conventions.
+    """
+    data = payload.get("data", {})
+    baseline = data.get("baseline_comparison", {}) if isinstance(data, dict) else {}
+    summary = data.get("summary", {}) if isinstance(data, dict) else {}
+    new_items = baseline.get("new_items", []) if isinstance(baseline, dict) else []
+    if not isinstance(new_items, list):
+        new_items = []
+
+    findings = data.get("findings", []) if isinstance(data, dict) else []
+    if not isinstance(findings, list):
+        findings = []
+
+    conventions = data.get("conventions", []) if isinstance(data, dict) else []
+    if not isinstance(conventions, list):
+        conventions = []
+
+    outlier_items: list[dict[str, Any]] = []
+    for conv in conventions:
+        if not isinstance(conv, dict):
+            continue
+        context_label = str(
+            conv.get("context_label")
+            or conv.get("name")
+            or conv.get("rule")
+            or conv.get("pattern")
+            or "unknown"
+        )
+        outliers = conv.get("outliers", [])
+        if not isinstance(outliers, list):
+            continue
+        for outlier in outliers:
+            if not isinstance(outlier, dict):
+                continue
+            item = dict(outlier)
+            item.setdefault("context_label", context_label)
+            outlier_items.append(item)
+
+    severity_counts: dict[str, int] = {}
+    top_findings: list[dict[str, str]] = []
+    new_findings: list[dict[str, str]] = []
+
+    for item in new_items:
+        if not isinstance(item, dict):
+            continue
+        new_findings.append({
+            "context": str(item.get("context_label") or item.get("file") or "unknown"),
+            "message": str(item.get("description") or item.get("message") or "(new finding)"),
+            "fingerprint": str(item.get("fingerprint") or ""),
+        })
+
+    def normalize_file(raw: Any) -> str:
+        if isinstance(raw, dict):
+            return str(raw.get("path") or raw.get("file") or "unknown")
+        return str(raw or "unknown")
+
+    for item in findings + outlier_items:
+        if not isinstance(item, dict):
+            continue
+        severity = str(item.get("severity") or item.get("level") or "unknown").lower()
+        severity_counts[severity] = severity_counts.get(severity, 0) + 1
+        top_findings.append({
+            "file": normalize_file(item.get("file") or item.get("path") or item.get("context_label")),
+            "rule": str(item.get("rule") or item.get("kind") or item.get("category") or "outlier"),
+            "message": str(item.get("description") or item.get("message") or "(outlier)"),
+            "suggested_fix": str(item.get("suggested_fix") or item.get("suggestion") or ""),
+        })
+
+    return {
+        "drift_increased": bool(baseline.get("drift_increased", False)),
+        "new_findings_count": len(new_findings),
+        "new_findings": new_findings[:100],
+        "alignment_score": summary.get("alignment_score") if isinstance(summary, dict) else None,
+        "outliers_found": summary.get("outliers_found") if isinstance(summary, dict) else None,
+        "parsed_outlier_items": len(outlier_items),
+        "severity_counts": severity_counts,
+        "top_findings": top_findings[:500],
+        "raw_excerpt": [],
+    }
+
+
 def write_json(path: str, payload: dict[str, Any]) -> None:
     with open(path, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
@@ -226,28 +368,53 @@ def main() -> int:
     test_log = read_text(os.path.join(output_dir, "test.log"))
     audit_log = read_text(os.path.join(output_dir, "audit.log"))
 
-    lint_digest = extract_lint_digest(lint_log) if results.get("lint") == "fail" else {
-        "lint_summary": "",
-        "phpcs_summary": "",
-        "phpstan_summary": "",
-        "build_failed": "",
-        "top_violations": [],
-    }
+    # Structured JSON files extracted from homeboy output by run-homeboy-commands.sh.
+    # These are preferred over log scraping — only fall back to parsers when missing.
+    lint_json = read_json(os.path.join(output_dir, "lint.json"))
+    test_json = read_json(os.path.join(output_dir, "test.json"))
+    audit_json = read_json(os.path.join(output_dir, "audit.json"))
 
-    test_digest = extract_test_failures(test_log) if results.get("test") == "fail" else {
-        "failed_tests_count": 0,
-        "top_failed_tests": [],
-    }
-    audit_digest = extract_audit_digest(
-        audit_log,
-        extract_json_candidates,
-        normalize_log_text,
-    ) if results.get("audit") == "fail" else {
-        "drift_increased": False,
-        "outliers_found": None,
-        "severity_counts": {},
-        "top_findings": [],
-    }
+    if results.get("lint") == "fail":
+        if lint_json and lint_json.get("data"):
+            lint_digest = build_lint_digest_from_json(lint_json)
+        else:
+            lint_digest = extract_lint_digest(lint_log)
+    else:
+        lint_digest = {
+            "lint_summary": "",
+            "phpcs_summary": "",
+            "phpstan_summary": "",
+            "build_failed": "",
+            "top_violations": [],
+        }
+
+    if results.get("test") == "fail":
+        if test_json and test_json.get("data"):
+            test_digest = build_test_digest_from_json(test_json)
+        else:
+            test_digest = extract_test_failures(test_log)
+    else:
+        test_digest = {
+            "failed_tests_count": 0,
+            "top_failed_tests": [],
+        }
+
+    if results.get("audit") == "fail":
+        if audit_json and audit_json.get("data"):
+            audit_digest = build_audit_digest_from_json(audit_json)
+        else:
+            audit_digest = extract_audit_digest(
+                audit_log,
+                extract_json_candidates,
+                normalize_log_text,
+            )
+    else:
+        audit_digest = {
+            "drift_increased": False,
+            "outliers_found": None,
+            "severity_counts": {},
+            "top_findings": [],
+        }
     autofixability = classify_autofixability(
         results,
         commands_csv,

--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -35,24 +35,48 @@ HOMEBOY_EXTENSION_ID="${HOMEBOY_EXTENSION_ID:-auto}"
 HOMEBOY_ACTION_REF="${HOMEBOY_ACTION_REF:-unknown}"
 HOMEBOY_ACTION_REPOSITORY="${HOMEBOY_ACTION_REPOSITORY:-unknown}"
 
+AUDIT_JSON="${OUTPUT_DIR}/audit.json"
 AUDIT_LOG="${OUTPUT_DIR}/audit.log"
 
-# --- Step 1: Extract audit JSON from log ---
+# --- Step 1: Read audit findings from structured JSON ---
 
-if [ ! -f "${AUDIT_LOG}" ]; then
-  echo "No audit log found at ${AUDIT_LOG} — falling back to generic issue filing"
-  exit 1
+# Prefer the pre-extracted .json file (produced by run-homeboy-commands.sh).
+# Fall back to scraping the .log file for backward compatibility.
+if [ -f "${AUDIT_JSON}" ] && [ -s "${AUDIT_JSON}" ]; then
+  FINDINGS_JSON=$(python3 -c "
+import json, sys
+payload = json.load(open(sys.argv[1]))
+data = payload.get('data', {})
+findings = data.get('findings', [])
+summary = data.get('summary', {})
+component = data.get('component_id', '')
+groups = {}
+for f in findings:
+    kind = f.get('kind', 'unknown')
+    groups.setdefault(kind, []).append(f)
+print(json.dumps({
+    'groups': {k: v for k, v in sorted(groups.items(), key=lambda x: -len(x[1]))},
+    'summary': summary,
+    'component_id': component,
+    'total_findings': len(findings)
+}))
+" "${AUDIT_JSON}" 2>/dev/null) || {
+    echo "Failed to read audit.json — falling back to log scraping"
+    FINDINGS_JSON=""
+  }
 fi
 
-# Extract the audit JSON payload from the log. The log contains the full
-# homeboy JSON output ({"success":true,"data":{...}}) mixed with stderr.
-# Use python to reliably extract it.
-FINDINGS_JSON=$(AUDIT_LOG_PATH="${AUDIT_LOG}" python3 -c "
-import json, os, sys
+# Fall back to log scraping if JSON file is missing or failed
+if [ -z "${FINDINGS_JSON:-}" ]; then
+  if [ ! -f "${AUDIT_LOG}" ]; then
+    echo "No audit log found at ${AUDIT_LOG} — falling back to generic issue filing"
+    exit 1
+  fi
 
-text = open(os.environ['AUDIT_LOG_PATH'], 'r', errors='replace').read()
+  FINDINGS_JSON=$(python3 -c "
+import json, sys
 
-# Strip GitHub Actions timestamp prefixes
+text = open(sys.argv[1], 'r', errors='replace').read()
 lines = []
 for line in text.splitlines():
     if 'Z ' in line:
@@ -61,7 +85,6 @@ for line in text.splitlines():
         lines.append(line)
 text = '\n'.join(lines)
 
-# Find the audit JSON payload
 decoder = json.JSONDecoder()
 i = 0
 payload = None
@@ -86,25 +109,21 @@ if not payload:
 findings = payload.get('data', {}).get('findings', [])
 summary = payload.get('data', {}).get('summary', {})
 component = payload.get('data', {}).get('component_id', '')
-
-# Group findings by kind
 groups = {}
 for f in findings:
     kind = f.get('kind', 'unknown')
-    if kind not in groups:
-        groups[kind] = []
-    groups[kind].append(f)
-
+    groups.setdefault(kind, []).append(f)
 print(json.dumps({
     'groups': {k: v for k, v in sorted(groups.items(), key=lambda x: -len(x[1]))},
     'summary': summary,
     'component_id': component,
     'total_findings': len(findings)
 }))
-" 2>/dev/null) || {
-  echo "Failed to parse audit findings from log — falling back to generic issue filing"
-  exit 1
-}
+" "${AUDIT_LOG}" 2>/dev/null) || {
+    echo "Failed to parse audit findings from log — falling back to generic issue filing"
+    exit 1
+  }
+fi
 
 TOTAL_FINDINGS=$(echo "${FINDINGS_JSON}" | jq -r '.total_findings')
 COMPONENT_FROM_AUDIT=$(echo "${FINDINGS_JSON}" | jq -r '.component_id // empty')


### PR DESCRIPTION
## Summary

Addresses #57 — the action now reads structured JSON output from homeboy commands instead of regex-scraping log files.

## The Problem

The action had **three independent copies** of the same JSON-from-log extraction pattern:

1. `digest/build-failure-digest.py` → `extract_json_candidates()` + `normalize_log_text()`
2. `digest/render-audit-summary.py` → duplicate of the above
3. `issues/auto-file-categorized-issues.sh` → inline Python doing the same `JSONDecoder().raw_decode()` loop

All three stripped GitHub Actions timestamp prefixes, scanned for `{` characters, and attempted JSON parsing to find homeboy's output envelope embedded in mixed text/JSON log streams.

## The Fix

**Single change point:** `run-homeboy-commands.sh` now extracts the JSON output envelope from each command's `.log` file into a `.json` file after execution:

```
homeboy audit → audit.log (text, for CI display) + audit.json (structured data)
homeboy lint  → lint.log  + lint.json
homeboy test  → test.log  + test.json
```

All downstream consumers read `.json` first, fall back to log scraping when missing:

- **`build-failure-digest.py`**: New `read_json()` + `build_{lint,test,audit}_digest_from_json()` functions
- **`auto-file-categorized-issues.sh`**: Reads `audit.json` directly instead of inline Python scraping
- **Log scraping preserved as fallback** for backward compatibility with older homeboy versions

## What's Next

- #58: Eliminate remaining grep/sed log-scraping in `post-pr-comment.sh` (the fallback paths in digest/issue scripts)  
- Future: Add native `--json` flag to `homeboy lint` so the extraction step becomes unnecessary