### PR TITLE
feat: auto-close audit issues when findings reach zero

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -400,7 +400,7 @@ runs:
 
     - name: Auto-file categorized audit issues
       id: categorized-issues
-      if: always() && inputs.auto-issue == 'true' && github.event_name != 'pull_request' && steps.select-results.outputs.results != '' && contains(steps.select-results.outputs.results, '"fail"') && contains(inputs.commands, 'audit') && steps.autofix-open-pr.outputs.created != 'true'
+      if: always() && inputs.auto-issue == 'true' && github.event_name != 'pull_request' && steps.select-results.outputs.results != '' && contains(inputs.commands, 'audit') && steps.autofix-open-pr.outputs.created != 'true'
       continue-on-error: true
       shell: bash
       env:

--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -131,8 +131,73 @@ if [ -n "${COMPONENT_FROM_AUDIT}" ]; then
   COMP_ID="${COMPONENT_FROM_AUDIT}"
 fi
 
+# --- Step 1b: Close resolved issues ---
+#
+# If a category has zero findings now but has an open issue, close it.
+# This runs even when TOTAL_FINDINGS is 0 (all categories resolved).
+
+EXISTING_ISSUES_FOR_CLOSE=$(gh api "repos/${REPO}/issues?state=open&labels=audit&per_page=100" \
+  --jq '[.[] | {number: .number, title: .title}]' 2>/dev/null || echo "[]")
+
+# Extract current finding kinds (empty if no findings)
+CURRENT_KINDS=""
+if [ "${TOTAL_FINDINGS}" != "0" ] && [ "${TOTAL_FINDINGS}" != "null" ]; then
+  CURRENT_KINDS=$(echo "${FINDINGS_JSON}" | jq -r '.groups | keys[]' 2>/dev/null || true)
+fi
+
+ISSUES_CLOSED=0
+
+# Check each existing audit issue — if its category is no longer in findings, close it
+while IFS= read -r ISSUE_LINE; do
+  [ -z "${ISSUE_LINE}" ] && continue
+
+  ISSUE_NUM=$(echo "${ISSUE_LINE}" | jq -r '.number')
+  ISSUE_TITLE=$(echo "${ISSUE_LINE}" | jq -r '.title')
+
+  # Extract the kind from the issue title: "audit: {kind_label} in {component} ({count})"
+  # Match our component only
+  if ! echo "${ISSUE_TITLE}" | grep -q "in ${COMP_ID}"; then
+    continue
+  fi
+
+  # Extract kind_label: everything between "audit: " and " in {component}"
+  KIND_LABEL=$(echo "${ISSUE_TITLE}" | sed -n "s/^audit: \(.*\) in ${COMP_ID}.*/\1/p")
+  [ -z "${KIND_LABEL}" ] && continue
+
+  # Convert kind_label back to kind (spaces → underscores)
+  KIND_KEY=$(echo "${KIND_LABEL}" | tr ' ' '_')
+
+  # Check if this kind still has findings
+  if echo "${CURRENT_KINDS}" | grep -qx "${KIND_KEY}" 2>/dev/null; then
+    continue  # Still has findings — will be updated below
+  fi
+
+  # No findings for this category — close the issue
+  CLOSE_COMMENT="All **${KIND_LABEL}** findings have been resolved. Closing automatically.
+
+Resolved by the [code factory pipeline](${RUN_URL}). If findings reappear, a new issue will be filed."
+
+  gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
+    --method POST \
+    --field body="${CLOSE_COMMENT}" > /dev/null 2>&1 || true
+
+  gh api "repos/${REPO}/issues/${ISSUE_NUM}" \
+    --method PATCH \
+    --field state="closed" \
+    --field state_reason="completed" > /dev/null 2>&1 || true
+
+  ISSUES_CLOSED=$((ISSUES_CLOSED + 1))
+  echo "  Closed issue #${ISSUE_NUM}: ${ISSUE_TITLE} (zero findings remaining)"
+done <<< "$(echo "${EXISTING_ISSUES_FOR_CLOSE}" | jq -c '.[]')"
+
 if [ "${TOTAL_FINDINGS}" = "0" ] || [ "${TOTAL_FINDINGS}" = "null" ]; then
-  echo "No audit findings to file issues for"
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  No audit findings to file issues for"
+  if [ "${ISSUES_CLOSED}" -gt 0 ]; then
+    echo "  Issues closed: ${ISSUES_CLOSED}"
+  fi
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   exit 0
 fi
 
@@ -285,4 +350,5 @@ echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Issues created: ${ISSUES_CREATED}"
 echo "  Issues updated: ${ISSUES_UPDATED}"
+echo "  Issues closed:  ${ISSUES_CLOSED}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

- **Auto-close resolved issues**: when a finding category drops to zero findings, the corresponding audit issue is closed with a resolution comment and `state_reason=completed`
- **Run on pass too**: relaxed `action.yml` condition so the categorized issues script runs whenever `audit` is in the commands list, not just on failure — otherwise it could never close issues
- **Title updates already worked**: the script was already updating issue titles with the latest count on each run (line 222)

## How it works

```
CI runs audit → findings JSON → script checks each open audit issue:
  - Category still in findings? → update title + body with new count
  - Category gone? → close issue with comment
  - New category? → create issue
```

## Example flow

1. `#535 audit: duplicate function in homeboy (20)` — filed when 20 findings existed
2. Core fingerprint engine lands → count drops to 6 → title updates to `(6)`
3. Autofixer resolves remaining 6 → count drops to 0 → issue auto-closes with comment: "All duplicate function findings have been resolved"

## What this enables

The code factory loop is now fully closed:
- Audit detects → issues filed → autofixer built → findings resolved → issues closed
- Zero human involvement from detection to resolution tracking