### PR TITLE
fix: validate autofix changes compile before committing

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -271,6 +271,17 @@ while [ "${PUSH_ATTEMPT}" -le "${AUTOFIX_PUSH_ATTEMPTS}" ]; do
     exit 0
   fi
 
+  # Validate that autofix changes compile before committing (#832).
+  if ! validate_autofix_compilation "${WORKSPACE}" "${COMP_ID}"; then
+    echo "Aborting autofix commit — changes do not compile"
+    git reset HEAD -- .
+    git checkout -- .
+    git clean -fd 2>/dev/null || true
+    echo "status=validation-failed" >> "${GITHUB_OUTPUT}"
+    echo "committed=false" >> "${GITHUB_OUTPUT}"
+    exit 0
+  fi
+
   commit_autofix_changes
 
   if push_autofix_commit; then

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -138,6 +138,22 @@ if git diff --cached --quiet; then
   exit 0
 fi
 
+# Validate that autofix changes compile before committing.
+# The validate_write gate catches this locally, but CI autofix runs through
+# a different path. This prevents shipping broken decompositions (#832).
+if [ "${BASELINE_ONLY}" != true ]; then
+  if ! validate_autofix_compilation "${WORKSPACE}" "${COMP_ID}"; then
+    echo "Aborting autofix commit — rolling back staged changes"
+    git reset HEAD -- .
+    git checkout -- .
+    git clean -fd 2>/dev/null || true
+    git checkout -
+    git branch -D "${AUTOFIX_BRANCH}"
+    echo "committed=false" >> "${GITHUB_OUTPUT}"
+    exit 0
+  fi
+fi
+
 # Capture autofix summary: file count, fix commands, and finding categories
 AUTOFIX_FILE_COUNT=$(git diff --cached --name-only | wc -l | xargs)
 AUTOFIX_CHANGED_FILES="$(git diff --cached --name-only | sort)"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -187,6 +187,68 @@ command_output_stem() {
   printf '%s\n' "${stem}"
 }
 
+# Validate that staged autofix changes compile.
+#
+# Ideally this would use the component's extension validate script (scripts.validate
+# in the extension manifest), but there's no `homeboy validate` CLI command yet.
+# As a pragmatic fallback, detect the project type from workspace files and run
+# the appropriate compiler check. This is a safety net — the proper fix is to wire
+# validate_write into the refactor pipeline's chunk verifier.
+#
+# Returns 0 if valid (or no validator found), 1 if compilation fails.
+validate_autofix_compilation() {
+  local workspace="${1:-.}"
+  local component_id="${2:-}"
+
+  # Try homeboy's own build command first (uses extension configuration)
+  if [ -n "${component_id}" ] && command -v homeboy &> /dev/null; then
+    echo "Validating autofix changes via homeboy build..."
+    set +e
+    homeboy build "${component_id}" --path "${workspace}" 2>&1 | tail -30
+    local hb_exit=${PIPESTATUS[0]}
+    set -e
+
+    if [ "${hb_exit}" -ne 0 ]; then
+      echo "::error::Autofix changes do not compile (homeboy build exit ${hb_exit})"
+      return 1
+    fi
+    echo "Autofix changes compile successfully (homeboy build)"
+    return 0
+  fi
+
+  # Fallback: detect project type from workspace files
+  local validate_cmd=""
+  if [ -f "${workspace}/Cargo.toml" ]; then
+    validate_cmd="cargo check --manifest-path ${workspace}/Cargo.toml"
+  elif [ -f "${workspace}/tsconfig.json" ]; then
+    validate_cmd="npx tsc --noEmit --project ${workspace}/tsconfig.json"
+  elif [ -f "${workspace}/composer.json" ]; then
+    # PHP: check syntax on changed files
+    validate_cmd="git diff --cached --name-only --diff-filter=ACMR -- '*.php' | xargs -r -n1 php -l"
+  elif [ -f "${workspace}/go.mod" ]; then
+    validate_cmd="go vet ./..."
+  fi
+
+  if [ -z "${validate_cmd}" ]; then
+    echo "No compilation validator detected — skipping"
+    return 0
+  fi
+
+  echo "Validating autofix changes compile: ${validate_cmd}"
+  set +e
+  eval "${validate_cmd}" 2>&1 | tail -30
+  local exit_code=${PIPESTATUS[0]}
+  set -e
+
+  if [ "${exit_code}" -ne 0 ]; then
+    echo "::error::Autofix changes do not compile (exit ${exit_code})"
+    return 1
+  fi
+
+  echo "Autofix changes compile successfully"
+  return 0
+}
+
 build_autofix_command() {
   local fix_cmd="$1"
   local component_id="$2"


### PR DESCRIPTION
## Summary

Safety net for #832. Validates that autofix changes compile before committing them.

## What it does

New `validate_autofix_compilation()` function in `lib.sh`:
- Detects project type from workspace files (`Cargo.toml` → `cargo check`, `tsconfig.json` → `tsc --noEmit`, `go.mod` → `go vet`)
- Runs the compiler after autofix changes are staged but before commit
- If compilation fails: abort, rollback staged changes, exit cleanly
- If no validator detected: skip (don't block non-compiled projects)

Applied to both:
- **PR context** (`apply-autofix-commit.sh`) — between staging and committing in the retry loop
- **Non-PR context** (`prepare-autofix-branch.sh`) — between staging and committing, skipped for baseline-only updates

## Why

PR #831 demonstrated the failure: autofix decomposed `mod.rs` files, adding `mod` declarations without creating valid target files. The resulting commit didn't compile. This gate would have caught it and aborted.

## Companion PR

- Extra-Chill/homeboy#833 fixes the decompose path bug (root cause)
- This PR adds the safety net (defense in depth)