### PR TITLE
feat: informative autofix commit messages

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -12,12 +12,13 @@ fi
 # Count autofix commits on this branch only (not full repo history).
 # HOMEBOY_CHANGED_SINCE holds the merge base ref when set by the action.
 # Fall back to origin/main..HEAD if not set, then full log as last resort.
+# Match the prefix (not full subject) so informative suffixes don't break detection.
 if [ -n "${HOMEBOY_CHANGED_SINCE:-}" ]; then
-  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep '^chore(ci): apply homeboy autofixes$' "${HOMEBOY_CHANGED_SINCE}..HEAD" 2>/dev/null | wc -l | xargs)
+  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" "${HOMEBOY_CHANGED_SINCE}..HEAD" 2>/dev/null | wc -l | xargs)
 elif [ -n "${GITHUB_BASE_REF:-}" ]; then
-  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep '^chore(ci): apply homeboy autofixes$' "origin/${GITHUB_BASE_REF}..HEAD" 2>/dev/null | wc -l | xargs)
+  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" "origin/${GITHUB_BASE_REF}..HEAD" 2>/dev/null | wc -l | xargs)
 else
-  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep '^chore(ci): apply homeboy autofixes$' | wc -l | xargs)
+  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" | wc -l | xargs)
 fi
 if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
   echo "Skipping autofix: reached max autofix commits (${AUTOFIX_COMMIT_COUNT}/${AUTOFIX_MAX_COMMITS})"
@@ -38,7 +39,7 @@ if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "h
 fi
 
 LAST_SUBJECT=$(git log -1 --pretty=%s 2>/dev/null || true)
-if [ "${LAST_SUBJECT}" = "chore(ci): apply homeboy autofixes" ]; then
+if [[ "${LAST_SUBJECT}" == "${AUTOFIX_COMMIT_PREFIX}"* ]]; then
   echo "Skipping autofix: HEAD already an autofix commit"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
@@ -144,9 +145,11 @@ for FIX_CMD in "${FIX_ARRAY[@]}"; do
   AUTOFIX_FIX_TYPES+="${BASE}"
 done
 
+COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}")"
+
 git config user.name "homeboy-ci[bot]"
 git config user.email "266378653+homeboy-ci[bot]@users.noreply.github.com"
-git commit -m "chore(ci): apply homeboy autofixes"
+git commit -m "${COMMIT_MSG}"
 
 # Use GitHub App token for push if available — pushes from a GitHub App
 # trigger workflow re-runs, while GITHUB_TOKEN pushes do not.

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -9,7 +9,7 @@ if ! [[ "${AUTOFIX_MAX_COMMITS}" =~ ^[0-9]+$ ]]; then
   AUTOFIX_MAX_COMMITS=2
 fi
 
-AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep '^chore(ci): apply homeboy autofixes$' | wc -l | xargs)
+AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" | wc -l | xargs)
 if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
   echo "Skipping non-PR autofix: reached max autofix commits (${AUTOFIX_COMMIT_COUNT}/${AUTOFIX_MAX_COMMITS})"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
@@ -121,9 +121,11 @@ for FIX_CMD in "${FIX_ARRAY[@]}"; do
   AUTOFIX_FIX_TYPES+="${BASE}"
 done
 
+COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}")"
+
 git config user.name "homeboy-ci[bot]"
 git config user.email "266378653+homeboy-ci[bot]@users.noreply.github.com"
-git commit -m "chore(ci): apply homeboy autofixes"
+git commit -m "${COMMIT_MSG}"
 
 # Use GitHub App token for push if available — pushes from a GitHub App
 # trigger workflow re-runs, while GITHUB_TOKEN pushes do not.

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -2,6 +2,29 @@
 
 set -euo pipefail
 
+# Prefix used for all autofix commits. Loop guards grep for this prefix,
+# so the subject line can vary after it (e.g. fix types, file count).
+AUTOFIX_COMMIT_PREFIX="chore(ci): homeboy autofix"
+
+# Build an informative autofix commit message.
+# Subject: chore(ci): homeboy autofix — audit, lint (7 files)
+# Body: list of changed files for traceability.
+build_autofix_commit_message() {
+  local fix_types="$1"
+  local file_count="$2"
+
+  local subject="${AUTOFIX_COMMIT_PREFIX}"
+  if [ -n "${fix_types}" ]; then
+    subject="${subject} — ${fix_types}"
+  fi
+  subject="${subject} (${file_count} files)"
+
+  local body
+  body="$(git diff --cached --name-only | sort)"
+
+  printf '%s\n\n%s\n' "${subject}" "${body}"
+}
+
 resolve_component_id() {
   if [ -n "${COMPONENT_NAME:-}" ]; then
     printf '%s\n' "${COMPONENT_NAME}"


### PR DESCRIPTION
## Summary

Autofix commits were generic and uninformative:

```
chore(ci): apply homeboy autofixes
```

Now they tell you **what ran** and **what changed**:

```
chore(ci): homeboy autofix — audit, lint (7 files)

src/MyClass.php
src/OtherClass.php
tests/MyClassTest.php
```

## Changes

| File | What |
|------|------|
| `scripts/core/lib.sh` | `AUTOFIX_COMMIT_PREFIX` constant + `build_autofix_commit_message()` helper |
| `scripts/autofix/apply-autofix-commit.sh` | Use informative message; grep prefix instead of exact match |
| `scripts/autofix/prepare-autofix-branch.sh` | Same for non-PR autofix path |

## Safety

All loop guards and duplicate detection now match the **prefix** `chore(ci): homeboy autofix` instead of an exact string. This means:
- Autofix commit count still works (grep matches `chore(ci): homeboy autofix — audit (3 files)`)
- HEAD duplicate detection still works (`[[ starts-with ]]` check)
- The em dash + fix types + file count are informational suffixes that don't break safety