### PR TITLE
refactor: consume Homeboy structured output directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ Use these outputs to gate downstream jobs:
 | `autofix-max-commits` | No | `2` | Safety limit for autofix commit chain depth per branch |
 | `autofix-commands` | No | | Override autofix commands (comma-separated, e.g. `lint --fix,test --fix`) |
 | `autofix-label` | No | | Optional PR label required before autofix runs (e.g. `autofix`) |
-| `test-scope` | No | `full` | Test scope for PRs: `full` or `changed` |
+| `scope` | No | `changed` | Execution scope: `changed` for PRs or `full` for entire codebase |
+| `lint-changed-only` | No | `true` | Deprecated: use `scope` instead |
+| `test-scope` | No | `changed` | Deprecated: use `scope` instead |
 | `auto-issue` | No | `false` | Auto-file issue on non-PR failures |
 | `comment-key` | No | *(auto)* | Shared PR comment key so multiple jobs aggregate into one sticky comment |
 | `comment-section-key` | No | *(auto)* | Section key within the shared PR comment |
@@ -170,8 +172,7 @@ Use these outputs to gate downstream jobs:
     extension: wordpress
     commands: lint,test,audit
     php-version: '8.2'
-    lint-changed-only: 'true'
-    test-scope: 'changed'
+    scope: 'changed'
 ```
 
 ### Split Jobs, Shared PR Comment
@@ -322,13 +323,19 @@ Use two workflows:
 
 1. **PR workflow** (fast + scoped)
    - `commands: lint,test,audit`
-   - `lint-changed-only: 'true'`
-   - `test-scope: 'changed'`
+   - `scope: 'changed'`
 
 2. **Release workflow** (continuous)
    - trigger on `schedule` (every 15 min) + `workflow_dispatch`
-   - `commands: release`
+   - `commands: lint,test,audit` with `auto-issue: 'true'`
+   - separate release workflow uses `commands: release`
    - quality gate before release
+
+### Scope behavior
+
+`scope: 'changed'` is a thin wrapper around the Homeboy CLI. On PRs, the action resolves the base SHA and passes `--changed-since <base-sha>` to Homeboy for `audit`, `lint`, and `test`.
+
+The action does **not** probe for or emulate missing CLI features. If the installed Homeboy version does not support a requested scoped command, that is a Homeboy CLI compatibility problem to fix in Homeboy itself.
 
 ### Fork PR Note
 

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -102,12 +102,17 @@ build_run_command() {
   local cmd="$1"
   local component_id="$2"
   local workspace="$3"
+  local output_file="${4:-}"
   local full_cmd
 
   if [[ "${cmd}" == refactor* ]]; then
     full_cmd="homeboy refactor ${component_id} ${cmd#refactor } --path ${workspace}"
   else
     full_cmd="homeboy ${cmd} ${component_id} --path ${workspace}"
+  fi
+
+  if [ -n "${output_file}" ]; then
+    full_cmd="${full_cmd} --output ${output_file}"
   fi
 
   local scope
@@ -125,12 +130,17 @@ build_autofix_command() {
   local fix_cmd="$1"
   local component_id="$2"
   local workspace="$3"
+  local output_file="${4:-}"
   local full_cmd
 
   if [[ "${fix_cmd}" == refactor* ]]; then
     full_cmd="homeboy refactor ${component_id} ${fix_cmd#refactor } --path ${workspace}"
   else
     full_cmd="homeboy ${fix_cmd} ${component_id} --path ${workspace}"
+  fi
+
+  if [ -n "${output_file}" ]; then
+    full_cmd="${full_cmd} --output ${output_file}"
   fi
 
   local scope

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -36,7 +36,8 @@ for CMD in "${CMD_ARRAY[@]}"; do
     unset HOMEBOY_SKIP_LINT 2>/dev/null || true
   fi
 
-  FULL_CMD="$(build_run_command "${CMD}" "${COMP_ID}" "${WORKSPACE}")"
+  OUTPUT_JSON="${HOMEBOY_OUTPUT_DIR}/${CMD}.json"
+  FULL_CMD="$(build_run_command "${CMD}" "${COMP_ID}" "${WORKSPACE}" "${OUTPUT_JSON}")"
 
   echo ""
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -52,34 +53,9 @@ for CMD in "${CMD_ARRAY[@]}"; do
   set -e
   echo "::endgroup::"
 
-  # Extract structured JSON from the log output.
-  # Homeboy commands embed JSON objects in their text output. The first
-  # top-level JSON object with a "success" key is the output envelope.
-  # Extract it into a .json file so downstream scripts can read structured
-  # data instead of scraping logs with regex.
-  python3 -c "
-import json, sys
-text = open(sys.argv[1]).read()
-# Strip GitHub Actions timestamp prefixes if present
-lines = []
-for line in text.split('\n'):
-    if ' Z ' in line:
-        line = line.split(' Z ', 1)[-1]
-    lines.append(line)
-text = '\n'.join(lines)
-decoder = json.JSONDecoder()
-for i, c in enumerate(text):
-    if c == '{':
-        try:
-            obj, _ = decoder.raw_decode(text, i)
-            if isinstance(obj, dict) and 'success' in obj:
-                json.dump(obj, open(sys.argv[2], 'w'), indent=2)
-                sys.exit(0)
-        except (json.JSONDecodeError, ValueError):
-            pass
-# No JSON envelope found — write a minimal status-only file
-json.dump({'success': sys.argv[3] == '0', 'data': {}}, open(sys.argv[2], 'w'))
-" "${HOMEBOY_OUTPUT_DIR}/${CMD}.log" "${HOMEBOY_OUTPUT_DIR}/${CMD}.json" "${CMD_EXIT}" 2>/dev/null || true
+  if [ ! -s "${OUTPUT_JSON}" ]; then
+    echo "::warning::homeboy ${CMD} did not write structured output to ${OUTPUT_JSON}"
+  fi
 
   if [ "${CMD_EXIT}" -eq 0 ]; then
     echo "::notice::homeboy ${CMD}: PASSED"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -20,6 +20,7 @@ assert_equals() {
 
 WORKSPACE="/tmp/workspace"
 COMPONENT="data-machine"
+OUTPUT_JSON="/tmp/workspace/out.json"
 
 # ── Unscoped (full mode) ──
 unset SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true
@@ -29,6 +30,11 @@ assert_equals \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
   "lint includes workspace path"
 
+assert_equals \
+  "homeboy lint data-machine --path /tmp/workspace --output /tmp/workspace/out.json" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "lint includes structured output path"
+
 # ── Scoped (changed mode) ──
 SCOPE_MODE="changed"
 SCOPE_BASE_REF="origin/main"
@@ -36,6 +42,11 @@ assert_equals \
   "homeboy lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
   "lint keeps path with changed-since"
+
+assert_equals \
+  "homeboy lint data-machine --path /tmp/workspace --output /tmp/workspace/out.json --changed-since origin/main" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "lint keeps output path with changed-since"
 
 assert_equals \
   "homeboy test data-machine --path /tmp/workspace --changed-since origin/main" \
@@ -54,12 +65,32 @@ assert_equals \
   "run command appends extra args"
 
 assert_equals \
-  "homeboy refactor ci data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "homeboy audit data-machine --path /tmp/workspace --output /tmp/workspace/out.json --changed-since origin/main --format json" \
+  "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "run command keeps output path before extra args"
+
+assert_equals \
+  "homeboy lint --fix data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_autofix_command "lint --fix" "${COMPONENT}" "${WORKSPACE}")" \
+  "autofix lint keeps path and changed-since"
+
+assert_equals \
+  "homeboy lint --fix data-machine --path /tmp/workspace --output /tmp/workspace/out.json --changed-since origin/main --format json" \
+  "$(build_autofix_command "lint --fix" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "autofix lint keeps output path and changed-since"
+
+assert_equals \
+  "homeboy audit --fix --write data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_autofix_command "audit --fix --write" "${COMPONENT}" "${WORKSPACE}")" \
+  "autofix audit keeps path and changed-since"
+
+assert_equals \
+  "homeboy refactor data-machine ci --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_run_command "refactor ci" "${COMPONENT}" "${WORKSPACE}")" \
   "refactor keeps path with changed-since"
 
 assert_equals \
-  "homeboy refactor ci --write data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "homeboy refactor data-machine ci --write --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_autofix_command "refactor ci --write" "${COMPONENT}" "${WORKSPACE}")" \
   "autofix refactor keeps path and changed-since"
 
@@ -67,7 +98,7 @@ assert_equals \
 unset SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true
 SCOPE_MODE="full"
 assert_equals \
-  "homeboy refactor ci --write data-machine --path /tmp/workspace" \
+  "homeboy refactor data-machine ci --write --path /tmp/workspace" \
   "$(build_autofix_command "refactor ci --write" "${COMPONENT}" "${WORKSPACE}")" \
   "autofix refactor keeps workspace path"
 

--- a/scripts/digest/build-failure-digest.py
+++ b/scripts/digest/build-failure-digest.py
@@ -8,55 +8,15 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import sys
 import subprocess
-from json import JSONDecoder
 from typing import Any
 
 # NOTE:
 # This script is executed as a file path from composite actions, so Python sets
 # sys.path to this directory (scripts/digest). Use local imports instead of
 # package-qualified imports to avoid ModuleNotFoundError in CI.
-from parsers import extract_audit_digest, extract_lint_digest, extract_test_failures
 from render import render_markdown
-
-
-def read_text(path: str) -> str:
-    try:
-        with open(path, "r", encoding="utf-8", errors="replace") as f:
-            return f.read()
-    except OSError:
-        return ""
-
-
-def extract_json_candidates(text: str) -> list[dict[str, Any]]:
-    decoder = JSONDecoder()
-    out: list[dict[str, Any]] = []
-    i = 0
-    while i < len(text):
-        if text[i] != "{":
-            i += 1
-            continue
-        try:
-            obj, end = decoder.raw_decode(text[i:])
-        except json.JSONDecodeError:
-            i += 1
-            continue
-        if isinstance(obj, dict):
-            out.append(obj)
-        i += max(end, 1)
-    return out
-
-
-def normalize_log_text(raw_text: str) -> str:
-    normalized_lines: list[str] = []
-    for line in raw_text.splitlines():
-        if "Z " in line:
-            normalized_lines.append(line.rsplit("Z ", 1)[1])
-        else:
-            normalized_lines.append(line)
-    return "\n".join(normalized_lines)
 
 
 def parse_bool(value: str | None) -> bool:
@@ -364,12 +324,8 @@ def main() -> int:
     autofix_enabled = parse_bool(autofix_enabled_raw)
     autofix_attempted = parse_bool(autofix_attempted_raw)
 
-    lint_log = read_text(os.path.join(output_dir, "lint.log"))
-    test_log = read_text(os.path.join(output_dir, "test.log"))
-    audit_log = read_text(os.path.join(output_dir, "audit.log"))
-
     # Structured JSON files extracted from homeboy output by run-homeboy-commands.sh.
-    # These are preferred over log scraping — only fall back to parsers when missing.
+    # These are the canonical action-side contract for downstream rendering.
     lint_json = read_json(os.path.join(output_dir, "lint.json"))
     test_json = read_json(os.path.join(output_dir, "test.json"))
     audit_json = read_json(os.path.join(output_dir, "audit.json"))
@@ -378,7 +334,18 @@ def main() -> int:
         if lint_json and lint_json.get("data"):
             lint_digest = build_lint_digest_from_json(lint_json)
         else:
-            lint_digest = extract_lint_digest(lint_log)
+            lint_digest = {
+                "lint_summary": "",
+                "phpcs_summary": "",
+                "phpstan_summary": "",
+                "build_failed": "",
+                "error_code": "",
+                "error_message": "",
+                "error_field": "",
+                "error_hint": "",
+                "top_violations": [],
+                "raw_excerpt": [],
+            }
     else:
         lint_digest = {
             "lint_summary": "",
@@ -392,7 +359,11 @@ def main() -> int:
         if test_json and test_json.get("data"):
             test_digest = build_test_digest_from_json(test_json)
         else:
-            test_digest = extract_test_failures(test_log)
+            test_digest = {
+                "failed_tests_count": 0,
+                "top_failed_tests": [],
+                "raw_excerpt": [],
+            }
     else:
         test_digest = {
             "failed_tests_count": 0,
@@ -403,11 +374,17 @@ def main() -> int:
         if audit_json and audit_json.get("data"):
             audit_digest = build_audit_digest_from_json(audit_json)
         else:
-            audit_digest = extract_audit_digest(
-                audit_log,
-                extract_json_candidates,
-                normalize_log_text,
-            )
+            audit_digest = {
+                "drift_increased": False,
+                "new_findings_count": 0,
+                "new_findings": [],
+                "alignment_score": None,
+                "outliers_found": None,
+                "parsed_outlier_items": 0,
+                "severity_counts": {},
+                "top_findings": [],
+                "raw_excerpt": [],
+            }
     else:
         audit_digest = {
             "drift_increased": False,
@@ -423,11 +400,13 @@ def main() -> int:
         autofix_commands_csv,
     )
 
+    lint_json_path = os.path.join(output_dir, "homeboy-lint-summary.json")
     test_json_path = os.path.join(output_dir, "homeboy-test-failures.json")
     audit_json_path = os.path.join(output_dir, "homeboy-audit-summary.json")
     autofixability_json_path = os.path.join(output_dir, "homeboy-autofixability.json")
     md_path = os.path.join(output_dir, "homeboy-failure-digest.md")
 
+    write_json(lint_json_path, lint_digest)
     write_json(test_json_path, test_digest)
     write_json(audit_json_path, audit_digest)
     write_json(autofixability_json_path, autofixability)

--- a/scripts/digest/render-command-summary.py
+++ b/scripts/digest/render-command-summary.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def load_json(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data if isinstance(data, dict) else {}
+
+
+def append_details(lines: list[str], summary: str, body_lines: list[str]) -> None:
+    content = [str(line) for line in body_lines if str(line).strip()]
+    if not content:
+        return
+    lines.append("")
+    lines.append(f"<details><summary>{summary}</summary>")
+    lines.append("")
+    lines.append("```text")
+    lines.extend(content)
+    lines.append("```")
+    lines.append("")
+    lines.append("</details>")
+
+
+def summarize_test_failure(item: dict[str, Any], idx: int) -> str:
+    name = str(item.get("name", "unknown"))
+    detail = str(item.get("detail", "")).strip()
+    location = str(item.get("location", "")).strip()
+    parts = [f"{idx}. {name}"]
+    if detail:
+        parts.append(detail)
+    if location:
+        parts.append(location)
+    return " — ".join(parts)
+
+
+def compact_summary(command: str, data: dict[str, Any]) -> str:
+    if command == "lint":
+        for value in [
+            data.get("error_message"),
+            data.get("build_failed"),
+            data.get("lint_summary"),
+            data.get("phpcs_summary"),
+            data.get("phpstan_summary"),
+        ]:
+            if value:
+                return str(value)
+        return "structured lint details available"
+
+    if command == "test":
+        failed_count = int(data.get("failed_tests_count", 0) or 0)
+        top_failed = data.get("top_failed_tests", []) or []
+        if top_failed:
+            first = top_failed[0] if isinstance(top_failed[0], dict) else {"name": str(top_failed[0])}
+            detail = str(first.get("detail", "")).strip()
+            name = str(first.get("name", "unknown")).strip()
+            suffix = f" — {name}" if name else ""
+            if detail:
+                suffix += f": {detail}"
+            return f"{failed_count} failed test(s){suffix}"
+        return f"{failed_count} failed test(s)"
+
+    if command == "audit":
+        new_findings_count = int(data.get("new_findings_count", 0) or 0)
+        if new_findings_count > 0:
+            return f"{new_findings_count} new finding(s) since baseline"
+        outliers = data.get("outliers_found")
+        if isinstance(outliers, int):
+            return f"{outliers} outlier(s) in current run"
+        alignment = data.get("alignment_score")
+        if isinstance(alignment, (int, float)):
+            return f"alignment score {alignment:.3f}"
+        return "structured audit details available"
+
+    return "structured command details available"
+
+
+def markdown_summary(command: str, data: dict[str, Any]) -> str:
+    lines: list[str] = []
+
+    if command == "lint":
+        if data.get("lint_summary"):
+            lines.append(f"- Lint summary: **{data['lint_summary']}**")
+        if data.get("phpcs_summary"):
+            lines.append(f"- PHPCS: {data['phpcs_summary']}")
+        if data.get("phpstan_summary"):
+            lines.append(f"- PHPStan: {data['phpstan_summary']}")
+        if data.get("build_failed"):
+            lines.append(f"- Build failed: {data['build_failed']}")
+        if data.get("error_code"):
+            lines.append(f"- Error code: `{data['error_code']}`")
+        if data.get("error_message"):
+            lines.append(f"- Error message: {data['error_message']}")
+        if data.get("error_field"):
+            lines.append(f"- Error field: `{data['error_field']}`")
+        if data.get("error_hint"):
+            lines.append(f"- Hint: {data['error_hint']}")
+        top_violations = [str(v) for v in (data.get("top_violations", []) or [])][:10]
+        append_details(lines, "Top lint violations", top_violations)
+
+    elif command == "test":
+        failed_count = int(data.get("failed_tests_count", 0) or 0)
+        lines.append(f"- Failed tests: **{failed_count}**")
+        top_failed = data.get("top_failed_tests", []) or []
+        details = []
+        for idx, item in enumerate(top_failed[:10], start=1):
+            if isinstance(item, dict):
+                details.append(summarize_test_failure(item, idx))
+            else:
+                details.append(f"{idx}. {item}")
+        append_details(lines, f"Failed test details ({min(len(details), 10)} shown)", details)
+
+    elif command == "audit":
+        alignment = data.get("alignment_score")
+        if isinstance(alignment, (int, float)):
+            lines.append(f"- Alignment score: **{alignment:.3f}**")
+        severity_counts = data.get("severity_counts", {}) or {}
+        if severity_counts:
+            sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(severity_counts.items()))
+            lines.append(f"- Severity counts: **{sev_text}**")
+        outliers = data.get("outliers_found")
+        if isinstance(outliers, int):
+            lines.append(f"- Outliers in current run: **{outliers}**")
+        lines.append(f"- Drift increased: **{'yes' if data.get('drift_increased') else 'no'}**")
+        new_findings = data.get("new_findings", []) or []
+        new_findings_count = int(data.get("new_findings_count", 0) or 0)
+        if new_findings_count > 0:
+            lines.append(f"- New findings since baseline: **{new_findings_count}**")
+            for idx, finding in enumerate(new_findings[:5], start=1):
+                context = str(finding.get("context", "unknown"))
+                message = str(finding.get("message", ""))
+                fingerprint = str(finding.get("fingerprint", ""))
+                entry = f"  {idx}. **{context}**"
+                if message:
+                    entry += f" — {message}"
+                if fingerprint:
+                    entry += f" (`{fingerprint}`)"
+                lines.append(entry)
+        top_findings = data.get("top_findings", []) or []
+        if top_findings:
+            lines.append("- Top actionable findings:")
+            detail_lines: list[str] = []
+            for idx, finding in enumerate(top_findings[:10], start=1):
+                file_value = str(finding.get("file", "unknown"))
+                rule_value = str(finding.get("rule", "unknown"))
+                message = str(finding.get("message", ""))
+                line = f"  {idx}. **{file_value}** — {rule_value}"
+                detail = f"{idx}. **{file_value}** — {rule_value}"
+                if message:
+                    line += f" — {message}"
+                    detail += f" — {message}"
+                lines.append(line)
+                detail_lines.append(detail)
+            append_details(lines, f"Audit findings ({min(len(top_findings), 10)} shown)", detail_lines)
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        print(f"Usage: {sys.argv[0]} <command> <json-file> [compact|markdown]", file=sys.stderr)
+        return 1
+
+    command = sys.argv[1].strip().lower()
+    path = sys.argv[2]
+    mode = sys.argv[3].strip().lower() if len(sys.argv) == 4 else "markdown"
+
+    data = load_json(path)
+    if mode == "compact":
+        print(compact_summary(command, data))
+    else:
+        print(markdown_summary(command, data))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/digest/render.py
+++ b/scripts/digest/render.py
@@ -97,7 +97,7 @@ def render_markdown(
             and not top_violations
             and not raw_excerpt
         ):
