### PR TITLE
feat: add binary-path input for build-once CI patterns

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,11 @@ inputs:
     required: false
     default: 'latest'
   source:
-    description: 'Path to build homeboy from source (e.g. "."). Falls back to release binary on build failure.'
+    description: 'Path to build homeboy from source (e.g. "."). Falls back to release binary on build failure. Ignored when binary-path is set.'
+    required: false
+    default: ''
+  binary-path:
+    description: 'Path to a pre-built homeboy binary. Skips source build and release download. Use with build-once CI patterns where a prior job uploads the binary as an artifact.'
     required: false
     default: ''
   rust-toolchain:
@@ -157,14 +161,28 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - name: Install pre-built binary
+      id: install-prebuilt
+      if: inputs.binary-path != ''
+      shell: bash
+      run: |
+        BINARY="${{ inputs.binary-path }}"
+        if [ ! -f "${BINARY}" ]; then
+          echo "::error::binary-path '${BINARY}' does not exist"
+          exit 1
+        fi
+        chmod +x "${BINARY}"
+        sudo cp "${BINARY}" /usr/local/bin/homeboy
+        echo "Installed pre-built binary: $(homeboy --version)"
+
     - name: Install Rust toolchain (source build)
-      if: inputs.source != ''
+      if: inputs.binary-path == '' && inputs.source != ''
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.rust-toolchain }}
 
     - name: Cache cargo (source build)
-      if: inputs.source != ''
+      if: inputs.binary-path == '' && inputs.source != ''
       uses: actions/cache@v4
       with:
         path: |
@@ -176,7 +194,7 @@ runs:
 
     - name: Build from source
       id: source-build
-      if: inputs.source != ''
+      if: inputs.binary-path == '' && inputs.source != ''
       shell: bash
       env:
         SOURCE_PATH: ${{ inputs.source }}
@@ -184,7 +202,7 @@ runs:
 
     - name: Resolve Homeboy version
       id: resolve-version
-      if: inputs.source == '' || steps.source-build.outputs.built != 'true'
+      if: inputs.binary-path == '' && (inputs.source == '' || steps.source-build.outputs.built != 'true')
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -193,7 +211,7 @@ runs:
 
     - name: Cache Homeboy
       id: cache-homeboy
-      if: inputs.source == '' || steps.source-build.outputs.built != 'true'
+      if: inputs.binary-path == '' && (inputs.source == '' || steps.source-build.outputs.built != 'true')
       uses: actions/cache@v4
       with:
         path: |
@@ -202,7 +220,7 @@ runs:
         key: homeboy-${{ steps.resolve-version.outputs.resolved-version }}-${{ inputs.extension }}-${{ runner.os }}-${{ runner.arch }}
 
     - name: Install Homeboy
-      if: (inputs.source == '' || steps.source-build.outputs.built != 'true') && steps.cache-homeboy.outputs.cache-hit != 'true'
+      if: inputs.binary-path == '' && (inputs.source == '' || steps.source-build.outputs.built != 'true') && steps.cache-homeboy.outputs.cache-hit != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -213,12 +231,13 @@ runs:
       id: resolve-binary
       shell: bash
       env:
+        HAS_BINARY_PATH_INPUT: ${{ inputs.binary-path }}
         HAS_SOURCE_INPUT: ${{ inputs.source }}
         SOURCE_BUILT: ${{ steps.source-build.outputs.built }}
       run: bash ${{ github.action_path }}/scripts/setup/resolve-binary-source.sh
 
     - name: Install extension
-      if: inputs.extension != '' && (steps.cache-homeboy.outputs.cache-hit != 'true' || steps.source-build.outputs.built == 'true')
+      if: inputs.extension != '' && (inputs.binary-path != '' || steps.cache-homeboy.outputs.cache-hit != 'true' || steps.source-build.outputs.built == 'true')
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}

--- a/scripts/setup/resolve-binary-source.sh
+++ b/scripts/setup/resolve-binary-source.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
-if [ -n "${HAS_SOURCE_INPUT}" ] && [ "${SOURCE_BUILT:-}" = "true" ]; then
+if [ -n "${HAS_BINARY_PATH_INPUT:-}" ]; then
+  echo "binary-source=prebuilt" >> "${GITHUB_OUTPUT}"
+elif [ -n "${HAS_SOURCE_INPUT}" ] && [ "${SOURCE_BUILT:-}" = "true" ]; then
   echo "binary-source=source" >> "${GITHUB_OUTPUT}"
 elif [ -n "${HAS_SOURCE_INPUT}" ]; then
   echo "binary-source=fallback" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

- Adds `binary-path` input that accepts a path to a pre-built homeboy binary
- When set, skips Rust toolchain install, cargo cache, source build, version resolution, and release download — just copies the binary to `/usr/local/bin`
- Reports `binary-source=prebuilt` in the output

## Why

The homeboy CI pipeline runs 3 serial jobs (lint → test → audit), each using `source: '.'` which triggers a full `cargo build --release` (~2-3 min). That's **6-9 min of redundant compilation**.

With `binary-path`, a single build job compiles once, uploads the binary as an artifact, and all downstream jobs download + use it directly.

## Usage

```yaml
# Build once
build:
  runs-on: ubuntu-latest
  steps:
    - uses: actions/checkout@v4
    - uses: dtolnay/rust-toolchain@stable
    - run: cargo build --release
    - uses: actions/upload-artifact@v4
      with:
        name: homeboy-binary
        path: target/release/homeboy

# Use pre-built binary
lint:
  needs: [build]
  steps:
    - uses: actions/checkout@v4
    - uses: actions/download-artifact@v4
      with:
        name: homeboy-binary
        path: .homeboy-bin
    - uses: Extra-Chill/homeboy-action@v1
      with:
        binary-path: .homeboy-bin/homeboy
        commands: lint
```

## Backward Compatible

- All existing inputs work exactly as before when `binary-path` is not set
- `source` is ignored when `binary-path` is set (documented in description)