### PR TITLE
feat: extend categorized auto-issues to cover lint and test findings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -407,9 +407,9 @@ runs:
         COMMENT_SECTION_TITLE_INPUT: ${{ inputs.comment-section-title }}
       run: bash ${{ github.action_path }}/scripts/pr/post-pr-comment.sh
 
-    - name: Auto-file categorized audit issues
+    - name: Auto-file categorized issues
       id: categorized-issues
-      if: always() && inputs.auto-issue == 'true' && github.event_name != 'pull_request' && steps.select-results.outputs.results != '' && contains(inputs.commands, 'audit') && steps.autofix-open-pr.outputs.created != 'true'
+      if: always() && inputs.auto-issue == 'true' && github.event_name != 'pull_request' && steps.select-results.outputs.results != '' && steps.autofix-open-pr.outputs.created != 'true'
       continue-on-error: true
       shell: bash
       env:

--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 #
-# File categorized GitHub issues from audit findings.
+# File categorized GitHub issues from audit, lint, and test findings.
 #
 # Instead of one monolithic issue per CI run, creates one issue per finding
 # category (kind). Each issue is deduplicated — if an open issue for that
-# category already exists, it's updated with a comment.
+# category already exists, it's updated with the new count.
 #
-# This is the "code factory" pattern: unfixable audit findings become the
+# This is the "code factory" pattern: unfixable findings become the
 # roadmap for improving the autofix system. Each category issue closes when
 # its fix kind gets automated.
+#
+# Supports three command types:
+#   audit  — groups by finding kind (e.g. missing_method, dead_code_marker)
+#   lint   — groups by category (e.g. security, i18n) or single aggregate
+#   test   — groups by failure cluster category or single aggregate
 #
 # Env vars:
 #   HOMEBOY_OUTPUT_DIR    — directory with command log files
@@ -35,266 +40,555 @@ HOMEBOY_EXTENSION_ID="${HOMEBOY_EXTENSION_ID:-auto}"
 HOMEBOY_ACTION_REF="${HOMEBOY_ACTION_REF:-unknown}"
 HOMEBOY_ACTION_REPOSITORY="${HOMEBOY_ACTION_REPOSITORY:-unknown}"
 
-AUDIT_JSON="${OUTPUT_DIR}/audit.json"
+# Track totals across all command types
+TOTAL_ISSUES_CREATED=0
+TOTAL_ISSUES_UPDATED=0
+TOTAL_ISSUES_CLOSED=0
+COMMANDS_PROCESSED=0
 
-# --- Step 1: Read audit findings from structured JSON ---
+# ─────────────────────────────────────────────────────────────────────────────
+# Normalizers: each command type produces the same intermediate JSON format
+#
+#   {
+#     "groups": { "kind_key": [ {file, description, suggestion}, ... ], ... },
+#     "total_findings": N,
+#     "component_id": "comp"
+#   }
+#
+# For aggregate-only results (no per-finding detail), groups has one key:
+#   { "groups": { "_aggregate": [] }, "total_findings": N, "aggregate": true }
+# ─────────────────────────────────────────────────────────────────────────────
 
-# The structured audit JSON extracted by run-homeboy-commands.sh is the
-# canonical action-side contract. If it is missing or invalid, let generic
-# issue filing handle the failure instead of scraping logs here.
-if [ -f "${AUDIT_JSON}" ] && [ -s "${AUDIT_JSON}" ]; then
-  FINDINGS_JSON=$(python3 -c "
+normalize_audit_json() {
+  local json_file="$1"
+  python3 -c "
 import json, sys
 payload = json.load(open(sys.argv[1]))
 data = payload.get('data', {})
 findings = data.get('findings', [])
-summary = data.get('summary', {})
 component = data.get('component_id', '')
 groups = {}
 for f in findings:
     kind = f.get('kind', 'unknown')
-    groups.setdefault(kind, []).append(f)
+    groups.setdefault(kind, []).append({
+        'file': f.get('file', 'unknown'),
+        'description': f.get('description', ''),
+        'suggestion': f.get('suggestion', '')
+    })
 print(json.dumps({
     'groups': {k: v for k, v in sorted(groups.items(), key=lambda x: -len(x[1]))},
-    'summary': summary,
     'component_id': component,
     'total_findings': len(findings)
 }))
-" "${AUDIT_JSON}" 2>/dev/null) || {
-    echo "Failed to read structured audit.json — falling back to generic issue filing"
-    FINDINGS_JSON=""
-  }
-fi
+" "${json_file}" 2>/dev/null
+}
 
