### PR TITLE
fix(ci): enforce homeboy-ci identity for commits and release pushes

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -149,9 +149,15 @@ done
 
 COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}")"
 
-git config user.name "homeboy-ci[bot]"
-git config user.email "266378653+homeboy-ci[bot]@users.noreply.github.com"
-git commit -m "${COMMIT_MSG}"
+BOT_NAME="homeboy-ci[bot]"
+BOT_EMAIL="266378653+homeboy-ci[bot]@users.noreply.github.com"
+git config user.name "${BOT_NAME}"
+git config user.email "${BOT_EMAIL}"
+GIT_AUTHOR_NAME="${BOT_NAME}" \
+GIT_AUTHOR_EMAIL="${BOT_EMAIL}" \
+GIT_COMMITTER_NAME="${BOT_NAME}" \
+GIT_COMMITTER_EMAIL="${BOT_EMAIL}" \
+  git commit -m "${COMMIT_MSG}"
 
 # Use GitHub App token for push if available — pushes from a GitHub App
 # trigger workflow re-runs, while GITHUB_TOKEN pushes do not.

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -123,9 +123,15 @@ done
 
 COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}")"
 
-git config user.name "homeboy-ci[bot]"
-git config user.email "266378653+homeboy-ci[bot]@users.noreply.github.com"
-git commit -m "${COMMIT_MSG}"
+BOT_NAME="homeboy-ci[bot]"
+BOT_EMAIL="266378653+homeboy-ci[bot]@users.noreply.github.com"
+git config user.name "${BOT_NAME}"
+git config user.email "${BOT_EMAIL}"
+GIT_AUTHOR_NAME="${BOT_NAME}" \
+GIT_AUTHOR_EMAIL="${BOT_EMAIL}" \
+GIT_COMMITTER_NAME="${BOT_NAME}" \
+GIT_COMMITTER_EMAIL="${BOT_EMAIL}" \
+  git commit -m "${COMMIT_MSG}"
 
 # Use GitHub App token for push if available — pushes from a GitHub App
 # trigger workflow re-runs, while GITHUB_TOKEN pushes do not.

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -108,8 +108,20 @@ echo ""
 
 # --- Step 4: Configure git identity ---
 
-git config user.name "homeboy-ci[bot]"
-git config user.email "266378653+homeboy-ci[bot]@users.noreply.github.com"
+BOT_NAME="homeboy-ci[bot]"
+BOT_EMAIL="266378653+homeboy-ci[bot]@users.noreply.github.com"
+git config user.name "${BOT_NAME}"
+git config user.email "${BOT_EMAIL}"
+export GIT_AUTHOR_NAME="${BOT_NAME}"
+export GIT_AUTHOR_EMAIL="${BOT_EMAIL}"
+export GIT_COMMITTER_NAME="${BOT_NAME}"
+export GIT_COMMITTER_EMAIL="${BOT_EMAIL}"
+
+if [ -n "${GH_TOKEN:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+  git -c "http.https://github.com/.extraheader=" remote set-url origin "${REMOTE_URL}"
+  git -c "http.https://github.com/.extraheader=" remote set-url --push origin "${REMOTE_URL}"
+fi
 
 # --- Step 5: Dry run check ---
 


### PR DESCRIPTION
## Summary
- force autofix and release commits to use homeboy-ci as both author and committer
- route release pushes through the GitHub App token instead of inherited checkout credentials
- prevent CI identity from leaking back to GitHub Actions or user credentials
