### PR TITLE
fix: scope autofix loop guards to actual loops, not historical totals

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -15,20 +15,30 @@ if ! [[ "${AUTOFIX_PUSH_ATTEMPTS}" =~ ^[0-9]+$ ]]; then
   AUTOFIX_PUSH_ATTEMPTS=3
 fi
 
-# Count autofix commits on this branch only (not full repo history).
-# Use scope base ref when available, fall back to origin/main..HEAD,
-# then full log as last resort.
-# Match the prefix (not full subject) so informative suffixes don't break detection.
+# Count autofix commits on THIS PR branch only.
+# Scope: base_ref..HEAD counts only commits added by this PR, so autofix
+# commits on other PRs or merged to main never count against this branch.
+# Fallback: count consecutive autofix commits at HEAD (same logic as non-PR)
+# so we never accidentally count the entire repo history.
 BASE="$(scope_base_ref)"
 if [ -n "${BASE}" ]; then
   AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" "${BASE}..HEAD" 2>/dev/null | wc -l | xargs)
 elif [ -n "${GITHUB_BASE_REF:-}" ]; then
   AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" "origin/${GITHUB_BASE_REF}..HEAD" 2>/dev/null | wc -l | xargs)
 else
-  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" | wc -l | xargs)
+  # No base ref available — count consecutive autofix commits at HEAD.
+  # This prevents false positives from historical autofix commits on other branches.
+  AUTOFIX_COMMIT_COUNT=0
+  while IFS= read -r subject; do
+    if [[ "${subject}" == "${AUTOFIX_COMMIT_PREFIX}"* ]]; then
+      AUTOFIX_COMMIT_COUNT=$((AUTOFIX_COMMIT_COUNT + 1))
+    else
+      break
+    fi
+  done < <(git log --format=%s -n "$((AUTOFIX_MAX_COMMITS + 1))" 2>/dev/null)
 fi
 if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
-  echo "Skipping autofix: reached max autofix commits (${AUTOFIX_COMMIT_COUNT}/${AUTOFIX_MAX_COMMITS})"
+  echo "Skipping autofix: ${AUTOFIX_COMMIT_COUNT} autofix commits on this branch (max ${AUTOFIX_MAX_COMMITS})"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -9,17 +9,21 @@ if ! [[ "${AUTOFIX_MAX_COMMITS}" =~ ^[0-9]+$ ]]; then
   AUTOFIX_MAX_COMMITS=2
 fi
 
-# Count autofix commits since the last release tag, not the entire repo history.
-# Without this scoping, past autofix commits permanently count against the limit,
-# turning the loop guard into a permanent shutoff after N total historical commits.
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-if [ -n "${LAST_TAG}" ]; then
-  AUTOFIX_COMMIT_COUNT=$(git log "${LAST_TAG}..HEAD" --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" | wc -l | xargs)
-else
-  AUTOFIX_COMMIT_COUNT=$(git log --oneline --grep "^${AUTOFIX_COMMIT_PREFIX}" | wc -l | xargs)
-fi
+# Count consecutive autofix commits at HEAD. A human commit resets the counter.
+# This prevents runaway autofix-PR loops while allowing autofix to resume after
+# any human merge. The old approach (count all autofix commits since last tag)
+# permanently tripped the guard after N total historical autofix commits across
+# all PRs, blocking all future autofix even after human intervention.
+AUTOFIX_COMMIT_COUNT=0
+while IFS= read -r subject; do
+  if [[ "${subject}" == "${AUTOFIX_COMMIT_PREFIX}"* ]]; then
+    AUTOFIX_COMMIT_COUNT=$((AUTOFIX_COMMIT_COUNT + 1))
+  else
+    break
+  fi
+done < <(git log --format=%s -n "$((AUTOFIX_MAX_COMMITS + 1))" 2>/dev/null)
 if [ "${AUTOFIX_COMMIT_COUNT}" -ge "${AUTOFIX_MAX_COMMITS}" ]; then
-  echo "Skipping non-PR autofix: reached max autofix commits since ${LAST_TAG:-beginning} (${AUTOFIX_COMMIT_COUNT}/${AUTOFIX_MAX_COMMITS})"
+  echo "Skipping non-PR autofix: ${AUTOFIX_COMMIT_COUNT} consecutive autofix commits at HEAD (max ${AUTOFIX_MAX_COMMITS})"
   echo "committed=false" >> "${GITHUB_OUTPUT}"
   exit 0
 fi


### PR DESCRIPTION
## Summary
- Non-PR autofix loop guard was permanently tripped (20/3 commits since last tag), blocking all autofix in the release pipeline
- Root cause: counter counted ALL autofix commits since last release tag, not consecutive runs — human merges between autofix PRs didn't reset it
- This created a deadlock: release needs audit green → audit fails on drift → autofix would fix it → loop guard blocks autofix → no release → no tag → counter never resets

## Changes

### `prepare-autofix-branch.sh` (non-PR / release context)
**Before:** Count autofix commits since last release tag  
**After:** Count consecutive autofix commits at HEAD  

A human commit (merge, manual fix) resets the counter to 0. Only triggers when N autofix commits land in a row with zero human intervention — which is the actual runaway loop we're guarding against.

### `apply-autofix-commit.sh` (PR context)
**Before:** Fallback path counted entire repo history  
**After:** Fallback uses same consecutive-at-HEAD logic  

The primary PR paths (base_ref..HEAD) were already correctly scoped. Only the fallback (no base ref available) was broken.

## How to verify
After this ships, the next release pipeline run should:
1. Run `audit` → detect drift (52 new findings vs stale baseline)
2. Run `audit --fix --write` (autofix is now unblocked)
3. Baseline update included in autofix commit
4. Re-run audit → drift resolved → release proceeds