-if [ -z "${FINDINGS_JSON:-}" ]; then
-  echo "Structured audit.json missing — falling back to generic issue filing"
-  exit 1
-fi
+normalize_lint_json() {
+  local json_file="$1"
+  python3 -c "
+import json, sys
+payload = json.load(open(sys.argv[1]))
+data = payload.get('data', {})
+status = data.get('status', 'unknown')
 
-TOTAL_FINDINGS=$(echo "${FINDINGS_JSON}" | jq -r '.total_findings')
-COMPONENT_FROM_AUDIT=$(echo "${FINDINGS_JSON}" | jq -r '.component_id // empty')
-if [ -n "${COMPONENT_FROM_AUDIT}" ]; then
-  COMP_ID="${COMPONENT_FROM_AUDIT}"
-fi
+# Primary: use lint_findings grouped by category (available with baseline)
+lint_findings = data.get('lint_findings', [])
+if lint_findings:
+    groups = {}
+    for f in lint_findings:
+        cat = f.get('category', 'uncategorized')
+        groups.setdefault(cat, []).append({
+            'file': f.get('id', '').split('::')[0] if '::' in f.get('id', '') else 'unknown',
+            'description': f.get('message', ''),
+            'suggestion': ''
+        })
+    print(json.dumps({
+        'groups': {k: v for k, v in sorted(groups.items(), key=lambda x: -len(x[1]))},
+        'component_id': data.get('component', ''),
+        'total_findings': len(lint_findings)
+    }))
+    sys.exit(0)
 
-# --- Step 1b: Close resolved issues ---
+# Fallback: baseline_comparison has new_items (items above baseline)
+bc = data.get('baseline_comparison', {})
+if bc:
+    new_items = bc.get('new_items', [])
+    if new_items:
+        groups = {}
+        for item in new_items:
+            label = item.get('context_label', 'lint:unknown')
+            # context_label format: 'lint:category' — extract category
+            cat = label.split(':', 1)[-1] if ':' in label else label
+            groups.setdefault(cat, []).append({
+                'file': 'unknown',
+                'description': item.get('description', ''),
+                'suggestion': ''
+            })
+        print(json.dumps({
+            'groups': {k: v for k, v in sorted(groups.items(), key=lambda x: -len(x[1]))},
+            'component_id': data.get('component', ''),
+            'total_findings': len(new_items)
+        }))
+        sys.exit(0)
+    delta = bc.get('delta', 0)
+    if delta > 0:
+        # Baseline regression but no itemized findings — aggregate
+        print(json.dumps({
+            'groups': {'_aggregate': []},
+            'component_id': data.get('component', ''),
+            'total_findings': delta,
+            'aggregate': True,
+            'aggregate_label': str(delta) + ' new findings above baseline'
+        }))
+        sys.exit(0)
+
+# Last resort: lint failed but no structured findings — single aggregate issue
+if status == 'failed':
+    exit_code = data.get('exit_code', 1)
+    print(json.dumps({
+        'groups': {'_aggregate': []},
+        'component_id': data.get('component', ''),
+        'total_findings': exit_code,
+        'aggregate': True,
+        'aggregate_label': 'lint failure (exit ' + str(exit_code) + ')'
+    }))
+    sys.exit(0)
+
+# Lint passed — report zero findings (triggers auto-close of resolved issues)
+print(json.dumps({
+    'groups': {},
+    'component_id': data.get('component', ''),
+    'total_findings': 0
+}))
+" "${json_file}" 2>/dev/null
+}
+
+normalize_test_json() {
+  local json_file="$1"
+  python3 -c "
+import json, sys
+payload = json.load(open(sys.argv[1]))
+data = payload.get('data', {})
+status = data.get('status', 'unknown')
+component = data.get('component', '')
+
+# Primary: use analysis clusters (detailed failure grouping)
+analysis = data.get('analysis', {})
+if analysis and analysis.get('clusters'):
+    clusters = analysis['clusters']
+    groups = {}
+    for c in clusters:
+        cat = c.get('category', 'unknown')
+        count = c.get('count', 1)
+        for test in c.get('example_tests', [])[:count]:
+            groups.setdefault(cat, []).append({
+                'file': ', '.join(c.get('affected_files', ['unknown'])[:3]),
+                'description': c.get('pattern', ''),
+                'suggestion': c.get('suggested_fix', '')
+            })
+        # If example_tests is empty or less than count, pad with the cluster info
+        existing = len(groups.get(cat, []))
+        for _ in range(count - existing):
+            groups.setdefault(cat, []).append({
+                'file': ', '.join(c.get('affected_files', ['unknown'])[:3]),
+                'description': c.get('pattern', ''),
+                'suggestion': c.get('suggested_fix', '')
+            })
+    total = analysis.get('total_failures', sum(len(v) for v in groups.values()))
+    print(json.dumps({
+        'groups': {k: v for k, v in sorted(groups.items(), key=lambda x: -len(x[1]))},
+        'component_id': component,
+        'total_findings': total
+    }))
+    sys.exit(0)
+
+# Secondary: use summary.failures (from --json-summary)
+summary = data.get('summary', {})
+if summary and summary.get('failures'):
+    failures = summary['failures']
+    groups = {}
+    for f in failures:
+        # Group by file
+        file_key = f.get('file', 'unknown')
+        groups.setdefault(file_key, []).append({
+            'file': file_key,
+            'description': f.get('test_name', '') + ': ' + f.get('message', ''),
+            'suggestion': ''
+        })
+    print(json.dumps({
+        'groups': {k: v for k, v in sorted(groups.items(), key=lambda x: -len(x[1]))},
+        'component_id': component,
+        'total_findings': len(failures)
+    }))
+    sys.exit(0)
+
+# Fallback: test_counts show failures — single aggregate issue
+counts = data.get('test_counts', {})
+failed = counts.get('failed', 0)
+if failed > 0:
+    total = counts.get('total', 0)
+    print(json.dumps({
+        'groups': {'_aggregate': []},
+        'component_id': component,
+        'total_findings': failed,
+        'aggregate': True,
+        'aggregate_label': str(failed) + ' failures out of ' + str(total) + ' tests'
+    }))
+    sys.exit(0)
+
+# Baseline regression check
+bc = data.get('baseline_comparison', {})
+if bc and bc.get('regression', False):
+    delta = abs(bc.get('failed_delta', 0))
+    print(json.dumps({
+        'groups': {'_aggregate': []},
+        'component_id': component,
+        'total_findings': max(delta, 1),
+        'aggregate': True,
+        'aggregate_label': str(delta) + ' new test regressions'
+    }))
+    sys.exit(0)
+
+# Test passed or no failure info
+if status == 'failed':
+    exit_code = data.get('exit_code', 1)
+    print(json.dumps({
+        'groups': {'_aggregate': []},
+        'component_id': component,
+        'total_findings': exit_code,
+        'aggregate': True,
+        'aggregate_label': 'test failure (exit ' + str(exit_code) + ')'
+    }))
+    sys.exit(0)
+
+# Tests passed — zero findings
+print(json.dumps({
+    'groups': {},
+    'component_id': component,
+    'total_findings': 0
+}))
+" "${json_file}" 2>/dev/null
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# close_resolved_issues CMD_TYPE COMP_ID CURRENT_KINDS_TEXT
 #
-# If a category has zero findings now but has an open issue, close it.
-# This runs even when TOTAL_FINDINGS is 0 (all categories resolved).
+# Close issues for categories that no longer have findings.
+# ─────────────────────────────────────────────────────────────────────────────
 
-EXISTING_ISSUES_FOR_CLOSE=$(gh api "repos/${REPO}/issues?state=open&labels=audit&per_page=100" \
-  --jq '[.[] | {number: .number, title: .title}]' 2>/dev/null || echo "[]")
+close_resolved_issues() {
+  local cmd_type="$1"
+  local comp_id="$2"
+  local current_kinds="$3"
+  local closed=0
 
-# Extract current finding kinds (empty if no findings)
-CURRENT_KINDS=""
-if [ "${TOTAL_FINDINGS}" != "0" ] && [ "${TOTAL_FINDINGS}" != "null" ]; then
-  CURRENT_KINDS=$(echo "${FINDINGS_JSON}" | jq -r '.groups | keys[]' 2>/dev/null || true)
-fi
+  local existing_issues
+  existing_issues=$(gh api "repos/${REPO}/issues?state=open&labels=${cmd_type}&per_page=100" \
+    --jq '[.[] | {number: .number, title: .title}]' 2>/dev/null || echo "[]")
 
-ISSUES_CLOSED=0
+  while IFS= read -r ISSUE_LINE; do
+    [ -z "${ISSUE_LINE}" ] && continue
 
-# Check each existing audit issue — if its category is no longer in findings, close it
-while IFS= read -r ISSUE_LINE; do
-  [ -z "${ISSUE_LINE}" ] && continue
+    local issue_num issue_title
+    issue_num=$(echo "${ISSUE_LINE}" | jq -r '.number')
+    issue_title=$(echo "${ISSUE_LINE}" | jq -r '.title')
 
-  ISSUE_NUM=$(echo "${ISSUE_LINE}" | jq -r '.number')
-  ISSUE_TITLE=$(echo "${ISSUE_LINE}" | jq -r '.title')
+    # Match our component only
+    if ! echo "${issue_title}" | grep -q "in ${comp_id}"; then
+      continue
+    fi
 
-  # Extract the kind from the issue title: "audit: {kind_label} in {component} ({count})"
-  # Match our component only
-  if ! echo "${ISSUE_TITLE}" | grep -q "in ${COMP_ID}"; then
-    continue
-  fi
+    # Extract kind_label: everything between "{cmd_type}: " and " in {component}"
+    local kind_label kind_key
+    kind_label=$(echo "${issue_title}" | sed -n "s/^${cmd_type}: \(.*\) in ${comp_id}.*/\1/p")
+    [ -z "${kind_label}" ] && continue
 
-  # Extract kind_label: everything between "audit: " and " in {component}"
-  KIND_LABEL=$(echo "${ISSUE_TITLE}" | sed -n "s/^audit: \(.*\) in ${COMP_ID}.*/\1/p")
-  [ -z "${KIND_LABEL}" ] && continue
+    # Convert kind_label back to kind key (spaces → underscores)
+    kind_key=$(echo "${kind_label}" | tr ' ' '_')
 
-  # Convert kind_label back to kind (spaces → underscores)
-  KIND_KEY=$(echo "${KIND_LABEL}" | tr ' ' '_')
+    # Check if this kind still has findings
+    if [ -n "${current_kinds}" ] && echo "${current_kinds}" | grep -qx "${kind_key}" 2>/dev/null; then
+      continue  # Still has findings — will be updated below
+    fi
 
-  # Check if this kind still has findings
-  if echo "${CURRENT_KINDS}" | grep -qx "${KIND_KEY}" 2>/dev/null; then
-    continue  # Still has findings — will be updated below
-  fi
-
-  # No findings for this category — close the issue
-  CLOSE_COMMENT="All **${KIND_LABEL}** findings have been resolved. Closing automatically.
+    # No findings for this category — close the issue
+    local close_comment="All **${kind_label}** findings have been resolved. Closing automatically.
 
 Resolved by the [code factory pipeline](${RUN_URL}). If findings reappear, a new issue will be filed."
 
-  gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
-    --method POST \
-    --field body="${CLOSE_COMMENT}" > /dev/null 2>&1 || true
+    gh api "repos/${REPO}/issues/${issue_num}/comments" \
+      --method POST \
+      --field body="${close_comment}" > /dev/null 2>&1 || true
 
-  gh api "repos/${REPO}/issues/${ISSUE_NUM}" \
-    --method PATCH \
-    --field state="closed" \
-    --field state_reason="completed" > /dev/null 2>&1 || true
+    gh api "repos/${REPO}/issues/${issue_num}" \
+      --method PATCH \
+      --field state="closed" \
+      --field state_reason="completed" > /dev/null 2>&1 || true
 
-  ISSUES_CLOSED=$((ISSUES_CLOSED + 1))
-  echo "  Closed issue #${ISSUE_NUM}: ${ISSUE_TITLE} (zero findings remaining)"
-done <<< "$(echo "${EXISTING_ISSUES_FOR_CLOSE}" | jq -c '.[]')"
+    closed=$((closed + 1))
+    echo "  Closed issue #${issue_num}: ${issue_title} (zero findings remaining)"
+  done <<< "$(echo "${existing_issues}" | jq -c '.[]')"
 
-if [ "${TOTAL_FINDINGS}" = "0" ] || [ "${TOTAL_FINDINGS}" = "null" ]; then
+  TOTAL_ISSUES_CLOSED=$((TOTAL_ISSUES_CLOSED + closed))
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# file_categorized_issues CMD_TYPE FINDINGS_JSON COMP_ID
+#
+# Create or update one issue per finding category.
+# ─────────────────────────────────────────────────────────────────────────────
+
+file_categorized_issues() {
+  local cmd_type="$1"
+  local findings_json="$2"
+  local comp_id="$3"
+
+  local total_findings is_aggregate
+  total_findings=$(echo "${findings_json}" | jq -r '.total_findings')
+  is_aggregate=$(echo "${findings_json}" | jq -r '.aggregate // false')
+
+  # Extract current kinds for close-resolution
+  local current_kinds=""
+  if [ "${total_findings}" != "0" ] && [ "${total_findings}" != "null" ]; then
+    current_kinds=$(echo "${findings_json}" | jq -r '.groups | keys[]' 2>/dev/null || true)
+  fi
+
+  # Close resolved issues for this command type
+  close_resolved_issues "${cmd_type}" "${comp_id}" "${current_kinds}"
+
+  if [ "${total_findings}" = "0" ] || [ "${total_findings}" = "null" ]; then
+    echo ""
+    echo "  No ${cmd_type} findings to file issues for"
+    return
+  fi
+
+  local cmd_label
+  cmd_label="$(echo "${cmd_type}" | sed 's/.*/\u&/')"  # Capitalize first letter
+
   echo ""
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "  No audit findings to file issues for"
-  if [ "${ISSUES_CLOSED}" -gt 0 ]; then
-    echo "  Issues closed: ${ISSUES_CLOSED}"
-  fi
+  echo "  Filing categorized ${cmd_type} issues for ${comp_id}"
+  echo "  Total findings: ${total_findings}"
+  echo "  Categories: $(echo "${findings_json}" | jq -r '.groups | keys | length')"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  exit 0
-fi
+  echo ""
 
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  Filing categorized issues for ${COMP_ID}"
-echo "  Total findings: ${TOTAL_FINDINGS}"
-echo "  Categories: $(echo "${FINDINGS_JSON}" | jq -r '.groups | keys | length')"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo ""
+  # Fetch existing open issues for this command type
+  local existing_issues
+  existing_issues=$(gh api "repos/${REPO}/issues?state=open&labels=${cmd_type}&per_page=100" \
+    --jq '[.[] | {number: .number, title: .title}]' 2>/dev/null || echo "[]")
 
-# --- Step 2: Fetch existing open issues to deduplicate ---
+  local kinds
+  kinds=$(echo "${findings_json}" | jq -r '.groups | keys[]')
 
-EXISTING_ISSUES=$(gh api "repos/${REPO}/issues?state=open&labels=audit&per_page=100" \
-  --jq '[.[] | {number: .number, title: .title}]' 2>/dev/null || echo "[]")
+  while IFS= read -r KIND; do
+    [ -z "${KIND}" ] && continue
 
-# --- Step 3: File one issue per finding category ---
+    local count kind_label issue_title title_prefix existing_number
+    count=$(echo "${findings_json}" | jq -r --arg k "${KIND}" '.groups[$k] | length')
 
-ISSUES_CREATED=0
-ISSUES_UPDATED=0
+    # For aggregate issues, use the aggregate_label and total count
+    if [ "${is_aggregate}" = "true" ] && [ "${KIND}" = "_aggregate" ]; then
+      local agg_label
+      agg_label=$(echo "${findings_json}" | jq -r '.aggregate_label // "failures"')
+      count="${total_findings}"
+      kind_label="${agg_label}"
+      issue_title="${cmd_type}: ${kind_label} in ${comp_id}"
+      title_prefix="${cmd_type}: "
+      # Match any issue for this cmd_type + component (aggregate issues update any existing)
+      existing_number=$(echo "${existing_issues}" | jq -r --arg prefix "${cmd_type}: " --arg comp "in ${comp_id}" \
+        '[.[] | select(.title | startswith($prefix) and contains($comp))] | first | .number // empty' 2>/dev/null || true)
+    else
+      kind_label=$(echo "${KIND}" | tr '_' ' ')
+      issue_title="${cmd_type}: ${kind_label} in ${comp_id} (${count})"
+      title_prefix="${cmd_type}: ${kind_label} in ${comp_id}"
+      existing_number=$(echo "${existing_issues}" | jq -r --arg prefix "${title_prefix}" \
+        '[.[] | select(.title | startswith($prefix))] | first | .number // empty' 2>/dev/null || true)
+    fi
 
-KINDS=$(echo "${FINDINGS_JSON}" | jq -r '.groups | keys[]')
+    # Build the findings table (only for non-aggregate issues with actual findings)
+    local findings_table="" truncated_note=""
+    if [ "${is_aggregate}" != "true" ] || [ "${KIND}" != "_aggregate" ]; then
+      findings_table+="| File | Description | Suggestion |"$'\n'
+      findings_table+="| --- | --- | --- |"$'\n'
 
-while IFS= read -r KIND; do
-  [ -z "${KIND}" ] && continue
+      local category_findings
+      category_findings=$(echo "${findings_json}" | jq -c --arg k "${KIND}" '.groups[$k][:50][]')
 
-  COUNT=$(echo "${FINDINGS_JSON}" | jq -r --arg k "${KIND}" '.groups[$k] | length')
+      while IFS= read -r FINDING; do
+        [ -z "${FINDING}" ] && continue
+        local file desc suggestion
+        file=$(echo "${FINDING}" | jq -r '.file // "unknown"')
+        desc=$(echo "${FINDING}" | jq -r '.description // "(no description)"' | sed 's/|/\\|/g')
+        suggestion=$(echo "${FINDING}" | jq -r '.suggestion // ""' | sed 's/|/\\|/g')
+        findings_table+="| \`${file}\` | ${desc} | ${suggestion} |"$'\n'
+      done <<< "${category_findings}"
 
-  # Build human-readable kind label
-  KIND_LABEL=$(echo "${KIND}" | tr '_' ' ')
+      if [ "${count}" -gt 50 ]; then
+        truncated_note=$'\n'"*Showing 50 of ${count} findings. Run \`homeboy ${cmd_type} ${comp_id}\` locally for the full list.*"$'\n'
+      fi
+    fi
 
-  # Issue title format: audit: {kind} in {component} ({count})
-  ISSUE_TITLE="audit: ${KIND_LABEL} in ${COMP_ID} (${COUNT})"
+    local body_file
+    body_file=$(mktemp)
 
-  # Check for existing open issue with same category prefix
-  # Match on "audit: {kind_label} in {component}" to allow count updates
-  TITLE_PREFIX="audit: ${KIND_LABEL} in ${COMP_ID}"
-  EXISTING_NUMBER=$(echo "${EXISTING_ISSUES}" | jq -r --arg prefix "${TITLE_PREFIX}" \
-    '[.[] | select(.title | startswith($prefix))] | first | .number // empty' 2>/dev/null || true)
+    if [ -n "${existing_number}" ]; then
+      # Update existing issue body + title
+      cat > "${body_file}" <<UPDATEEOF
+## ${cmd_label}: ${kind_label}
 
-  # Build the findings table for this category
-  FINDINGS_TABLE=""
-  FINDINGS_TABLE+="| File | Description | Suggestion |"$'\n'
-  FINDINGS_TABLE+="| --- | --- | --- |"$'\n'
-
-  # Get findings for this kind (limit to 50 per issue to avoid GitHub body limits)
-  CATEGORY_FINDINGS=$(echo "${FINDINGS_JSON}" | jq -c --arg k "${KIND}" '.groups[$k][:50][]')
-
-  while IFS= read -r FINDING; do
-    [ -z "${FINDING}" ] && continue
-    FILE=$(echo "${FINDING}" | jq -r '.file // "unknown"')
-    DESC=$(echo "${FINDING}" | jq -r '.description // "(no description)"' | sed 's/|/\\|/g')
-    SUGGESTION=$(echo "${FINDING}" | jq -r '.suggestion // ""' | sed 's/|/\\|/g')
-    FINDINGS_TABLE+="| \`${FILE}\` | ${DESC} | ${SUGGESTION} |"$'\n'
-  done <<< "${CATEGORY_FINDINGS}"
-
-  TRUNCATED_NOTE=""
-  if [ "${COUNT}" -gt 50 ]; then
-    TRUNCATED_NOTE=$'\n'"*Showing 50 of ${COUNT} findings. Run \`homeboy audit ${COMP_ID}\` locally for the full list.*"$'\n'
-  fi
-
-  # Write the body to a temp file to avoid shell quoting issues with backticks
-  BODY_FILE=$(mktemp)
-
-  if [ -n "${EXISTING_NUMBER}" ]; then
-    # Update existing issue body + title (no comments — body is the source of truth)
-    cat > "${BODY_FILE}" <<UPDATEEOF
-## Audit: ${KIND_LABEL}
-
-**Component:** \`${COMP_ID}\`
-**Count:** ${COUNT} findings
+**Component:** \`${comp_id}\`
+**Count:** ${count} findings
 **Last run:** ${RUN_URL}
 **Updated:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
 **Homeboy:** \`${HOMEBOY_CLI_VERSION}\` | Action: \`${HOMEBOY_ACTION_REPOSITORY}@${HOMEBOY_ACTION_REF}\`
+UPDATEEOF
+
+      if [ -n "${findings_table}" ]; then
+        cat >> "${body_file}" <<TABLEEOF
 
 ### Findings
 
-${FINDINGS_TABLE}
-${TRUNCATED_NOTE}
+${findings_table}
+${truncated_note}
+TABLEEOF
+      fi
+
+      cat >> "${body_file}" <<'UPDATEFOOTEREOF'
 
 ---
 *Updated automatically by [Homeboy Action](https://github.com/Extra-Chill/homeboy-action) on each CI run until resolved.*
-UPDATEEOF
+UPDATEFOOTEREOF
 
-    gh api "repos/${REPO}/issues/${EXISTING_NUMBER}" \
-      --method PATCH \
-      --field title="${ISSUE_TITLE}" \
-      -F body=@"${BODY_FILE}" > /dev/null 2>&1 || true
+      gh api "repos/${REPO}/issues/${existing_number}" \
+        --method PATCH \
+        --field title="${issue_title}" \
+        -F body=@"${body_file}" > /dev/null 2>&1 || true
 
-    ISSUES_UPDATED=$((ISSUES_UPDATED + 1))
-    echo "  Updated issue #${EXISTING_NUMBER}: ${ISSUE_TITLE}"
-  else
-    # Create new issue
-    cat > "${BODY_FILE}" <<ISSUEEOF
-## Audit: ${KIND_LABEL}
+      TOTAL_ISSUES_UPDATED=$((TOTAL_ISSUES_UPDATED + 1))
+      echo "  Updated issue #${existing_number}: ${issue_title}"
+    else
+      # Create new issue
+      cat > "${body_file}" <<ISSUEEOF
+## ${cmd_label}: ${kind_label}
 
-**Component:** \`${COMP_ID}\`
-**Count:** ${COUNT} findings
+**Component:** \`${comp_id}\`
+**Count:** ${count} findings
 **Run:** ${RUN_URL}
 **Homeboy:** \`${HOMEBOY_CLI_VERSION}\` | Action: \`${HOMEBOY_ACTION_REPOSITORY}@${HOMEBOY_ACTION_REF}\`
 
 ### Context
 
-This issue was filed automatically because \`homeboy audit\` found **${COUNT}** \`${KIND_LABEL}\` findings that could not be auto-fixed.
+This issue was filed automatically because \`homeboy ${cmd_type}\` found **${count}** \`${kind_label}\` findings that could not be auto-fixed.
 
 Each finding in this category represents the same class of problem. Closing this issue means either:
 1. The findings are resolved in the codebase, or
 2. A new autofix rule handles them mechanically
+ISSUEEOF
+
+      if [ -n "${findings_table}" ]; then
+        cat >> "${body_file}" <<TABLEEOF
 
 ### Findings
 
-${FINDINGS_TABLE}
-${TRUNCATED_NOTE}
-ISSUEEOF
+${findings_table}
+${truncated_note}
+TABLEEOF
+      fi
 
-    if [ "${AUTOFIX_ATTEMPTED}" = "true" ]; then
-      cat >> "${BODY_FILE}" <<'AUTOFIXEOF'
+      if [ "${AUTOFIX_ATTEMPTED}" = "true" ]; then
+        cat >> "${body_file}" <<'AUTOFIXEOF'
 
 ### Autofix status
 
 Autofix was attempted before filing this issue. These findings are **not yet mechanically fixable** — they need either a new fixer rule or manual resolution.
 AUTOFIXEOF
-    fi
+      fi
 
-    cat >> "${BODY_FILE}" <<'FOOTEREOF'
+      cat >> "${body_file}" <<'FOOTEREOF'
 
 ---
 *Filed automatically by [Homeboy Action](https://github.com/Extra-Chill/homeboy-action). This issue updates on each CI run until resolved.*
 FOOTEREOF
 
-    # Try with audit label, fall back to no labels if it doesn't exist
-    gh api "repos/${REPO}/issues" \
-      --method POST \
-      --field title="${ISSUE_TITLE}" \
-      -F body=@"${BODY_FILE}" \
-      --field "labels[]=audit" > /dev/null 2>&1 || \
-    gh api "repos/${REPO}/issues" \
-      --method POST \
-      --field title="${ISSUE_TITLE}" \
-      -F body=@"${BODY_FILE}" > /dev/null 2>&1
+      # Try with command-type label, fall back to no labels if it doesn't exist
+      gh api "repos/${REPO}/issues" \
+        --method POST \
+        --field title="${issue_title}" \
+        -F body=@"${body_file}" \
+        --field "labels[]=${cmd_type}" > /dev/null 2>&1 || \
+      gh api "repos/${REPO}/issues" \
+        --method POST \
+        --field title="${issue_title}" \
+        -F body=@"${body_file}" > /dev/null 2>&1
 
-    ISSUES_CREATED=$((ISSUES_CREATED + 1))
-    echo "  Created issue: ${ISSUE_TITLE}"
+      TOTAL_ISSUES_CREATED=$((TOTAL_ISSUES_CREATED + 1))
+      echo "  Created issue: ${issue_title}"
+    fi
+
+    rm -f "${body_file}"
+  done <<< "${kinds}"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main: process each command type that produced structured JSON output
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Determine which commands were run from COMMANDS env or detect from JSON files
+IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS:-}"
+
+for CMD in "${CMD_ARRAY[@]}"; do
+  CMD=$(echo "${CMD}" | xargs)
+
+  # Only process command types we know how to normalize
+  case "${CMD}" in
+    audit|lint|test) ;;
+    *) continue ;;
+  esac
+
+  JSON_FILE="${OUTPUT_DIR}/${CMD}.json"
+
+  if [ ! -f "${JSON_FILE}" ] || [ ! -s "${JSON_FILE}" ]; then
+    echo "No structured ${CMD}.json found — skipping categorized issues for ${CMD}"
+    continue
   fi
 
-  rm -f "${BODY_FILE}"
-done <<< "${KINDS}"
+  # Normalize the JSON into the common intermediate format
+  FINDINGS_JSON=""
+  case "${CMD}" in
+    audit) FINDINGS_JSON=$(normalize_audit_json "${JSON_FILE}") ;;
+    lint)  FINDINGS_JSON=$(normalize_lint_json "${JSON_FILE}") ;;
+    test)  FINDINGS_JSON=$(normalize_test_json "${JSON_FILE}") ;;
+  esac
+
+  if [ -z "${FINDINGS_JSON}" ]; then
+    echo "Failed to normalize ${CMD}.json — skipping categorized issues for ${CMD}"
+    continue
+  fi
+
+  # Resolve component ID from the JSON if available
+  local_comp_id="${COMP_ID}"
+  COMPONENT_FROM_JSON=$(echo "${FINDINGS_JSON}" | jq -r '.component_id // empty')
+  if [ -n "${COMPONENT_FROM_JSON}" ]; then
+    local_comp_id="${COMPONENT_FROM_JSON}"
+  fi
+
+  # File issues for this command type
+  file_categorized_issues "${CMD}" "${FINDINGS_JSON}" "${local_comp_id}"
+  COMMANDS_PROCESSED=$((COMMANDS_PROCESSED + 1))
+done
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  Issues created: ${ISSUES_CREATED}"
-echo "  Issues updated: ${ISSUES_UPDATED}"
-echo "  Issues closed:  ${ISSUES_CLOSED}"
+echo "  Categorized issues summary"
+echo "  Commands processed: ${COMMANDS_PROCESSED}"
+echo "  Issues created: ${TOTAL_ISSUES_CREATED}"
+echo "  Issues updated: ${TOTAL_ISSUES_UPDATED}"
+echo "  Issues closed:  ${TOTAL_ISSUES_CLOSED}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Exit 1 if no commands were successfully processed — lets generic fallback handle it
+if [ "${COMMANDS_PROCESSED}" -eq 0 ]; then
+  echo "No commands produced valid structured output for categorized issues"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Extends the categorized auto-issue system (currently audit-only) to also handle **lint** and **test** command outputs. Closes #96.

- **Refactored** `auto-file-categorized-issues.sh` from audit-only to a multi-command normalizer system
- **Broadened** `action.yml` condition — categorized issues step runs for any command, not just audit
- **Generic fallback preserved** — `auto-file-issue.sh` only fires when no structured JSON can be normalized

## How it works

Each command type has a Python normalizer that produces a common intermediate format:

```
┌──────────┐     ┌────────────────┐     ┌──────────────────┐
│ audit.json│ ──► │ normalize_audit │ ──► │                  │
└──────────┘     └────────────────┘     │  Common format:  │
┌──────────┐     ┌────────────────┐     │  {groups, total, │ ──► create/update/close
│  lint.json│ ──► │ normalize_lint  │ ──► │   component_id}  │     GitHub issues
└──────────┘     └────────────────┘     │                  │
┌──────────┐     ┌────────────────┐     │                  │
│  test.json│ ──► │ normalize_test  │ ──► │                  │
└──────────┘     └────────────────┘     └──────────────────┘
```

### Lint normalization priority
1. `lint_findings[]` grouped by `category` (security, i18n, etc) — when baseline is active
2. `baseline_comparison.new_items` grouped by `context_label` — baseline regression items
3. `baseline_comparison.delta > 0` — aggregate issue for unstructured baseline regression
4. `status == "failed"` — aggregate fallback
5. Passed → zero findings → triggers auto-close of resolved issues

### Test normalization priority
1. `analysis.clusters[]` grouped by `category` (missing_method, missing_class, etc) — when `--analyze` was used
2. `summary.failures[]` grouped by file — when `--json-summary` was used
3. `test_counts.failed > 0` — aggregate issue with failure count
4. `baseline_comparison.regression == true` — regression aggregate
5. `status == "failed"` — aggregate fallback
6. Passed → zero findings → triggers auto-close

### Issue title patterns
```
audit: missing test file in data-machine (333)     [label: audit]
lint: security in data-machine (23)                [label: lint]
lint: i18n in data-machine (5)                     [label: lint]
test: missing method in data-machine (3)           [label: test]
test: 8 failures out of 150 tests in data-machine  [label: test]  (aggregate)
```

### Dedup & lifecycle
- Same as audit: issues dedup by `{command}: {kind} in {component}` prefix
- Count in title updates on each run (ratchet visible)
- Auto-close when findings reach 0
- Each command type uses its own label for isolation

## What's NOT changed
- `run-homeboy-commands.sh` — already writes `{cmd}.json` for all commands via `--output` flag
- `auto-file-issue.sh` (generic fallback) — preserved as safety net, gated on `categorized-issues.outcome != 'success'`
- Audit behavior — identical output, just refactored into shared functions

## Follow-up needed
- Update data-machine CI workflows (`homeboy-release.yml`) to benefit from the new categorized lint/test issues
- Clean up stale generic "CI failure" issues in data-machine (#836, #839, #844, #846, #847)