### PR TITLE
refactor: route CI autofix through refactor ci

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -62,22 +62,23 @@ if [ -n "${AUTOFIX_COMMANDS:-}" ]; then
   IFS=',' read -ra FIX_ARRAY <<< "${AUTOFIX_COMMANDS}"
 else
   # Derive fix commands from the command list, but enforce canonical order:
-  # audit → lint → test. Audit produces structural changes (missing files,
-  # baselines), lint fixes style on the resulting code, test stubs come last.
-  HAS_AUDIT=false HAS_LINT=false HAS_TEST=false
+  # audit → lint → test → refactor. Refactor owns the single write phase.
+  HAS_AUDIT=false HAS_LINT=false HAS_TEST=false HAS_REFACTOR=false
   IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
   for CMD in "${CMD_ARRAY[@]}"; do
     CMD=$(echo "${CMD}" | xargs)
-    case "${CMD}" in
+    BASE_CMD=$(printf '%s' "${CMD}" | awk '{print $1}')
+    case "${BASE_CMD}" in
       audit) HAS_AUDIT=true ;;
       lint)  HAS_LINT=true ;;
       test)  HAS_TEST=true ;;
+      refactor) HAS_REFACTOR=true ;;
     esac
   done
   FIX_ARRAY=()
-  [ "${HAS_AUDIT}" = true ] && FIX_ARRAY+=("audit --fix --write")
-  [ "${HAS_LINT}" = true ]  && FIX_ARRAY+=("lint --fix")
-  [ "${HAS_TEST}" = true ]  && FIX_ARRAY+=("test --fix")
+  if [ "${HAS_REFACTOR}" = true ] || [ "${HAS_AUDIT}" = true ] || [ "${HAS_LINT}" = true ] || [ "${HAS_TEST}" = true ]; then
+    FIX_ARRAY+=("refactor ci --write")
+  fi
 fi
 
 if [ ${#FIX_ARRAY[@]} -eq 0 ]; then

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -51,23 +51,23 @@ resolve_workspace() {
   pwd
 }
 
-# Sort commands into canonical order: audit → lint → test.
-# Audit is most likely to induce changes (structural fixes), lint fixes style
-# on the resulting code, test validates the final state. Non-standard commands
-# (release, custom extension commands) are preserved at the end in their
-# original relative order.
+# Sort commands into canonical order: audit → lint → test → refactor.
+# Audit/lint/test are read-first quality gates. Refactor is the single
+# write/mutation phase when used.
 canonicalize_commands() {
   local commands="$1"
-  local audit="" lint="" test="" others=()
-  local cmd
+  local audit="" lint="" test="" refactor="" others=()
+  local cmd base_cmd
 
   IFS=',' read -ra CMD_ARRAY <<< "${commands}"
   for cmd in "${CMD_ARRAY[@]}"; do
     cmd=$(echo "${cmd}" | xargs)
-    case "${cmd}" in
+    base_cmd=$(printf '%s' "${cmd}" | awk '{print $1}')
+    case "${base_cmd}" in
       audit)   audit="audit" ;;
       lint)    lint="lint" ;;
       test)    test="test" ;;
+      refactor) refactor="${cmd}" ;;
       *)       others+=("${cmd}") ;;
     esac
   done
@@ -76,6 +76,7 @@ canonicalize_commands() {
   [ -n "${audit}" ] && result+=("${audit}")
   [ -n "${lint}" ]  && result+=("${lint}")
   [ -n "${test}" ]  && result+=("${test}")
+  [ -n "${refactor}" ]  && result+=("${refactor}")
   result+=("${others[@]+"${others[@]}"}")
 
   local IFS=','

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -54,21 +54,21 @@ assert_equals \
   "run command appends extra args"
 
 assert_equals \
-  "homeboy lint --fix data-machine --path /tmp/workspace --changed-since origin/main --format json" \
-  "$(build_autofix_command "lint --fix" "${COMPONENT}" "${WORKSPACE}")" \
-  "autofix lint keeps path and changed-since"
+  "homeboy refactor ci data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_run_command "refactor ci" "${COMPONENT}" "${WORKSPACE}")" \
+  "refactor keeps path with changed-since"
 
 assert_equals \
-  "homeboy audit --fix --write data-machine --path /tmp/workspace --changed-since origin/main --format json" \
-  "$(build_autofix_command "audit --fix --write" "${COMPONENT}" "${WORKSPACE}")" \
-  "autofix audit keeps path and changed-since"
+  "homeboy refactor ci --write data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_autofix_command "refactor ci --write" "${COMPONENT}" "${WORKSPACE}")" \
+  "autofix refactor keeps path and changed-since"
 
 # ── Unscoped autofix ──
 unset SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true
 SCOPE_MODE="full"
 assert_equals \
-  "homeboy test --fix data-machine --path /tmp/workspace" \
-  "$(build_autofix_command "test --fix" "${COMPONENT}" "${WORKSPACE}")" \
-  "autofix test keeps workspace path"
+  "homeboy refactor ci --write data-machine --path /tmp/workspace" \
+  "$(build_autofix_command "refactor ci --write" "${COMPONENT}" "${WORKSPACE}")" \
+  "autofix refactor keeps workspace path"
 
 printf 'All command builder checks passed.\n'

--- a/scripts/scope/flags.sh
+++ b/scripts/scope/flags.sh
@@ -20,7 +20,7 @@ scope_flags_for() {
   fi
 
   case "${base_cmd}" in
-    audit|lint|test)
+    audit|lint|test|refactor)
       printf '%s' "--changed-since ${SCOPE_BASE_REF}"
       ;;
     # release and other commands are never scoped


### PR DESCRIPTION
## Summary
- update command ordering to treat `refactor` as the final phase after `audit`, `lint`, and `test`
- change autofix command derivation to call `refactor ci --write` instead of stitching together per-command `--fix` invocations
- pass scope flags through to `refactor` so PR runs stay changed-only where appropriate

## Why
- keeps planner/mutation logic in `homeboy` core instead of teaching the action to compensate for missing core behavior
- makes the action a thin wrapper around the new core contract: run read-only gates, then run one final write phase
- aligns the action with the new CI shape: `audit -> lint -> test -> refactor`