### PR TITLE
fix: limit autofix comment status to refactor sections

### DIFF
--- a/scripts/pr/comment/lib.sh
+++ b/scripts/pr/comment/lib.sh
@@ -132,3 +132,29 @@ with open(sys.argv[1], "w") as f:
     json.dump(tooling, f)
 ' "${file_path}"
 }
+
+is_refactor_owning_section() {
+  local section_key="${SECTION_KEY:-}"
+  local section_title="${SECTION_TITLE:-}"
+  local commands_csv="${COMMANDS:-}"
+
+  case "${section_key}" in
+    refactor*|auto-refactor*|*refactor*)
+      return 0
+      ;;
+  esac
+
+  case "${section_title}" in
+    Refactor*|Auto-refactor*|*Refactor*)
+      return 0
+      ;;
+  esac
+
+  case "${commands_csv}" in
+    *refactor*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -6,6 +6,10 @@ source "${GITHUB_ACTION_PATH}/scripts/scope/context.sh"
 source "${GITHUB_ACTION_PATH}/scripts/pr/comment/lib.sh"
 
 append_autofix_section() {
+  if ! is_refactor_owning_section; then
+    return 0
+  fi
+
   if [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_COMMITTED:-}" = "true" ]; then
     local autofix_summary=":wrench: **Autofix applied**"
     if [ -n "${AUTOFIX_FILE_COUNT:-}" ] && [ -n "${AUTOFIX_FIX_TYPES:-}" ]; then


### PR DESCRIPTION
## Summary
- stop detector job sections from rendering autofix outcome text in shared PR comments
- keep autofix mutation status limited to refactor-owning sections so earlier audit/lint/test jobs do not contradict later autofix commits
- preserve the existing shared comment aggregation flow while making autofix messaging match the refactor-as-write-path model