### PR TITLE
feat: detailed autofix commit messages with per-category fix counts

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -172,19 +172,18 @@ homeboy.json"
       AUTOFIX_FIX_TYPES+="${BASE}"
     done
 
+    AUTOFIX_DETAILS=""
+    AUTOFIX_TOTAL_FIXES=""
     if [ -n "${HOMEBOY_OUTPUT_DIR:-}" ] && [ -d "${HOMEBOY_OUTPUT_DIR}" ]; then
-      AUTOFIX_FINDING_TYPES="$(jq -r '
-        [
-          .. | .fix_summary? // empty | .rules? // empty | .[]? | .rule? // empty
-        ]
-        | map(select(type == "string" and length > 0))
-        | unique
-        | sort
-        | join(", ")
-      ' "${HOMEBOY_OUTPUT_DIR}"/*.json 2>/dev/null | tail -n 1)"
+      local raw_details
+      raw_details="$(extract_fix_details_from_output "${HOMEBOY_OUTPUT_DIR}")"
+      if [ -n "${raw_details}" ]; then
+        AUTOFIX_TOTAL_FIXES="$(echo "${raw_details}" | head -1)"
+        AUTOFIX_DETAILS="$(echo "${raw_details}" | tail -n +2)"
+      fi
     fi
 
-    COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_FINDING_TYPES}")"
+    COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_DETAILS}" "${AUTOFIX_TOTAL_FIXES}")"
   fi
 
   BOT_NAME="homeboy-ci[bot]"

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -167,22 +167,18 @@ else
     AUTOFIX_FIX_TYPES+="${BASE}"
   done
 
-  # Extract finding categories from autofix JSON output.
-  # Looks for fix_summary.rules[].rule or data.findings[].kind in the output files.
-  AUTOFIX_FINDING_TYPES=""
+  AUTOFIX_DETAILS=""
+  AUTOFIX_TOTAL_FIXES=""
   if [ -d "${AUTOFIX_OUTPUT_DIR}" ]; then
-    AUTOFIX_FINDING_TYPES="$(jq -r '
-      [
-        .. | .fix_summary? // empty | .rules? // empty | .[]? | .rule? // empty
-      ]
-      | map(select(type == "string" and length > 0))
-      | unique
-      | sort
-      | join(", ")
-    ' "${AUTOFIX_OUTPUT_DIR}"/*.json 2>/dev/null | tail -n 1)"
+    local raw_details
+    raw_details="$(extract_fix_details_from_output "${AUTOFIX_OUTPUT_DIR}")"
+    if [ -n "${raw_details}" ]; then
+      AUTOFIX_TOTAL_FIXES="$(echo "${raw_details}" | head -1)"
+      AUTOFIX_DETAILS="$(echo "${raw_details}" | tail -n +2)"
+    fi
   fi
 
-  COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_FINDING_TYPES}")"
+  COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_DETAILS}" "${AUTOFIX_TOTAL_FIXES}")"
 fi
 rm -rf "${AUTOFIX_OUTPUT_DIR}"
 

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -11,26 +11,104 @@ source "${SCRIPT_DIR}/../scope/flags.sh"
 AUTOFIX_COMMIT_PREFIX="chore(ci): homeboy autofix"
 
 # Build an informative autofix commit message.