-            lines.append("- No structured lint details parsed from lint log.")
+            lines.append("- No structured lint details available.")
         build_job_url = _resolve_job_link(
             job_links,
             run_url,
@@ -119,7 +119,7 @@ def render_markdown(
                 [_summarize_test_failure(test, idx) for idx, test in enumerate(top_tests[:10], start=1)],
             )
         else:
-            lines.append("- No per-test failure details parsed from test log.")
+            lines.append("- No structured test failure details available.")
 
         raw_excerpt = [str(line) for line in (test_digest.get("raw_excerpt", []) or [])]
         if raw_excerpt:
@@ -186,7 +186,7 @@ def render_markdown(
                 )
             _append_details_block(lines, f"All parsed audit findings ({len(top_findings)})", detail_lines)
         else:
-            lines.append("- No structured audit findings parsed from audit log.")
+            lines.append("- No structured audit findings available.")
 
         raw_excerpt = [str(line) for line in (audit_digest.get("raw_excerpt", []) or [])]
         if raw_excerpt:
@@ -246,6 +246,7 @@ def render_markdown(
     lines.append("")
 
     lines.append("### Machine-readable artifacts")
+    lines.append("- `homeboy-lint-summary.json`")
     lines.append("- `homeboy-test-failures.json`")
     lines.append("- `homeboy-audit-summary.json`")
     lines.append("- `homeboy-autofixability.json`")

--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -36,12 +36,12 @@ HOMEBOY_ACTION_REF="${HOMEBOY_ACTION_REF:-unknown}"
 HOMEBOY_ACTION_REPOSITORY="${HOMEBOY_ACTION_REPOSITORY:-unknown}"
 
 AUDIT_JSON="${OUTPUT_DIR}/audit.json"
-AUDIT_LOG="${OUTPUT_DIR}/audit.log"
 
 # --- Step 1: Read audit findings from structured JSON ---
 
-# Prefer the pre-extracted .json file (produced by run-homeboy-commands.sh).
-# Fall back to scraping the .log file for backward compatibility.
+# The structured audit JSON extracted by run-homeboy-commands.sh is the
+# canonical action-side contract. If it is missing or invalid, let generic
+# issue filing handle the failure instead of scraping logs here.
 if [ -f "${AUDIT_JSON}" ] && [ -s "${AUDIT_JSON}" ]; then
   FINDINGS_JSON=$(python3 -c "
 import json, sys
@@ -61,68 +61,14 @@ print(json.dumps({
     'total_findings': len(findings)
 }))
 " "${AUDIT_JSON}" 2>/dev/null) || {
-    echo "Failed to read audit.json — falling back to log scraping"
+    echo "Failed to read structured audit.json — falling back to generic issue filing"
     FINDINGS_JSON=""
   }
 fi
 
-# Fall back to log scraping if JSON file is missing or failed
 if [ -z "${FINDINGS_JSON:-}" ]; then
-  if [ ! -f "${AUDIT_LOG}" ]; then
-    echo "No audit log found at ${AUDIT_LOG} — falling back to generic issue filing"
-    exit 1
-  fi
-
-  FINDINGS_JSON=$(python3 -c "
-import json, sys
-
-text = open(sys.argv[1], 'r', errors='replace').read()
-lines = []
-for line in text.splitlines():
-    if 'Z ' in line:
-        lines.append(line.rsplit('Z ', 1)[1])
-    else:
-        lines.append(line)
-text = '\n'.join(lines)
-
-decoder = json.JSONDecoder()
-i = 0
-payload = None
-while i < len(text):
-    if text[i] != '{':
-        i += 1
-        continue
-    try:
-        obj, end = decoder.raw_decode(text[i:])
-    except json.JSONDecodeError:
-        i += 1
-        continue
-    if isinstance(obj, dict):
-        data = obj.get('data', {})
-        if isinstance(data, dict) and ('findings' in data or 'summary' in data):
-            payload = obj
-    i += max(end, 1)
-
-if not payload:
-    sys.exit(1)
-
-findings = payload.get('data', {}).get('findings', [])
-summary = payload.get('data', {}).get('summary', {})
-component = payload.get('data', {}).get('component_id', '')
-groups = {}
-for f in findings:
-    kind = f.get('kind', 'unknown')
-    groups.setdefault(kind, []).append(f)
-print(json.dumps({
-    'groups': {k: v for k, v in sorted(groups.items(), key=lambda x: -len(x[1]))},
-    'summary': summary,
-    'component_id': component,
-    'total_findings': len(findings)
-}))
-" "${AUDIT_LOG}" 2>/dev/null) || {
-    echo "Failed to parse audit findings from log — falling back to generic issue filing"
-    exit 1
-  }
+  echo "Structured audit.json missing — falling back to generic issue filing"
+  exit 1
 fi
 
 TOTAL_FINDINGS=$(echo "${FINDINGS_JSON}" | jq -r '.total_findings')

--- a/scripts/issues/auto-file-issue.sh
+++ b/scripts/issues/auto-file-issue.sh
@@ -2,6 +2,29 @@
 
 set -euo pipefail
 
+compact_summary() {
+  local command="$1"
+  local json_file="$2"
+  python3 "${GITHUB_ACTION_PATH}/scripts/digest/render-command-summary.py" "${command}" "${json_file}" compact 2>/dev/null || true
+}
+
+summary_json_for() {
+  case "$1" in
+    lint)
+      printf '%s\n' "${OUTPUT_DIR}/homeboy-lint-summary.json"
+      ;;
+    test)
+      printf '%s\n' "${OUTPUT_DIR}/homeboy-test-failures.json"
+      ;;
+    audit)
+      printf '%s\n' "${OUTPUT_DIR}/homeboy-audit-summary.json"
+      ;;
+    *)
+      printf '%s\n' ""
+      ;;
+  esac
+}
+
 REPO="${GITHUB_REPOSITORY}"
 COMP_ID="${COMPONENT_NAME:-$(basename "${GITHUB_REPOSITORY}")}"
 OUTPUT_DIR="${HOMEBOY_OUTPUT_DIR:-}"
