### PR TITLE
fix: remove `local` keyword outside function in prepare-autofix-branch.sh

### DIFF
--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -170,7 +170,6 @@ else
   AUTOFIX_DETAILS=""
   AUTOFIX_TOTAL_FIXES=""
   if [ -d "${AUTOFIX_OUTPUT_DIR}" ]; then
-    local raw_details
     raw_details="$(extract_fix_details_from_output "${AUTOFIX_OUTPUT_DIR}")"
     if [ -n "${raw_details}" ]; then
       AUTOFIX_TOTAL_FIXES="$(echo "${raw_details}" | head -1)"


### PR DESCRIPTION
## Summary

- Removes `local raw_details` on line 173 of `prepare-autofix-branch.sh` — it was at script top-level scope, not inside a function
- Bash only allows `local` inside functions; this caused the autofix pipeline to crash silently after applying fixes

## Impact

This bug caused the homeboy release to deadlock on 2026-03-18:

1. `cargo fmt --check` failed on an empty test file → lint step failed
2. Autofix ran `cargo fmt` successfully and created a branch
3. **Script crashed at line 173** before it could commit/push → fix was discarded
4. `.release-last-failed` recorded the HEAD SHA → every subsequent cron run skipped
5. No autofix PR was created → no new commits → release stuck all day

## Fix

Remove the `local` keyword — `raw_details` is already a plain variable in script scope.