### PR TITLE
fix: recompute PR autofix on latest branch head

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,12 @@ All three jobs write to the **same PR comment** automatically.
 When enabled, the action will:
 1. Run configured commands
 2. If any fail, run safe autofix commands
-3. Commit changes as `chore(ci): apply homeboy autofixes`
-4. Push to the PR branch
-5. Re-run checks and report final status
+3. Re-fetch the latest PR branch head and recompute fixes there when the branch moved underneath CI
+4. Commit changes as `chore(ci): homeboy autofix ...`
+5. Push directly to the PR branch when credentials allow
+6. Re-run checks and report final status
+
+For fork PRs, Homeboy Action now attempts the same direct-to-PR autofix flow first. Actual push success still depends on the token/permission model available to the workflow run.
 
 ### Auto-open Fix PRs on non-PR runs
 

--- a/action.yml
+++ b/action.yml
@@ -394,7 +394,11 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         BINARY_SOURCE: ${{ steps.resolve-binary.outputs.binary-source }}
         AUTOFIX_ENABLED: ${{ inputs.autofix }}
+        AUTOFIX_ATTEMPTED: ${{ steps.autofix-commit.outputs.attempted }}
         AUTOFIX_COMMITTED: ${{ steps.autofix-commit.outputs.committed }}
+        AUTOFIX_STATUS: ${{ steps.autofix-commit.outputs.status }}
+        AUTOFIX_TARGET_REPO: ${{ steps.autofix-commit.outputs.target-repo }}
+        AUTOFIX_TARGET_BRANCH: ${{ steps.autofix-commit.outputs.target-branch }}
         AUTOFIX_FILE_COUNT: ${{ steps.autofix-commit.outputs.autofix-file-count }}
         AUTOFIX_FIX_TYPES: ${{ steps.autofix-commit.outputs.autofix-fix-types }}
         COMMENT_KEY_INPUT: ${{ inputs.comment-key }}

--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -10,6 +10,11 @@ if ! [[ "${AUTOFIX_MAX_COMMITS}" =~ ^[0-9]+$ ]]; then
   AUTOFIX_MAX_COMMITS=2
 fi
 
+AUTOFIX_PUSH_ATTEMPTS="${AUTOFIX_PUSH_ATTEMPTS:-3}"
+if ! [[ "${AUTOFIX_PUSH_ATTEMPTS}" =~ ^[0-9]+$ ]]; then
+  AUTOFIX_PUSH_ATTEMPTS=3
+fi
+
 # Count autofix commits on this branch only (not full repo history).
 # Use scope base ref when available, fall back to origin/main..HEAD,
 # then full log as last resort.
@@ -28,14 +33,10 @@ if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
   exit 0
 fi
 
-if is_fork; then
-  echo "Skipping autofix: fork PR (${PR_HEAD_REPO:-unknown} → ${GITHUB_REPOSITORY})"
-  echo "committed=false" >> "${GITHUB_OUTPUT}"
-  exit 0
-fi
-
 if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "homeboy-ci[bot]" ]; then
   echo "Skipping autofix: workflow actor is ${GITHUB_ACTOR} (bot loop guard)"
+  echo "attempted=false" >> "${GITHUB_OUTPUT}"
+  echo "status=skipped-bot-loop" >> "${GITHUB_OUTPUT}"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi
@@ -43,6 +44,8 @@ fi
 LAST_SUBJECT=$(git log -1 --pretty=%s 2>/dev/null || true)
 if [[ "${LAST_SUBJECT}" == "${AUTOFIX_COMMIT_PREFIX}"* ]]; then
   echo "Skipping autofix: HEAD already an autofix commit"