@@ -35,8 +58,7 @@ IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
 
 FAILED_COMMANDS=()
 PRIMARY_COMMAND=""
-PRIMARY_LOG_FILE=""
-PRIMARY_FATAL_LINE=""
+PRIMARY_SUMMARY=""
 
 for RAW_CMD in "${CMD_ARRAY[@]}"; do
   CMD="$(echo "${RAW_CMD}" | xargs)"
@@ -45,14 +67,13 @@ for RAW_CMD in "${CMD_ARRAY[@]}"; do
     FAILED_COMMANDS+=("${CMD}")
     if [ -z "${PRIMARY_COMMAND}" ]; then
       PRIMARY_COMMAND="${CMD}"
-      PRIMARY_LOG_FILE="${OUTPUT_DIR}/${CMD}.log"
+      PRIMARY_JSON="$(summary_json_for "${CMD}")"
+      if [ -n "${PRIMARY_JSON}" ] && [ -f "${PRIMARY_JSON}" ]; then
+        PRIMARY_SUMMARY="$(compact_summary "${CMD}" "${PRIMARY_JSON}")"
+      fi
     fi
   fi
 done
-
-if [ -n "${PRIMARY_LOG_FILE}" ] && [ -f "${PRIMARY_LOG_FILE}" ]; then
-  PRIMARY_FATAL_LINE=$(grep -m1 -E "(PHP Fatal error:|Fatal error:|Unhandled exception|panic:|BUILD FAILED:)" "${PRIMARY_LOG_FILE}" || true)
-fi
 
 FAILED_CMDS_MD=""
 for CMD in "${FAILED_COMMANDS[@]}"; do
