### PR TITLE
fix: redirect informational echoes to stderr in publish_comment_body

### DIFF
--- a/scripts/pr/comment/publish.sh
+++ b/scripts/pr/comment/publish.sh
@@ -23,7 +23,7 @@ publish_comment_body() {
   local existing_comment_id="$2"
 
   if [ -n "${existing_comment_id}" ]; then
-    echo "Updating shared comment ${existing_comment_id}..."
+    echo "Updating shared comment ${existing_comment_id}..." >&2
     if ! gh api "repos/${REPO}/issues/comments/${existing_comment_id}" \
       --method PATCH \
       --field body="${comment_body}" > /dev/null 2>&1; then
@@ -34,7 +34,7 @@ publish_comment_body() {
     return 0
   fi
 
-  echo "Creating shared comment..."
+  echo "Creating shared comment..." >&2
   local create_response
   create_response=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
     --method POST \


### PR DESCRIPTION
## Summary

- `publish_comment_body()` was leaking status messages (`Updating shared comment...`, `Creating shared comment...`) to stdout
- Since the function's stdout is captured as the comment ID, the multi-line output caused `$GITHUB_ENV` writes to include a bare number on its own line
- GitHub Actions rejects this with `##[error]Invalid format '4055963170'`
- This was the real reason the Audit job was failing on homeboy PRs — the audit itself passed (`RESULTS: {"audit":"pass"}`) but the PR comment publish step crashed the job

## Fix

Redirect both `echo` statements to `>&2` (stderr) so only the comment ID reaches stdout.

## Impact

Unblocks homeboy CI — the audit gate was reporting failure even though audit was passing.