### PR TITLE
feat: enable audit --fix --write on PR autofix path

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -65,6 +65,7 @@ else
     case "${CMD}" in
       lint) FIX_ARRAY+=("lint --fix") ;;
       test) FIX_ARRAY+=("test --fix") ;;
+      audit) FIX_ARRAY+=("audit --fix --write") ;;
     esac
   done
 fi


### PR DESCRIPTION
## Summary
- Add `audit` case to command mapping in `apply-autofix-commit.sh` (line 68): `audit) FIX_ARRAY+=("audit --fix --write")`
- Previously only `lint --fix` and `test --fix` were mapped for PR autofix; audit was only available on the non-PR path (`prepare-autofix-branch.sh`)

## Context
Enables the full Code Factory autofix loop on PRs: audit findings (missing methods, imports, test stubs) now get auto-fixed alongside lint formatting issues. The `build_autofix_command` helper in `lib.sh` already handles `audit*` patterns including `--changed-since` scoping.

Safety note: audit fixes are more invasive than lint formatting (method stubs, imports, file creation). They go through the audit fixer's safety tier system (safe_auto, safe_with_checks, plan_only) and chunk verification, so only safe fixes are applied automatically.

Companion PRs:
- homeboy: test.rs sidecar wiring + audit fix_summary bridge
- homeboy-extensions: test-runner.sh sidecar support