@@ -88,10 +109,10 @@ if [ -n "${EXISTING_ISSUE}" ]; then
   if [ -n "${PRIMARY_COMMAND}" ]; then
     COMMENT+="- Command: \`homeboy ${PRIMARY_COMMAND}\`"$'\n'
   fi
-  if [ -n "${PRIMARY_FATAL_LINE}" ]; then
-    COMMENT+="- First fatal/error: \`${PRIMARY_FATAL_LINE}\`"$'\n'
+  if [ -n "${PRIMARY_SUMMARY}" ]; then
+    COMMENT+="- Summary: ${PRIMARY_SUMMARY}"$'\n'
   else
-    COMMENT+="- First fatal/error: not detected in log tail"$'\n'
+    COMMENT+="- Summary: structured failure summary unavailable"$'\n'
   fi
 
   if [ -n "${SECONDARY_CMDS_MD}" ]; then
@@ -119,16 +140,6 @@ if [ -n "${EXISTING_ISSUE}" ]; then
   COMMENT+="**Failed commands:**"$'\n'
   COMMENT+="${FAILED_CMDS_MD}"$'\n'
   COMMENT+="**Run:** ${RUN_URL}"$'\n'
-
-  for RAW_CMD in "${CMD_ARRAY[@]}"; do
-    CMD="$(echo "${RAW_CMD}" | xargs)"
-    STATUS=$(echo "${RESULTS}" | jq -r --arg cmd "${CMD}" '.[$cmd] // "unknown"' 2>/dev/null || echo "unknown")
-    if [ "${STATUS}" = "fail" ] && [ -f "${OUTPUT_DIR}/${CMD}.log" ]; then
-      LOG_TAIL=$(tail -30 "${OUTPUT_DIR}/${CMD}.log")
-      COMMENT+=$'\n'"<details><summary>${CMD} output (last 30 lines)</summary>"$'\n\n'
-      COMMENT+="\`\`\`"$'\n'"${LOG_TAIL}"$'\n'"\`\`\`"$'\n'"</details>"$'\n'
-    fi
-  done
 
   gh api "repos/${REPO}/issues/${EXISTING_ISSUE}/comments" \
     --method POST \
