### PR TITLE
fix: place --output global flag before subcommand for clap compatibility

### DIFF
--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -150,15 +150,18 @@ build_run_command() {
   local workspace="$3"
   local output_file="${4:-}"
   local full_cmd
+  local global_flags=""
 
-  if [[ "${cmd}" == refactor* ]]; then
-    full_cmd="homeboy refactor ${component_id} ${cmd#refactor } --path ${workspace}"
-  else
-    full_cmd="homeboy ${cmd} ${component_id} --path ${workspace}"
+  # --output is a global flag and must appear before the subcommand
+  # (clap global args don't propagate when placed after positional args)
+  if [ -n "${output_file}" ]; then
+    global_flags="--output ${output_file} "
   fi
 
-  if [ -n "${output_file}" ]; then
-    full_cmd="${full_cmd} --output ${output_file}"
+  if [[ "${cmd}" == refactor* ]]; then
+    full_cmd="homeboy ${global_flags}refactor ${component_id} ${cmd#refactor } --path ${workspace}"
+  else
+    full_cmd="homeboy ${global_flags}${cmd} ${component_id} --path ${workspace}"
   fi
 
   local scope
@@ -190,15 +193,17 @@ build_autofix_command() {
   local workspace="$3"
   local output_file="${4:-}"
   local full_cmd
+  local global_flags=""
 
-  if [[ "${fix_cmd}" == refactor* ]]; then
-    full_cmd="homeboy refactor ${component_id} ${fix_cmd#refactor } --path ${workspace}"
-  else
-    full_cmd="homeboy ${fix_cmd} ${component_id} --path ${workspace}"
+  # --output is a global flag and must appear before the subcommand
+  if [ -n "${output_file}" ]; then
+    global_flags="--output ${output_file} "
   fi
 
-  if [ -n "${output_file}" ]; then
-    full_cmd="${full_cmd} --output ${output_file}"
+  if [[ "${fix_cmd}" == refactor* ]]; then
+    full_cmd="homeboy ${global_flags}refactor ${component_id} ${fix_cmd#refactor } --path ${workspace}"
+  else
+    full_cmd="homeboy ${global_flags}${fix_cmd} ${component_id} --path ${workspace}"
   fi
 
   local scope

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -31,7 +31,7 @@ assert_equals \
   "lint includes workspace path"
 
 assert_equals \
-  "homeboy lint data-machine --path /tmp/workspace --output /tmp/workspace/out.json" \
+  "homeboy --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "lint includes structured output path"
 
@@ -44,7 +44,7 @@ assert_equals \
   "lint keeps path with changed-since"
 
 assert_equals \
-  "homeboy lint data-machine --path /tmp/workspace --output /tmp/workspace/out.json --changed-since origin/main" \
+  "homeboy --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "lint keeps output path with changed-since"
 
@@ -65,7 +65,7 @@ assert_equals \
   "run command appends extra args"
 
 assert_equals \
-  "homeboy audit data-machine --path /tmp/workspace --output /tmp/workspace/out.json --changed-since origin/main --format json" \
+  "homeboy --output /tmp/workspace/out.json audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "run command keeps output path before extra args"
 
@@ -75,7 +75,7 @@ assert_equals \
   "autofix refactor lint keeps path and changed-since"
 
 assert_equals \
-  "homeboy refactor data-machine --from lint --write --path /tmp/workspace --output /tmp/workspace/out.json --changed-since origin/main --format json" \
+  "homeboy --output /tmp/workspace/out.json refactor data-machine --from lint --write --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_autofix_command "refactor --from lint --write" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "autofix refactor lint keeps output path and changed-since"
 

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -35,7 +35,7 @@ run_release_command() {
   shift
   local exit_code=0
   set +e
-  homeboy release "$@" --output "${output_file}"
+  homeboy --output "${output_file}" release "$@"
   exit_code=$?
   set -e
   if [ ! -s "${output_file}" ]; then


### PR DESCRIPTION
## Summary

- Moves `--output` flag before the subcommand in all command builders (`build_run_command`, `build_autofix_command`, `run_release_command`)
- clap's `global = true` doesn't propagate `--output` when placed after positional args — this caused the lint gate in CI to silently drop structured output
- Updates all test expectations to match the new flag position (24/24 tests pass)

## Context

This unblocks homeboy PR #748 (audit baseline regeneration) where the lint gate was failing because `--output file.json` was being ignored when appended after positional args.