+  echo "attempted=false" >> "${GITHUB_OUTPUT}"
+  echo "status=skipped-head-autofix" >> "${GITHUB_OUTPUT}"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi
@@ -50,6 +53,8 @@ fi
 if [ -n "${AUTOFIX_LABEL:-}" ]; then
   if ! echo "${PR_LABELS_JSON}" | jq -e --arg label "${AUTOFIX_LABEL}" 'index($label) != null' > /dev/null; then
     echo "Skipping autofix: required label '${AUTOFIX_LABEL}' not present"
+    echo "attempted=false" >> "${GITHUB_OUTPUT}"
+    echo "status=skipped-missing-label" >> "${GITHUB_OUTPUT}"
     echo "committed=false" >> "${GITHUB_OUTPUT}"
     exit 0
   fi
@@ -57,6 +62,119 @@ fi
 
 COMP_ID="$(resolve_component_id)"
 WORKSPACE="$(resolve_workspace)"
+TARGET_REPO="$(resolve_pr_target_repo)"
+TARGET_BRANCH="$(resolve_pr_target_branch)"
+TARGET_REF="refs/remotes/homeboy-autofix-target/${TARGET_BRANCH}"
+
+fetch_latest_target_head() {
+  local fetch_url
+  fetch_url="$(build_github_remote_url "${TARGET_REPO}" "${APP_TOKEN:-}")"
+  git fetch --no-tags --depth=1 "${fetch_url}" "+refs/heads/${TARGET_BRANCH}:${TARGET_REF}"
+}
+
+reset_to_target_head() {
+  git reset --hard "${TARGET_REF}"
+  git clean -fd
+}
+
+run_autofixes() {
+  echo "Applying autofixes..."
+  for FIX_CMD in "${FIX_ARRAY[@]}"; do
+    FIX_CMD=$(echo "${FIX_CMD}" | xargs)
+    BASE_CMD="$(build_autofix_command "${FIX_CMD}" "${COMP_ID}" "${WORKSPACE}")"
+
+    echo "Running autofix: ${BASE_CMD}"
+    set +e
+    eval "${BASE_CMD}"
+    FIX_EXIT=$?
+    set -e
+
+    if [ "${FIX_EXIT}" -ne 0 ]; then
+      echo "Autofix command exited non-zero (${FIX_EXIT}), continuing to check for file changes"
+    fi
+  done
+}
+
+maybe_update_baseline() {
+  if [ "$(scope_context)" != "pr" ]; then
+    echo "Updating audit baseline (non-PR context)..."
+    set +e
+    BASELINE_CMD="homeboy audit ${COMP_ID} --baseline --path ${WORKSPACE}"
+    eval "${BASELINE_CMD}"
+    BASELINE_EXIT=$?
+    set -e
+    if [ "${BASELINE_EXIT}" -ne 0 ]; then
+      echo "Baseline update exited non-zero (${BASELINE_EXIT}), continuing"
+    fi
+  else
+    echo "Skipping baseline update on PR branch (avoids homeboy.json merge conflicts)"
+  fi
+}
+
+stage_autofix_changes() {
+  if git diff --quiet && git diff --cached --quiet; then
+    return 1
+  fi
+
+  git add -A
+  if git diff --cached --quiet; then
+    return 1
+  fi
+
+  return 0
+}
+
+commit_autofix_changes() {
+  AUTOFIX_FILE_COUNT=$(git diff --cached --name-only | wc -l | xargs)
+  AUTOFIX_FIX_TYPES=""
+  AUTOFIX_FINDING_TYPES=""
+
+  for FIX_CMD in "${FIX_ARRAY[@]}"; do
+    FIX_CMD=$(echo "${FIX_CMD}" | xargs)
+    BASE=$(echo "${FIX_CMD}" | awk '{print $1}')
+    if [ -n "${AUTOFIX_FIX_TYPES}" ]; then
+      AUTOFIX_FIX_TYPES+=", "
+    fi
+    AUTOFIX_FIX_TYPES+="${BASE}"
+  done
+
+  if [ -n "${HOMEBOY_OUTPUT_DIR:-}" ] && [ -d "${HOMEBOY_OUTPUT_DIR}" ]; then
+    AUTOFIX_FINDING_TYPES="$(jq -r '
+      [
+        .. | .fix_summary? // empty | .rules? // empty | .[]? | .rule? // empty
+      ]
+      | map(select(type == "string" and length > 0))
+      | unique
+      | sort
+      | join(", ")
+    ' "${HOMEBOY_OUTPUT_DIR}"/*.json 2>/dev/null | tail -n 1)"
+  fi
+
+  COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_FINDING_TYPES}")"
+
+  BOT_NAME="homeboy-ci[bot]"
+  BOT_EMAIL="266378653+homeboy-ci[bot]@users.noreply.github.com"
+  git config user.name "${BOT_NAME}"
+  git config user.email "${BOT_EMAIL}"
+  GIT_AUTHOR_NAME="${BOT_NAME}" \
+  GIT_AUTHOR_EMAIL="${BOT_EMAIL}" \
+  GIT_COMMITTER_NAME="${BOT_NAME}" \
+  GIT_COMMITTER_EMAIL="${BOT_EMAIL}" \
+    git commit -m "${COMMIT_MSG}"
+}
+
+push_autofix_commit() {
+  local push_target
+  push_target="$(resolve_push_target "${TARGET_REPO}" "${APP_TOKEN:-}")"
+
+  if [ -n "${APP_TOKEN:-}" ]; then
+    echo "Pushing autofix to ${TARGET_REPO}:${TARGET_BRANCH} with GitHub App token"
+  else
+    echo "Pushing autofix to ${TARGET_REPO}:${TARGET_BRANCH}"
+  fi
+
+  git -c "http.https://github.com/.extraheader=" push "${push_target}" "HEAD:refs/heads/${TARGET_BRANCH}"
+}
 
 if [ -n "${AUTOFIX_COMMANDS:-}" ]; then
   IFS=',' read -ra FIX_ARRAY <<< "${AUTOFIX_COMMANDS}"