@@ -163,10 +174,10 @@ else
   if [ -n "${PRIMARY_COMMAND}" ]; then
     BODY+="- Command: \`homeboy ${PRIMARY_COMMAND}\`"$'\n'
   fi
-  if [ -n "${PRIMARY_FATAL_LINE}" ]; then
-    BODY+="- First fatal/error: \`${PRIMARY_FATAL_LINE}\`"$'\n'
+  if [ -n "${PRIMARY_SUMMARY}" ]; then
+    BODY+="- Summary: ${PRIMARY_SUMMARY}"$'\n'
   else
-    BODY+="- First fatal/error: not detected in log tail"$'\n'
+    BODY+="- Summary: structured failure summary unavailable"$'\n'
   fi
 
   if [ -n "${SECONDARY_CMDS_MD}" ]; then
@@ -181,17 +192,6 @@ else
 
   BODY+="### Failed Commands"$'\n\n'
   BODY+="${FAILED_CMDS_MD}"$'\n'
-
-  for RAW_CMD in "${CMD_ARRAY[@]}"; do
-    CMD="$(echo "${RAW_CMD}" | xargs)"
-    STATUS=$(echo "${RESULTS}" | jq -r --arg cmd "${CMD}" '.[$cmd] // "unknown"' 2>/dev/null || echo "unknown")
-    if [ "${STATUS}" = "fail" ] && [ -f "${OUTPUT_DIR}/${CMD}.log" ]; then
-      LOG_TAIL=$(tail -50 "${OUTPUT_DIR}/${CMD}.log")
-      BODY+="### \`homeboy ${CMD}\` output"$'\n\n'
-      BODY+="<details><summary>Last 50 lines</summary>"$'\n\n'
-      BODY+="\`\`\`"$'\n'"${LOG_TAIL}"$'\n'"\`\`\`"$'\n'"</details>"$'\n\n'
-    fi
-  done
 
   BODY+="---"$'\n'
   BODY+="*Filed automatically by [Homeboy Action](https://github.com/Extra-Chill/homeboy-action)*"

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -5,66 +5,10 @@ set -euo pipefail
 # Source scope module for scope queries
 source "${GITHUB_ACTION_PATH}/scripts/scope/context.sh"
 
