### PR TITLE
fix: use app token for PR comments, issues, and autofix PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -334,6 +334,7 @@ runs:
       if: github.event_name != 'pull_request' && steps.autofix-prepare-nonpr.outputs.committed == 'true' && steps.rerun-commands.outputs.results != '' && !contains(steps.rerun-commands.outputs.results, '"fail"')
       shell: bash
       env:
+        GH_TOKEN: ${{ inputs.app-token || github.token }}
         COMPONENT_NAME: ${{ inputs.component }}
         AUTOFIX_BRANCH: ${{ steps.autofix-prepare-nonpr.outputs.autofix-branch }}
         RESULTS: ${{ steps.rerun-commands.outputs.results }}
@@ -373,7 +374,7 @@ runs:
       if: contains(inputs.commands, 'release') && github.event_name != 'pull_request'
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.app-token || github.token }}
         RELEASE_DRY_RUN: ${{ inputs.release-dry-run }}
         RELEASE_BRANCH: ${{ inputs.release-branch }}
         COMPONENT_NAME: ${{ inputs.component }}
@@ -383,7 +384,7 @@ runs:
       if: always() && github.event_name == 'pull_request'
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.app-token || github.token }}
         COMMANDS: ${{ inputs.commands }}
         COMPONENT_NAME: ${{ inputs.component }}
         RESULTS: ${{ steps.select-results.outputs.results }}
@@ -403,7 +404,7 @@ runs:
       continue-on-error: true
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.app-token || github.token }}
         RESULTS: ${{ steps.select-results.outputs.results }}
         COMMANDS: ${{ inputs.commands }}
         COMPONENT_NAME: ${{ inputs.component }}
@@ -416,7 +417,7 @@ runs:
       if: always() && inputs.auto-issue == 'true' && github.event_name != 'pull_request' && steps.select-results.outputs.results != '' && contains(steps.select-results.outputs.results, '"fail"') && steps.autofix-open-pr.outputs.created != 'true' && steps.categorized-issues.outcome != 'success'
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.app-token || github.token }}
         RESULTS: ${{ steps.select-results.outputs.results }}
         COMMANDS: ${{ inputs.commands }}
         COMPONENT_NAME: ${{ inputs.component }}


### PR DESCRIPTION
## Summary

- PR comments, auto-filed issues, autofix PRs, and releases now use the `app-token` when provided
- Posts as **homeboy-ci[bot]** instead of **github-actions[bot]**
- Falls back to `github.token` when `app-token` is not set (backward compatible)

## Before

All GitHub API interactions used `github.token` → everything posted as `github-actions[bot]`, which is generic and makes it hard to distinguish homeboy activity from other CI actions.

## After

When `app-token` is provided (via `actions/create-github-app-token`):
- PR comments → homeboy-ci[bot]
- Auto-filed issues → homeboy-ci[bot]
- Autofix PRs → homeboy-ci[bot]
- Release operations → homeboy-ci[bot]

Setup steps (version resolution, binary download, extension install) still use `github.token` since they don't create visible artifacts.