### PR TITLE
fix(release): pull latest before running release

### DIFF
--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -48,6 +48,13 @@ if [ "${CURRENT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
   exit 0
 fi
 
+# --- Step 2b: Sync with remote ---
+# The quality gate runs in separate jobs that may push autofix commits
+# or new PRs may merge while the pipeline is in flight. Pull to ensure
+# we release from the actual HEAD of the branch.
+
+git pull --ff-only origin "${RELEASE_BRANCH}" 2>/dev/null || true
+
 # --- Step 3: Check for releasable commits via homeboy ---
 
 DRY_RUN_FLAGS="--dry-run --skip-checks --skip-publish"


### PR DESCRIPTION
## Summary

Adds `git pull --ff-only` before the release dry-run check in `run-release.sh`.

## Problem

The release workflow checks out `main` at the start of the run. By the time the Prepare Release step runs (after build → lint → test → audit), main may have advanced:
- Autofix commits pushed during the quality gate
- PRs merged while the pipeline was in flight

`homeboy release` correctly rejects the stale checkout: `Local branch is 1 commit(s) behind remote`. But this fails the entire release run unnecessarily.

## Fix

Fast-forward pull before running the release command. If the pull fails (diverged history, which shouldn't happen on main), it falls through and homeboy's own remote_sync check handles the error.