-render_audit_summary_from_log() {
-  local log_file="$1"
-  python3 "${GITHUB_ACTION_PATH}/scripts/digest/render-audit-summary.py" "${log_file}" 2>/dev/null || true
-}
-
-render_audit_summary_from_json() {
-  local json_file="$1"
-  python3 - "$json_file" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-if not path.is_file():
-    raise SystemExit(0)
-
-data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
-
-alignment_score = data.get("alignment_score")
-if isinstance(alignment_score, (int, float)):
-    print(f"- Alignment score: **{alignment_score:.3f}**")
-
-severity_counts = data.get("severity_counts") or {}
-if severity_counts:
-    sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(severity_counts.items()))
-    print(f"- Severity counts: **{sev_text}**")
-
-print(f"- Drift increased: **{'yes' if data.get('drift_increased') else 'no'}**")
-
-outliers_found = data.get("outliers_found")
-if isinstance(outliers_found, int):
-    print(f"- Outliers in current run: **{outliers_found}**")
-
-new_findings_count = data.get("new_findings_count")
-new_findings = data.get("new_findings") or []
-if isinstance(new_findings_count, int) and new_findings_count > 0:
-    print(f"- New findings since baseline: **{new_findings_count}**")
-    for idx, item in enumerate(new_findings[:5], start=1):
-        context = str(item.get("context", "unknown"))
-        message = str(item.get("message", ""))
-        fingerprint = str(item.get("fingerprint", ""))
-        line = f"  {idx}. **{context}**"
-        if message:
-            line += f" — {message}"
-        if fingerprint:
-            line += f" (`{fingerprint}`)"
-        print(line)
-
-top_findings = data.get("top_findings") or []
-if top_findings:
-    print("- Top actionable findings:")
-    for idx, item in enumerate(top_findings[:5], start=1):
-        file_value = str(item.get("file", "unknown"))
-        rule_value = str(item.get("rule", "unknown"))
-        message = str(item.get("message", ""))
-        line = f"  {idx}. **{file_value}** — {rule_value}"
-        if message:
-            line += f" — {message}"
-        print(line)
-PY
+render_structured_summary() {
+  local command="$1"
+  local json_file="$2"
+  python3 "${GITHUB_ACTION_PATH}/scripts/digest/render-command-summary.py" "${command}" "${json_file}" markdown 2>/dev/null || true
 }
 
 OUTPUT_DIR="${HOMEBOY_OUTPUT_DIR:-}"
@@ -160,12 +104,10 @@ if [ -n "${DIGEST_FILE}" ] && [ -f "${DIGEST_FILE}" ]; then
   SECTION_BODY+="$(cat "${DIGEST_FILE}")"$'\n\n'
 fi
 