@@ -83,108 +201,61 @@ fi
 
 if [ ${#FIX_ARRAY[@]} -eq 0 ]; then
   echo "No autofix commands configured for this command set"
+  echo "attempted=false" >> "${GITHUB_OUTPUT}"
+  echo "status=skipped-no-commands" >> "${GITHUB_OUTPUT}"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi
 
-echo "Applying autofixes..."
-for FIX_CMD in "${FIX_ARRAY[@]}"; do
-  FIX_CMD=$(echo "${FIX_CMD}" | xargs)
-  BASE_CMD="$(build_autofix_command "${FIX_CMD}" "${COMP_ID}" "${WORKSPACE}")"
+echo "attempted=true" >> "${GITHUB_OUTPUT}"
 
-  echo "Running autofix: ${BASE_CMD}"
-  set +e
-  eval "${BASE_CMD}"
-  FIX_EXIT=$?
-  set -e
+if ! fetch_latest_target_head; then
+  echo "::warning::Could not fetch latest PR head ${TARGET_REPO}:${TARGET_BRANCH}; using current checkout"
+else
+  echo "Fetched latest PR head ${TARGET_REPO}:${TARGET_BRANCH}"
+fi
 
-  if [ "${FIX_EXIT}" -ne 0 ]; then
-    echo "Autofix command exited non-zero (${FIX_EXIT}), continuing to check for file changes"
+PUSH_ATTEMPT=1
+while [ "${PUSH_ATTEMPT}" -le "${AUTOFIX_PUSH_ATTEMPTS}" ]; do
+  if git show-ref --verify --quiet "${TARGET_REF}"; then
+    reset_to_target_head
   fi
+
+  run_autofixes
+  maybe_update_baseline
+
+  if ! stage_autofix_changes; then
+    echo "No autofix changes detected"
+    echo "status=no-changes" >> "${GITHUB_OUTPUT}"
+    echo "committed=false" >> "${GITHUB_OUTPUT}"
+    exit 0
+  fi
+
+  commit_autofix_changes
+
+  if push_autofix_commit; then
+    echo "committed=true" >> "${GITHUB_OUTPUT}"
+    echo "status=pushed" >> "${GITHUB_OUTPUT}"
+    echo "target-repo=${TARGET_REPO}" >> "${GITHUB_OUTPUT}"
+    echo "target-branch=${TARGET_BRANCH}" >> "${GITHUB_OUTPUT}"
+    echo "autofix-file-count=${AUTOFIX_FILE_COUNT}" >> "${GITHUB_OUTPUT}"
+    echo "autofix-fix-types=${AUTOFIX_FIX_TYPES}" >> "${GITHUB_OUTPUT}"
+    exit 0
+  fi
+
+  if [ "${PUSH_ATTEMPT}" -ge "${AUTOFIX_PUSH_ATTEMPTS}" ]; then
+    break
+  fi
+
+  echo "Autofix push failed on attempt ${PUSH_ATTEMPT}/${AUTOFIX_PUSH_ATTEMPTS}; refetching latest PR head and recomputing"
+  fetch_latest_target_head || true
+  PUSH_ATTEMPT=$((PUSH_ATTEMPT + 1))
 done
 
-# Skip baseline update on PR branches. The baseline lives in homeboy.json which
-# is shared across all branches — updating it on PR autofix commits creates
-# serial merge conflicts (every PR's autofix touches homeboy.json, and merging
-# one invalidates all others). Baselines should only be updated on main.
-# PR CI already uses --changed-since for scoped checks, so the baseline
-# doesn't need to reflect PR-specific state.
-if [ "$(scope_context)" != "pr" ]; then
-  echo "Updating audit baseline (non-PR context)..."
-  set +e
-  BASELINE_CMD="homeboy audit ${COMP_ID} --baseline --path ${WORKSPACE}"
-  eval "${BASELINE_CMD}"
-  BASELINE_EXIT=$?
-  set -e
-  if [ "${BASELINE_EXIT}" -ne 0 ]; then
-    echo "Baseline update exited non-zero (${BASELINE_EXIT}), continuing"
-  fi
-else
-  echo "Skipping baseline update on PR branch (avoids homeboy.json merge conflicts)"
-fi
-
-if git diff --quiet && git diff --cached --quiet; then
-  echo "No autofix changes detected"
-  echo "committed=false" >> "${GITHUB_OUTPUT}"
-  exit 0
-fi
-
-git add -A
-if git diff --cached --quiet; then
-  echo "No staged changes after autofix"
-  echo "committed=false" >> "${GITHUB_OUTPUT}"
-  exit 0
-fi
-
-# Capture autofix summary: file count and which fix commands ran
-AUTOFIX_FILE_COUNT=$(git diff --cached --name-only | wc -l | xargs)
-AUTOFIX_FIX_TYPES=""
-AUTOFIX_FINDING_TYPES=""
-for FIX_CMD in "${FIX_ARRAY[@]}"; do
-  FIX_CMD=$(echo "${FIX_CMD}" | xargs)
-  BASE=$(echo "${FIX_CMD}" | awk '{print $1}')
-  if [ -n "${AUTOFIX_FIX_TYPES}" ]; then
-    AUTOFIX_FIX_TYPES+=", "
-  fi
-  AUTOFIX_FIX_TYPES+="${BASE}"
-done
-
-if [ -n "${HOMEBOY_OUTPUT_DIR:-}" ] && [ -d "${HOMEBOY_OUTPUT_DIR}" ]; then
-  AUTOFIX_FINDING_TYPES="$(jq -r '
-    [
-      .. | .fix_summary? // empty | .rules? // empty | .[]? | .rule? // empty
-    ]
-    | map(select(type == "string" and length > 0))
-    | unique
-    | sort
-    | join(", ")
-  ' "${HOMEBOY_OUTPUT_DIR}"/*.json 2>/dev/null | tail -n 1)"
-fi
-
-COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_FINDING_TYPES}")"
-
-BOT_NAME="homeboy-ci[bot]"
-BOT_EMAIL="266378653+homeboy-ci[bot]@users.noreply.github.com"
-git config user.name "${BOT_NAME}"
-git config user.email "${BOT_EMAIL}"
-GIT_AUTHOR_NAME="${BOT_NAME}" \
-GIT_AUTHOR_EMAIL="${BOT_EMAIL}" \
-GIT_COMMITTER_NAME="${BOT_NAME}" \
-GIT_COMMITTER_EMAIL="${BOT_EMAIL}" \
-  git commit -m "${COMMIT_MSG}"
-
-# Use GitHub App token for push if available — pushes from a GitHub App
-# trigger workflow re-runs, while GITHUB_TOKEN pushes do not.
-if [ -n "${APP_TOKEN:-}" ]; then
-  echo "Pushing with GitHub App token (will trigger CI re-run)"
-  git -c "http.https://github.com/.extraheader=" \
-    push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-    "HEAD:${GITHUB_HEAD_REF}"
-else
-  echo "Pushing with default token (will NOT trigger CI re-run)"
-  git push origin "HEAD:${GITHUB_HEAD_REF}"
-fi
-
-echo "committed=true" >> "${GITHUB_OUTPUT}"
-echo "autofix-file-count=${AUTOFIX_FILE_COUNT}" >> "${GITHUB_OUTPUT}"
-echo "autofix-fix-types=${AUTOFIX_FIX_TYPES}" >> "${GITHUB_OUTPUT}"
+echo "::warning::Autofix changes were generated but could not be pushed to ${TARGET_REPO}:${TARGET_BRANCH}"
+echo "committed=false" >> "${GITHUB_OUTPUT}"
+echo "status=push-failed" >> "${GITHUB_OUTPUT}"
+echo "target-repo=${TARGET_REPO}" >> "${GITHUB_OUTPUT}"
+echo "target-branch=${TARGET_BRANCH}" >> "${GITHUB_OUTPUT}"
+echo "autofix-file-count=${AUTOFIX_FILE_COUNT:-0}" >> "${GITHUB_OUTPUT}"
+echo "autofix-fix-types=${AUTOFIX_FIX_TYPES:-}" >> "${GITHUB_OUTPUT}"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -55,6 +55,48 @@ resolve_workspace() {
   pwd
 }
 
+resolve_pr_target_repo() {
+  if [ -n "${PR_HEAD_REPO:-}" ]; then
+    printf '%s\n' "${PR_HEAD_REPO}"
+  else
+    printf '%s\n' "${GITHUB_REPOSITORY}"
+  fi
+}
+
+resolve_pr_target_branch() {
+  if [ -n "${GITHUB_HEAD_REF:-}" ]; then
+    printf '%s\n' "${GITHUB_HEAD_REF}"
+  elif [ -n "${GITHUB_REF_NAME:-}" ]; then
+    printf '%s\n' "${GITHUB_REF_NAME}"
+  else
+    git rev-parse --abbrev-ref HEAD 2>/dev/null || true
+  fi
+}
+
+build_github_remote_url() {
+  local repo="$1"
+  local token="${2:-}"
+
+  if [ -n "${token}" ]; then
+    printf 'https://x-access-token:%s@github.com/%s.git\n' "${token}" "${repo}"
+  else
+    printf 'https://github.com/%s.git\n' "${repo}"
+  fi
+}
+
+resolve_push_target() {
+  local repo="$1"
+  local token="${2:-}"
+
+  if [ -n "${token}" ]; then
+    build_github_remote_url "${repo}" "${token}"
+  elif [ "${repo}" = "${GITHUB_REPOSITORY:-}" ]; then
+    printf 'origin\n'
+  else
+    build_github_remote_url "${repo}"
+  fi
+}
+
 # Sort commands into canonical order: audit → lint → test → refactor.
 # Audit/lint/test are the core quality gates; real refactor commands run after
 # them when explicitly requested.

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -117,4 +117,43 @@ assert_equals \
   "$(build_run_command "refactor --all" "${COMPONENT}" "${WORKSPACE}")" \
   "refactor keeps workspace path"
 
+PR_HEAD_REPO="some-contributor/homeboy-action"
+GITHUB_REPOSITORY="Extra-Chill/homeboy-action"
+GITHUB_HEAD_REF="feat/fork-pr"
+GITHUB_REF_NAME="ignored-here"
+assert_equals \
+  "some-contributor/homeboy-action" \
+  "$(resolve_pr_target_repo)" \
+  "target repo prefers PR head repo"
+
+assert_equals \
+  "feat/fork-pr" \
+  "$(resolve_pr_target_branch)" \
+  "target branch prefers PR head ref"
+
+assert_equals \
+  "https://github.com/some-contributor/homeboy-action.git" \
+  "$(build_github_remote_url "some-contributor/homeboy-action")" \
+  "build github remote url without token"
+
+assert_equals \
+  "https://x-access-token:secret123@github.com/some-contributor/homeboy-action.git" \
+  "$(build_github_remote_url "some-contributor/homeboy-action" "secret123")" \
+  "build github remote url with token"
+
+assert_equals \
+  "origin" \
+  "$(resolve_push_target "Extra-Chill/homeboy-action")" \
+  "same-repo push without token uses origin"
+
+assert_equals \
+  "https://github.com/some-contributor/homeboy-action.git" \
+  "$(resolve_push_target "some-contributor/homeboy-action")" \
+  "fork push without token uses explicit remote url"
+
+assert_equals \
+  "https://x-access-token:secret123@github.com/some-contributor/homeboy-action.git" \
+  "$(resolve_push_target "some-contributor/homeboy-action" "secret123")" \
+  "fork push with token uses authenticated remote url"
+
 printf 'All command builder checks passed.\n'

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -90,6 +90,8 @@ if [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_COMMITTED:-}" = "true" ]; t
     AUTOFIX_SUMMARY+=" — ${AUTOFIX_FILE_COUNT} file(s) fixed"
   fi
   SECTION_BODY+="> ${AUTOFIX_SUMMARY}"$'\n\n'
+elif [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_ATTEMPTED:-false}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "push-failed" ]; then
+  SECTION_BODY+="> :warning: Autofix generated changes but could not push them back to **${AUTOFIX_TARGET_REPO:-${REPO}}:${AUTOFIX_TARGET_BRANCH:-unknown}**"$'\n\n'
 elif [ "${AUTOFIX_ENABLED}" = "true" ]; then
   SECTION_BODY+="> :information_source: Autofix enabled, but no fixable file changes were produced"$'\n\n'
 fi
@@ -108,10 +110,6 @@ if is_scoped; then
   SECTION_BODY+="> :zap: Scope: **changed files only**"$'\n\n'
 elif [ "$(scope_context)" = "pr" ] && [ "${SCOPE_MODE:-full}" = "full" ]; then
   SECTION_BODY+="> :information_source: Scope resolved to **full**"$'\n\n'
-fi
-
-if is_fork; then
-  SECTION_BODY+="> :lock: Fork PR — autofix disabled, read-only checks"$'\n\n'
 fi
 
 # Only show test-specific fallback note when commands include test.


### PR DESCRIPTION
## Summary
- refetch the latest PR branch head before autofix commit/push so CI recomputes fixes on top of the newest branch state
- attempt direct-to-PR autofix pushes for both same-repo and fork PRs, with explicit status outputs/commenting when push-back fails
- add helper coverage for PR target repo/branch resolution and push target selection, and document the new PR autofix flow