### PR TITLE
feat: include finding categories in autofix PR body and commit message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -341,6 +341,7 @@ runs:
         RESULTS: ${{ steps.rerun-commands.outputs.results }}
         AUTOFIX_FILE_COUNT: ${{ steps.autofix-prepare-nonpr.outputs.autofix-file-count }}
         AUTOFIX_FIX_TYPES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-fix-types }}
+        AUTOFIX_FINDING_TYPES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-finding-types }}
       run: bash ${{ github.action_path }}/scripts/autofix/open-autofix-pr.sh
 
     - name: Select final results

--- a/scripts/autofix/open-autofix-pr.sh
+++ b/scripts/autofix/open-autofix-pr.sh
@@ -42,9 +42,15 @@ elif [ -n "${AUTOFIX_FILE_COUNT:-}" ]; then
   AUTOFIX_DETAIL="- **${AUTOFIX_FILE_COUNT}** file(s) fixed"
 fi
 
+FINDING_DETAIL=""
+if [ -n "${AUTOFIX_FINDING_TYPES:-}" ]; then
+  FINDING_DETAIL="- **Finding categories:** ${AUTOFIX_FINDING_TYPES}"
+fi
+
 cat > "${BODY_FILE}" <<EOF
 ## Summary
 ${AUTOFIX_DETAIL:+${AUTOFIX_DETAIL}
+}${FINDING_DETAIL:+${FINDING_DETAIL}
 }- Rerun after autofix passed for configured command set.
 - Generated automatically by Homeboy Action.
 

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -76,10 +76,14 @@ AUTOFIX_BRANCH="ci/autofix/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 echo "Creating autofix branch: ${AUTOFIX_BRANCH}"
 git checkout -b "${AUTOFIX_BRANCH}"
 
+AUTOFIX_OUTPUT_DIR=$(mktemp -d)
+
 echo "Applying non-PR autofixes..."
+FIX_INDEX=0
 for FIX_CMD in "${FIX_ARRAY[@]}"; do
   FIX_CMD=$(echo "${FIX_CMD}" | xargs)
-  BASE_CMD="$(build_autofix_command "${FIX_CMD}" "${COMP_ID}" "${WORKSPACE}")"
+  OUTPUT_FILE="${AUTOFIX_OUTPUT_DIR}/fix-${FIX_INDEX}.json"
+  BASE_CMD="$(build_autofix_command "${FIX_CMD}" "${COMP_ID}" "${WORKSPACE}" "${OUTPUT_FILE}")"
 
   echo "Running autofix: ${BASE_CMD}"
   set +e
@@ -90,6 +94,7 @@ for FIX_CMD in "${FIX_ARRAY[@]}"; do
   if [ "${FIX_EXIT}" -ne 0 ]; then
     echo "Autofix command exited non-zero (${FIX_EXIT}), continuing to inspect generated changes"
   fi
+  FIX_INDEX=$((FIX_INDEX + 1))
 done
 
 # Update baseline so it stays current when this commit merges to main.
@@ -121,7 +126,7 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
-# Capture autofix summary: file count and which fix commands ran
+# Capture autofix summary: file count, fix commands, and finding categories
 AUTOFIX_FILE_COUNT=$(git diff --cached --name-only | wc -l | xargs)
 AUTOFIX_FIX_TYPES=""
 for FIX_CMD in "${FIX_ARRAY[@]}"; do
@@ -133,7 +138,23 @@ for FIX_CMD in "${FIX_ARRAY[@]}"; do
   AUTOFIX_FIX_TYPES+="${BASE}"
 done
 
-COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}")"
+# Extract finding categories from autofix JSON output.
+# Looks for fix_summary.rules[].rule or data.findings[].kind in the output files.
+AUTOFIX_FINDING_TYPES=""
+if [ -d "${AUTOFIX_OUTPUT_DIR}" ]; then
+  AUTOFIX_FINDING_TYPES="$(jq -r '
+    [
+      .. | .fix_summary? // empty | .rules? // empty | .[]? | .rule? // empty
+    ]
+    | map(select(type == "string" and length > 0))
+    | unique
+    | sort
+    | join(", ")
+  ' "${AUTOFIX_OUTPUT_DIR}"/*.json 2>/dev/null | tail -n 1)"
+fi
+rm -rf "${AUTOFIX_OUTPUT_DIR}"
+
+COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_FINDING_TYPES}")"
 
 BOT_NAME="homeboy-ci[bot]"
 BOT_EMAIL="266378653+homeboy-ci[bot]@users.noreply.github.com"
@@ -161,3 +182,4 @@ echo "committed=true" >> "${GITHUB_OUTPUT}"
 echo "autofix-branch=${AUTOFIX_BRANCH}" >> "${GITHUB_OUTPUT}"
 echo "autofix-file-count=${AUTOFIX_FILE_COUNT}" >> "${GITHUB_OUTPUT}"
 echo "autofix-fix-types=${AUTOFIX_FIX_TYPES}" >> "${GITHUB_OUTPUT}"
+echo "autofix-finding-types=${AUTOFIX_FINDING_TYPES}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- Autofix PRs now show **which audit finding categories** were fixed, not just "23 files fixed via audit"
- Finding types extracted from `--output` JSON files written by the fix commands

## Before
```
## Summary
- **23** file(s) fixed via **audit**
- Rerun after autofix passed for configured command set.
```

## After
```
## Summary
- **23** file(s) fixed via **audit**
- **Finding categories:** orphaned_test, stale_doc_reference, unreferenced_export, duplicate_function
- Rerun after autofix passed for configured command set.
```

Commit message also includes finding types:
```
chore(ci): homeboy autofix — audit [orphaned_test, stale_doc_ref] (23 files)
```

## Changes
- `prepare-autofix-branch.sh`: Pass `--output` file to fix commands, extract finding types with jq
- `open-autofix-pr.sh`: Add finding categories line to PR body
- `action.yml`: Wire `autofix-finding-types` output through to PR creation step