-# Subject: chore(ci): homeboy autofix — audit, lint (7 files)
-# Body: list of changed files for traceability.
+# Subject: chore(ci): homeboy autofix — audit (7 files, 33 fixes)
+# Body: per-category fix counts with affected files.
 build_autofix_commit_message() {
   local fix_types="$1"
   local file_count="$2"
-  local finding_types="${3:-}"
+  local fix_details="${3:-}"
+  local total_fixes="${4:-}"
 
   local subject="${AUTOFIX_COMMIT_PREFIX}"
   if [ -n "${fix_types}" ]; then
     subject="${subject} — ${fix_types}"
   fi
-  if [ -n "${finding_types}" ]; then
-    subject="${subject} [${finding_types}]"
+  subject="${subject} (${file_count} files"
+  if [ -n "${total_fixes}" ] && [ "${total_fixes}" != "0" ]; then
+    subject="${subject}, ${total_fixes} fixes"
   fi
-  subject="${subject} (${file_count} files)"
+  subject="${subject})"
 
-  local body
-  body="$(git diff --cached --name-only | sort)"
+  local body=""
+  if [ -n "${fix_details}" ]; then
+    body="${fix_details}"
+  else
+    body="$(git diff --cached --name-only | sort)"
+  fi
 
   printf '%s\n\n%s\n' "${subject}" "${body}"
+}
+
+# Extract a detailed fix breakdown from homeboy JSON output files.
+# Reads FixResult JSON and produces a human-readable summary grouped by fix category.
+# First line: total fix count. Remaining lines: per-category breakdown.
+extract_fix_details_from_output() {
+  local output_dir="$1"
+
+  # Find all JSON output files
+  local json_files
+  json_files=$(find "${output_dir}" -name '*.json' -type f 2>/dev/null)
+  if [ -z "${json_files}" ]; then
+    return
+  fi
+
+  # Use jq to aggregate fix details across all output files.
+  # Insertion kinds can be strings ("import_add") or objects ({"visibility_change": {...}}).
+  # We normalize to the top-level key name and map to human-readable labels.
+  # shellcheck disable=SC2086
+  jq -rs '
+    [.[] | .data // . ] | map(select(type == "object")) |
+
+    # Normalize insertion kind to a category string
+    def category:
+      if type == "string" then .
+      elif type == "object" then (keys[0] // "unknown")
+      else "unknown"
+      end;
+
+    # Human-readable category names
+    def humanize:
+      {
+        "function_removal": "Orphaned tests removed",
+        "visibility_change": "Visibility narrowed (pub → pub(crate))",
+        "reexport_removal": "Unused re-exports removed",
+        "import_add": "Missing imports added",
+        "method_stub": "Method stubs added",
+        "file_move": "Files moved",
+        "line_replacement": "Lines replaced",
+        "line_removal": "Lines removed",
+        "missing_test_file": "Test files generated"
+      }[.] // .;
+
+    # Collect insertions with normalized category
+    [.[].fixes // [] | .[] | .file as $file |
+      .insertions[]? | {cat: (.kind | category), file: $file}
+    ] as $insertions |
+
+    # Collect new files
+    [.[].new_files // [] | .[] | {cat: .finding, file}] as $new_files |
+
+    # Combine and group by category
+    ($insertions + $new_files) | group_by(.cat) |
+    map({
+      cat: .[0].cat,
+      count: length,
+      files: [.[].file] | unique | map(
+        split("/") | if length > 1 and .[-1] == "mod.rs"
+          then [.[-2], .[-1]] | join("/")
+          else .[-1]
+        end
+      ) | unique | sort
+    }) |
+    sort_by(-.count) |
+
+    # Total
+    (map(.count) | add // 0) as $total |
+
+    # Format: first line is total, rest is breakdown
+    "\($total)\n" +
+    (map("\(.cat | humanize): \(.count)\n  \(.files | join(", "))") | join("\n"))
+  ' ${json_files} 2>/dev/null || true
 }
 
 resolve_component_id() {


### PR DESCRIPTION
## Summary

- Autofix commit messages now include a structured breakdown: fix type, count, and affected files per category
- Replaces the old bare filename list with human-readable categories like "Orphaned tests removed: 28", "Visibility narrowed: 4", etc.
- Total fix count shown in subject line: `chore(ci): homeboy autofix — audit (12 files, 242 fixes)`
- `mod.rs` entries show parent directory for disambiguation (`auto/mod.rs` not just `mod.rs`)

## Before

```
chore(ci): homeboy autofix — audit (12 files)

homeboy.json
src/core/code_audit/comment_hygiene.rs
src/core/code_audit/compiler_warnings.rs
...
```

## After

```
chore(ci): homeboy autofix — audit (12 files, 242 fixes)

Orphaned tests removed: 156
  analyze.rs, apply.rs, baseline.rs, claims.rs, ...
Visibility narrowed (pub → pub(crate)): 35
  apply.rs, attachments.rs, contract.rs, ...
Unused re-exports removed: 25
  auto/mod.rs, component/mod.rs, deploy/mod.rs, ...
Test files generated: 16
  baseline_test.rs, command_test.rs, ...
Method stubs added: 6
  build.rs, changelog.rs, changes.rs, ...
Missing imports added: 3
  grammar.rs, report_test.rs
Files moved: 1
  deploy_test.rs
```

Closes Extra-Chill/homeboy#846.