### PR TITLE
feat: add continuous release workflow (homeboy-action releasing itself)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+# Continuous release pipeline for Homeboy Action.
+#
+# Runs every 15 minutes (and on manual dispatch). Checks for releasable
+# conventional commits since the last tag. If found:
+#   1. Version bump + changelog generation
+#   2. Tag + push
+#   3. Post-release hook moves the floating v1 tag
+#
+# No binary builds, no extensions needed — homeboy reads homeboy.json
+# directly for version targets and hooks.
+#
+# No human input needed — version is computed from commit types:
+#   fix: → patch, feat: → minor, BREAKING CHANGE → major
+#   chore:/ci:/docs:/test: → no release
+
+name: Release
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Preview the release without making changes'
+        type: boolean
+        default: false
+
+jobs:
+  # ── Step 1: Check for releasable commits ──
+  check:
+    name: Check for releasable commits
+    runs-on: ubuntu-latest
+    outputs:
+      should-release: ${{ steps.check.outputs.should-release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Restore failure cache
+        id: failure-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .release-last-failed
+          key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            release-last-failed-${{ github.ref_name }}-
+
+      - name: Dry-run release check
+        id: release-check
+        uses: Extra-Chill/homeboy-action@v1
+        with:
+          component: homeboy-action
+          commands: release
+          release-dry-run: 'true'
+
+      - name: Decide whether to release
+        id: check
+        run: |
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [ -f .release-last-failed ]; then
+            LAST_FAILED="$(tr -d '[:space:]' < .release-last-failed)"
+            if [ "${HEAD_SHA}" = "${LAST_FAILED}" ]; then
+              echo "::notice::HEAD ${HEAD_SHA:0:8} matches last failed release attempt — skipping until new commits"
+              echo "should-release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          RELEASE_VERSION="${{ steps.release-check.outputs.release-version }}"
+          BUMP_TYPE="${{ steps.release-check.outputs.release-bump-type }}"
+
+          if [ -z "${RELEASE_VERSION}" ]; then
+            echo "should-release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No releasable commits at HEAD ${HEAD_SHA:0:8}"
+          else
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release dry-run predicts v${RELEASE_VERSION} (${BUMP_TYPE})"
+          fi
+
+  # ── Step 2: Release ──
+  release:
+    name: Release
+    needs: check
+    if: needs.check.outputs.should-release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - uses: Extra-Chill/homeboy-action@v1
+        id: release
+        with:
+          component: homeboy-action
+          commands: release
+          release-dry-run: ${{ inputs.dry-run || 'false' }}
+          app-token: ${{ steps.app-token.outputs.token || '' }}
+
+  # ── Record failed SHA to prevent retry loops ──
+  record-failure:
+    name: Record failure
+    needs:
+      - check
+      - release
+    if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.release.result == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Save failed SHA
+        run: git rev-parse HEAD > .release-last-failed
+
+      - name: Cache failed SHA
+        uses: actions/cache/save@v4
+        with:
+          path: .release-last-failed
+          key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
+
+  # ── Clear failure cache on success ──
+  clear-failure:
+    name: Clear failure cache
+    needs: release
+    if: ${{ needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear failure cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache list --json id,key --jq '.[] | select(.key | startswith("release-last-failed-${{ github.ref_name }}-")) | .id' | while read -r id; do
+            gh cache delete "$id" 2>/dev/null || true
+          done


### PR DESCRIPTION
## Summary

- Adds a cron-based continuous release pipeline that runs every 15 minutes
- Uses **homeboy-action itself** (v1) to run `homeboy release` — no extension needed
- `homeboy.json` already has version targets (`VERSION` file) and the `post:release` hook that moves the floating `v1` tag via `gh api`
- Includes failure caching to avoid retrying broken SHAs

## How it works

```
merge to main (with conventional commit)
  → cron (≤15 min) detects releasable commits
    → homeboy release bumps VERSION, generates changelog, tags
      → post:release hook moves v1 tag to new HEAD
```

No more manual `v1` tag updates. The fix we just shipped (#87) would have been released automatically.

## What's in the workflow

| Job | Purpose |
|---|---|
| Check | Dry-run release, skip if no releasable commits or last attempt failed |
| Release | Run `homeboy release` with homeboy-ci app token |
| Record failure | Cache failed SHA to prevent retry loops |
| Clear failure | Remove cache after successful release |

## Self-hosting

This is homeboy-action using homeboy-action to release itself. The `homeboy.json` component config was already set up — this PR just adds the CI trigger.