-AUDIT_SUMMARY_JSON="${OUTPUT_DIR}/homeboy-audit-summary.json"
-
 if is_scoped; then
   SECTION_BODY+="> :zap: Scope: **changed files only**"$'\n\n'
 elif [ "$(scope_context)" = "pr" ] && [ "${SCOPE_MODE:-full}" = "full" ]; then
-  SECTION_BODY+="> :information_source: Scope resolved to **full** (CLI compatibility or explicit override)"$'\n\n'
+  SECTION_BODY+="> :information_source: Scope resolved to **full**"$'\n\n'
 fi
 
 if is_fork; then
@@ -175,7 +117,7 @@ fi
 # Only show test-specific fallback note when commands include test.
 if [[ ",${COMMANDS}," == *",test,"* ]] || [[ "${COMMANDS}" == "test" ]]; then
   if [ "$(scope_context)" = "pr" ] && [ "${SCOPE_MODE:-full}" = "full" ]; then
-    SECTION_BODY+="> :information_source: PR test scope fell back to **full** (CLI compatibility or explicit override)"$'\n\n'
+    SECTION_BODY+="> :information_source: PR test scope: **full**"$'\n\n'
   elif [ "${TEST_SCOPE_EFFECTIVE:-}" = "changed" ]; then
     SECTION_BODY+="> :zap: PR test scope: **changed** (files affected by this PR)"$'\n\n'
   fi
@@ -185,7 +127,18 @@ IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
 
 for CMD in "${CMD_ARRAY[@]}"; do
   CMD=$(echo "${CMD}" | xargs)
-  LOG_FILE="${OUTPUT_DIR}/${CMD}.log"
+  SUMMARY_JSON=""
+  case "${CMD}" in
+    lint)
+      SUMMARY_JSON="${OUTPUT_DIR}/homeboy-lint-summary.json"
+      ;;
+    test)
+      SUMMARY_JSON="${OUTPUT_DIR}/homeboy-test-failures.json"
+      ;;
+    audit)
+      SUMMARY_JSON="${OUTPUT_DIR}/homeboy-audit-summary.json"
+      ;;
+  esac
 
   STATUS=$(echo "${RESULTS}" | jq -r --arg cmd "${CMD}" '.[$cmd] // "unknown"' 2>/dev/null || echo "unknown")
 
@@ -199,84 +152,13 @@ for CMD in "${CMD_ARRAY[@]}"; do
 
   SECTION_BODY+=":${ICON}: **${CMD}**${SCOPE_NOTE}"$'\n'
 
-  if [ "${CMD}" = "audit" ] && [ -f "${AUDIT_SUMMARY_JSON}" ]; then
-    SECTION_BODY+="- Actionable audit summary:"$'\n'
-    SECTION_BODY+="$(render_audit_summary_from_json "${AUDIT_SUMMARY_JSON}")"$'\n'
-  elif [ "${CMD}" = "audit" ] && [ -f "${LOG_FILE}" ]; then
-    AUDIT_MD="$(render_audit_summary_from_log "${LOG_FILE}")"
-    if [ -n "${AUDIT_MD}" ]; then
-      SECTION_BODY+="- Actionable audit summary:"$'\n'
-      SECTION_BODY+="${AUDIT_MD}"$'\n'
+  if [ -f "${SUMMARY_JSON}" ]; then
+    SUMMARY_MD="$(render_structured_summary "${CMD}" "${SUMMARY_JSON}")"
+    if [ -n "${SUMMARY_MD}" ]; then
+      SECTION_BODY+="${SUMMARY_MD}"$'\n'
     fi
