### PR TITLE
fix: annotate dev builds with commit hash in version reporting

### DIFF
--- a/scripts/setup/capture-tooling-metadata.sh
+++ b/scripts/setup/capture-tooling-metadata.sh
@@ -4,6 +4,20 @@ set -euo pipefail
 
 HOMEBOY_CLI_VERSION="$(homeboy --version 2>/dev/null || echo 'unknown')"
 
+# Annotate dev builds with commit hash so CI logs distinguish
+# "0.74.1 release" from "0.74.1+abc1234 built from HEAD"
+if [ -d ".git" ]; then
+  HEAD_SHORT="$(git rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -n "${HEAD_SHORT}" ]; then
+    VERSION_NUM="${HOMEBOY_CLI_VERSION#homeboy }"
+    TAG_COMMIT="$(git rev-parse "v${VERSION_NUM}" 2>/dev/null || true)"
+    HEAD_FULL="$(git rev-parse HEAD 2>/dev/null || true)"
+    if [ -n "${TAG_COMMIT}" ] && [ "${TAG_COMMIT}" != "${HEAD_FULL}" ]; then
+      HOMEBOY_CLI_VERSION="${HOMEBOY_CLI_VERSION}+${HEAD_SHORT}"
+    fi
+  fi
+fi
+
 if [ -n "${EXTENSION_ID:-}" ]; then
   EXTENSION_ID_EFFECTIVE="${EXTENSION_ID}"
 else


### PR DESCRIPTION
## Summary
- When the binary is built from HEAD (not at a release tag), appends `+<short-hash>` to `HOMEBOY_CLI_VERSION`
- CI logs now show e.g. `homeboy 0.74.1+abc1234` for dev builds vs plain `homeboy 0.74.1` for tagged releases
- Follows semver build metadata convention
- Helps diagnose audit baseline mismatches where the binary has newer detectors than the release