### PR TITLE
fix: scope autofix commit counter to since last release tag

### DIFF
--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -9,9 +9,17 @@ if ! [[ "${AUTOFIX_MAX_COMMITS}" =~ ^[0-9]+$ ]]; then
   AUTOFIX_MAX_COMMITS=2
 fi
 
-AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" | wc -l | xargs)
+# Count autofix commits since the last release tag, not the entire repo history.
+# Without this scoping, past autofix commits permanently count against the limit,
+# turning the loop guard into a permanent shutoff after N total historical commits.
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [ -n "${LAST_TAG}" ]; then
+  AUTOFIX_COMMIT_COUNT=$(git log "${LAST_TAG}..HEAD" --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" | wc -l | xargs)
+else
+  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" | wc -l | xargs)
+fi
 if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
-  echo "Skipping non-PR autofix: reached max autofix commits (${AUTOFIX_COMMIT_COUNT}/${AUTOFIX_MAX_COMMITS})"
+  echo "Skipping non-PR autofix: reached max autofix commits since ${LAST_TAG:-beginning} (${AUTOFIX_COMMIT_COUNT}/${AUTOFIX_MAX_COMMITS})"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi


### PR DESCRIPTION
## Summary

- **Scopes the autofix commit counter** to commits since the last release tag instead of the entire repo history
- Without this fix, the counter permanently blocks autofix after N total historical commits ever merged — turning a loop guard into a permanent shutoff
- Discovered via [release run #547](https://github.com/Extra-Chill/homeboy/actions/runs/23113704170) where the log showed `Skipping non-PR autofix: reached max autofix commits (20/3)` — 20 lifetime autofix commits vs a limit of 3

## Problem

`prepare-autofix-branch.sh` counted autofix commits with:
```bash
git log --oneline --grep "^chore(ci): homeboy autofix" | wc -l
```

This searches the **entire commit history**. The homeboy repo has 20 autofix commits merged to main over time. With `autofix-max-commits: 3`, the guard always triggers (`20 >= 3`) and autofix can never run.

## Fix

Scope the count to `$LAST_TAG..HEAD` so only autofix commits **since the last release** count. This preserves the loop guard (prevents runaway autofix within a single release cycle) while allowing autofix to function across releases.

Falls back to full history if no tags exist (fresh repos).

## Impact

Unblocks the self-healing release loop:
1. Audit detects drift → autofix runs `audit --fix --write`
2. Autofix commits fixes + updates baseline
3. Next cron release passes with updated baseline
4. Repeat — the factory maintains itself