-  fi
-
-  if [ -f "${LOG_FILE}" ] && [ "${HAS_DIGEST}" != "true" ]; then
-    PHPCS_SUMMARY=$(grep -o "LINT SUMMARY: .*" "${LOG_FILE}" | head -1 || true)
-    if [ -n "${PHPCS_SUMMARY}" ]; then
-      FIXABLE=$(grep -o "Fixable: [0-9]*" "${LOG_FILE}" | head -1 || true)
-      FILES_INFO=$(grep -o "Files with issues: .*" "${LOG_FILE}" | head -1 || true)
-      SECTION_BODY+="- PHPCS: ${PHPCS_SUMMARY}"$'\n'
-      if [ -n "${FIXABLE}" ]; then
-        SECTION_BODY+="- ${FIXABLE} | ${FILES_INFO}"$'\n'
-      fi
-    fi
-
-    TOP_VIOLATIONS=$(sed -n '/TOP VIOLATIONS:/,/^$/p' "${LOG_FILE}" | grep -E '^\s+\S' | head -5 || true)
-    if [ -n "${TOP_VIOLATIONS}" ]; then
-      SECTION_BODY+=$'\n'"<details><summary>Top violations</summary>"$'\n\n'"\`\`\`"$'\n'
-      SECTION_BODY+="${TOP_VIOLATIONS}"$'\n'
-      SECTION_BODY+="\`\`\`"$'\n'"</details>"$'\n'
-    fi
-
-    PHPSTAN_SUMMARY=$(grep -o "PHPSTAN SUMMARY: .*" "${LOG_FILE}" | head -1 || true)
-    if [ -n "${PHPSTAN_SUMMARY}" ]; then
-      SECTION_BODY+="- PHPStan: ${PHPSTAN_SUMMARY}"$'\n'
-    fi
-
-    BUILD_FAILED=$(grep -o "BUILD FAILED: .*" "${LOG_FILE}" | head -1 || true)
-    if [ -n "${BUILD_FAILED}" ]; then
-      SECTION_BODY+="- ${BUILD_FAILED}"$'\n'
-    fi
-
-    FATAL=$(grep "PHP Fatal error:" "${LOG_FILE}" | head -1 | sed 's/.*PHP Fatal error:/Fatal:/' || true)
-    if [ -n "${FATAL}" ]; then
-      SECTION_BODY+=$'\n'"<details><summary>Fatal error</summary>"$'\n\n'"\`\`\`"$'\n'
-      SECTION_BODY+="${FATAL}"$'\n'
-      SECTION_BODY+="\`\`\`"$'\n'"</details>"$'\n'
-    fi
-
-    CARGO_ERRORS=$(grep -c "^error\[" "${LOG_FILE}" 2>/dev/null || echo "0")
-    CARGO_WARNINGS=$(grep -c "^warning\[" "${LOG_FILE}" 2>/dev/null || echo "0")
-    if [[ "${CARGO_ERRORS}" =~ ^[0-9]+$ ]] && [[ "${CARGO_WARNINGS}" =~ ^[0-9]+$ ]] && { [ "${CARGO_ERRORS}" -gt 0 ] || [ "${CARGO_WARNINGS}" -gt 0 ]; }; then
-      SECTION_BODY+="- Cargo: ${CARGO_ERRORS} error(s), ${CARGO_WARNINGS} warning(s)"$'\n'
-    fi
-
-    # Aggregate all Cargo "test result:" lines (unit + integration + doc-tests).
-    # Cargo emits one line per test binary; the last is often doc-tests with
-    # 0 passed, so we aggregate instead of taking tail -1.
-    CARGO_TEST_LINES=$(grep -E "^test result:" "${LOG_FILE}" 2>/dev/null || true)
-    if [ -n "${CARGO_TEST_LINES}" ]; then
-      CARGO_TOTAL_PASSED=$(echo "${CARGO_TEST_LINES}" | grep -oP '\d+ passed' | awk '{s+=$1} END {print s+0}')
-      CARGO_TOTAL_FAILED=$(echo "${CARGO_TEST_LINES}" | grep -oP '\d+ failed' | awk '{s+=$1} END {print s+0}')
-      CARGO_TOTAL_IGNORED=$(echo "${CARGO_TEST_LINES}" | grep -oP '\d+ ignored' | awk '{s+=$1} END {print s+0}')
-      if [ "${CARGO_TOTAL_PASSED}" -gt 0 ] || [ "${CARGO_TOTAL_FAILED}" -gt 0 ]; then
-        CARGO_STATUS="ok"
-        if [ "${CARGO_TOTAL_FAILED}" -gt 0 ]; then
-          CARGO_STATUS="FAILED"
-        fi
-        SECTION_BODY+="- test result: ${CARGO_STATUS}. ${CARGO_TOTAL_PASSED} passed; ${CARGO_TOTAL_FAILED} failed; ${CARGO_TOTAL_IGNORED} ignored"$'\n'
-      fi
-    fi
-
-    # PHPUnit test results: "OK (N tests, N assertions)" or
-    # "Tests: N, Assertions: N, Failures: N, Errors: N, Skipped: N."
-    PHPUNIT_OK=$(grep -oP "OK \(\d+ tests?, \d+ assertions?\)" "${LOG_FILE}" | tail -1 || true)
-    PHPUNIT_SUMMARY=$(grep -oP "Tests: \d+.*" "${LOG_FILE}" | tail -1 || true)
-    if [ -n "${PHPUNIT_OK}" ]; then
-      SECTION_BODY+="- ${PHPUNIT_OK}"$'\n'
-    elif [ -n "${PHPUNIT_SUMMARY}" ]; then
-      SECTION_BODY+="- ${PHPUNIT_SUMMARY}"$'\n'
-    fi
+  elif [ "${STATUS}" = "fail" ] && [ "${HAS_DIGEST}" != "true" ]; then
+    SECTION_BODY+="- No structured ${CMD} summary artifact was generated."$'\n'
   fi
 
   SECTION_BODY+=$'\n'

--- a/scripts/scope/resolve.sh
+++ b/scripts/scope/resolve.sh
@@ -98,27 +98,7 @@ else
   SCOPE_MODE="full"
 fi
 
-# ── Step 4: Verify CLI support for --changed-since ──
-# If scope is "changed", verify that homeboy supports --changed-since for
-# at least one command. If not, fall back to full.
-
-if [ "${SCOPE_MODE}" = "changed" ]; then
-  CLI_SUPPORTS_SCOPE="false"
-  for probe_cmd in audit lint test; do
-    if homeboy "${probe_cmd}" --help 2>/dev/null | grep -q -- '--changed-since'; then
-      CLI_SUPPORTS_SCOPE="true"
-      break
-    fi
-  done
-
-  if [ "${CLI_SUPPORTS_SCOPE}" = "false" ]; then
-    echo "::warning::Installed homeboy CLI does not support --changed-since; falling back to full scope"
-    SCOPE_MODE="full"
-    SCOPE_BASE_REF=""
-  fi
-fi
-
-# ── Step 5: Write outputs ──
+# ── Step 4: Write outputs ──
 
 echo "SCOPE_CONTEXT=${SCOPE_CONTEXT}" >> "${GITHUB_ENV}"
 echo "SCOPE_BASE_REF=${SCOPE_BASE_REF}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Summary
- switch command execution to Homeboy's explicit `--output <path>` contract instead of recovering JSON from mixed logs
- keep PR comments, issue filing, and digest rendering on structured JSON artifacts only
- remove action-side CLI compatibility fallbacks so Homeboy CLI remains the source of truth

## Why
Homeboy already ships the machine-readable output contract, so `homeboy-action` should consume it directly instead of compensating with log parsing and mixed-output recovery. This keeps the action thin and makes GitHub-facing behavior consistent across CI contexts.

## Validation
- `bash scripts/core/test-command-builders.sh`
- `bash -n scripts/core/lib.sh scripts/core/run-homeboy-commands.sh scripts/core/test-command-builders.sh scripts/pr/post-pr-comment.sh scripts/issues/auto-file-issue.sh scripts/issues/auto-file-categorized-issues.sh`
- `python3 -m py_compile scripts/digest/build-failure-digest.py scripts/digest/render.py scripts/digest/render-command-summary.py`