### PR TITLE
feat: refactor owns all autofix — single invocation replaces per-source derivation

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -213,24 +213,10 @@ push_autofix_commit() {
 if [ -n "${AUTOFIX_COMMANDS:-}" ]; then
   IFS=',' read -ra FIX_ARRAY <<< "${AUTOFIX_COMMANDS}"
 else
-  # Derive refactor sources from the command list, but enforce canonical order:
-  # audit → lint → test. In Homeboy, fix = refactor, so the action should call
-  # canonical refactor source passes instead of command-specific fix modes.
-  HAS_AUDIT=false HAS_LINT=false HAS_TEST=false
-  IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
-  for CMD in "${CMD_ARRAY[@]}"; do
-    CMD=$(echo "${CMD}" | xargs)
-    BASE_CMD=$(printf '%s' "${CMD}" | awk '{print $1}')
-    case "${BASE_CMD}" in
-      audit) HAS_AUDIT=true ;;
-      lint)  HAS_LINT=true ;;
-      test)  HAS_TEST=true ;;
-    esac
-  done
-  FIX_ARRAY=()
-  [ "${HAS_AUDIT}" = true ] && FIX_ARRAY+=("refactor --from audit --write")
-  [ "${HAS_LINT}" = true ]  && FIX_ARRAY+=("refactor --from lint --write")
-  [ "${HAS_TEST}" = true ]  && FIX_ARRAY+=("refactor --from test --write")
+  # The refactor command is the single source of truth for all code fixes.
+  # --from all runs audit → lint → test sources sequentially in one invocation,
+  # so later stages see earlier stages' modifications.
+  FIX_ARRAY=("refactor --from all --write")
 fi
 
 if [ ${#FIX_ARRAY[@]} -eq 0 ]; then

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -51,23 +51,10 @@ WORKSPACE="$(resolve_workspace)"
 if [ -n "${AUTOFIX_COMMANDS:-}" ]; then
   IFS=',' read -ra FIX_ARRAY <<< "${AUTOFIX_COMMANDS}"
 else
-  # Derive refactor sources from the command list, but enforce canonical order:
-  # audit → lint → test. In Homeboy, fix = refactor, so non-PR autofix should
-  # also use canonical refactor source passes.
-  HAS_AUDIT=false HAS_LINT=false HAS_TEST=false
-  IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
-  for CMD in "${CMD_ARRAY[@]}"; do
-    CMD=$(echo "${CMD}" | xargs)
-    case "${CMD}" in
-      audit) HAS_AUDIT=true ;;
-      lint)  HAS_LINT=true ;;
-      test)  HAS_TEST=true ;;
-    esac
-  done
-  FIX_ARRAY=()
-  [ "${HAS_AUDIT}" = true ] && FIX_ARRAY+=("refactor --from audit --write")
-  [ "${HAS_LINT}" = true ]  && FIX_ARRAY+=("refactor --from lint --write")
-  [ "${HAS_TEST}" = true ]  && FIX_ARRAY+=("refactor --from test --write")
+  # The refactor command is the single source of truth for all code fixes.
+  # --from all runs audit → lint → test sources sequentially in one invocation,
+  # so later stages see earlier stages' modifications.
+  FIX_ARRAY=("refactor --from all --write")
 fi
 
 if [ ${#FIX_ARRAY[@]} -eq 0 ]; then

--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -358,7 +358,7 @@ NOFIXEOF
 ### Autofix status
 
 ${status_icon} ${status_text}${tier_note}
-Run: \`homeboy audit ${comp_id} --fix --write --only ${kind}\`
+Run: \`homeboy refactor ${comp_id} --from audit --write --only ${kind}\`
 FIXEOF
 }
 

--- a/scripts/scope/flags.sh
+++ b/scripts/scope/flags.sh
@@ -6,13 +6,13 @@
 
 # Get CLI flags for a command based on current scope.
 # Usage: scope_flags_for "lint"
-#        scope_flags_for "audit --fix --write"
+#        scope_flags_for "refactor --from all --write"
 # Prints: "--changed-since abc123" or ""
 scope_flags_for() {
   local cmd="$1"
   local base_cmd
 
-  # Extract the base command (first word) from compound commands like "audit --fix --write"
+  # Extract the base command (first word) from compound commands like "refactor --from all --write"
   base_cmd=$(printf '%s' "${cmd}" | awk '{print $1}')
 
   if [ "${SCOPE_MODE:-full}" != "changed" ] || [ -z "${SCOPE_BASE_REF:-}" ]; then


### PR DESCRIPTION
## Summary

Simplify the autofix pipeline: when no explicit `autofix-commands` are set, run one `refactor --from all --write` instead of deriving separate per-source passes.

## Before

The action derived fix commands from the command list:
- `audit` → `refactor --from audit --write`
- `lint` → `refactor --from lint --write`
- `test` → `refactor --from test --write`

Three separate invocations, each running in isolation.

## After

One invocation: `refactor --from all --write`

This runs audit → lint → test sources **sequentially inside one sandbox**, so later stages see earlier stages' modifications. The `refactor` command is the single source of truth for all code changes.

## Mental model

```
audit, lint, test  →  find problems (read-only)
refactor           →  fix problems (writes)
```

## Also updated
- `auto-file-categorized-issues.sh`: fix hint now says `refactor ... --from audit` instead of `audit --fix --write`
- `scope/flags.sh`: comments updated