### PR TITLE
refactor: use `homeboy validate` instead of hardcoded language detection

### DIFF
--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -189,59 +189,29 @@ command_output_stem() {
 
 # Validate that staged autofix changes compile.
 #
-# Ideally this would use the component's extension validate script (scripts.validate
-# in the extension manifest), but there's no `homeboy validate` CLI command yet.
-# As a pragmatic fallback, detect the project type from workspace files and run
-# the appropriate compiler check. This is a safety net — the proper fix is to wire
-# validate_write into the refactor pipeline's chunk verifier.
+# Uses `homeboy validate` which runs the component's extension-provided
+# validation script (scripts.validate). This is language-agnostic — Rust
+# extensions run `cargo check`, WordPress runs `php -l`, TypeScript runs
+# `tsc --noEmit`, etc.
 #
-# Returns 0 if valid (or no validator found), 1 if compilation fails.
+# Returns 0 if valid (or no validator available), 1 if compilation fails.
 validate_autofix_compilation() {
   local workspace="${1:-.}"
   local component_id="${2:-}"
 
-  # Try homeboy's own build command first (uses extension configuration)
-  if [ -n "${component_id}" ] && command -v homeboy &> /dev/null; then
-    echo "Validating autofix changes via homeboy build..."
-    set +e
-    homeboy build "${component_id}" --path "${workspace}" 2>&1 | tail -30
-    local hb_exit=${PIPESTATUS[0]}
-    set -e
-
-    if [ "${hb_exit}" -ne 0 ]; then
-      echo "::error::Autofix changes do not compile (homeboy build exit ${hb_exit})"
-      return 1
-    fi
-    echo "Autofix changes compile successfully (homeboy build)"
+  if [ -z "${component_id}" ]; then
+    echo "No component ID for validation — skipping"
     return 0
   fi
 
-  # Fallback: detect project type from workspace files
-  local validate_cmd=""
-  if [ -f "${workspace}/Cargo.toml" ]; then
-    validate_cmd="cargo check --manifest-path ${workspace}/Cargo.toml"
-  elif [ -f "${workspace}/tsconfig.json" ]; then
-    validate_cmd="npx tsc --noEmit --project ${workspace}/tsconfig.json"
-  elif [ -f "${workspace}/composer.json" ]; then
-    # PHP: check syntax on changed files
-    validate_cmd="git diff --cached --name-only --diff-filter=ACMR -- '*.php' | xargs -r -n1 php -l"
-  elif [ -f "${workspace}/go.mod" ]; then
-    validate_cmd="go vet ./..."
-  fi
-
-  if [ -z "${validate_cmd}" ]; then
-    echo "No compilation validator detected — skipping"
-    return 0
-  fi
-
-  echo "Validating autofix changes compile: ${validate_cmd}"
+  echo "Validating autofix changes compile..."
   set +e
-  eval "${validate_cmd}" 2>&1 | tail -30
+  homeboy validate "${component_id}" --path "${workspace}" 2>&1 | tail -30
   local exit_code=${PIPESTATUS[0]}
   set -e
 
   if [ "${exit_code}" -ne 0 ]; then
-    echo "::error::Autofix changes do not compile (exit ${exit_code})"
+    echo "::error::Autofix changes do not compile (homeboy validate exit ${exit_code})"
     return 1
   fi
 


### PR DESCRIPTION
## Summary

Replaces the inline language-detection heuristics with `homeboy validate`.

### Before (40 lines)
```bash
if [ -f Cargo.toml ]; then cargo check ...
elif [ -f tsconfig.json ]; then tsc --noEmit ...
elif [ -f composer.json ]; then php -l ...
elif [ -f go.mod ]; then go vet ...
```

### After (10 lines)
```bash
homeboy validate "${component_id}" --path "${workspace}"
```

## Why

`homeboy validate` uses the extension system — it resolves `scripts.validate` from the component's extension manifest. Same validation path that local `--write` commands use. Language-agnostic by design, no heuristics.

## Depends on

- Extra-Chill/homeboy#834 (`homeboy validate` CLI command) — must be released before this PR takes effect in CI