### PR TITLE
fix: use stable branch name for non-PR autofix to prevent duplicate PRs

### DIFF
--- a/scripts/autofix/open-autofix-pr.sh
+++ b/scripts/autofix/open-autofix-pr.sh
@@ -27,6 +27,49 @@ EXISTING_PR_URL=$(gh pr list \
 
 if [ -n "${EXISTING_PR_URL}" ]; then
   echo "Autofix PR already exists: ${EXISTING_PR_URL}"
+
+  # Update the PR body with the latest run context (branch was force-pushed
+  # with fresh autofix changes, so the old workflow run link is stale).
+  EXISTING_PR_NUMBER=$(gh pr list \
+    --state open \
+    --base "${BASE_BRANCH}" \
+    --head "${AUTOFIX_BRANCH}" \
+    --json number \
+    --jq '.[0].number // empty' 2>/dev/null || true)
+
+  if [ -n "${EXISTING_PR_NUMBER}" ]; then
+    UPDATE_BODY_FILE="$(mktemp)"
+
+    AUTOFIX_DETAIL=""
+    if [ -n "${AUTOFIX_FILE_COUNT:-}" ] && [ -n "${AUTOFIX_FIX_TYPES:-}" ]; then
+      AUTOFIX_DETAIL="- **${AUTOFIX_FILE_COUNT}** file(s) fixed via **${AUTOFIX_FIX_TYPES}**"
+    elif [ -n "${AUTOFIX_FILE_COUNT:-}" ]; then
+      AUTOFIX_DETAIL="- **${AUTOFIX_FILE_COUNT}** file(s) fixed"
+    fi
+
+    FINDING_DETAIL=""
+    if [ -n "${AUTOFIX_FINDING_TYPES:-}" ]; then
+      FINDING_DETAIL="- **Finding categories:** ${AUTOFIX_FINDING_TYPES}"
+    fi
+
+    cat > "${UPDATE_BODY_FILE}" <<UPDATEBODY
+## Summary
+${AUTOFIX_DETAIL:+${AUTOFIX_DETAIL}
+}${FINDING_DETAIL:+${FINDING_DETAIL}
+}- Rerun after autofix passed for configured command set.
+- Generated automatically by Homeboy Action.
+
+## Context
+- Workflow run: ${RUN_URL}
+- Branch: ${AUTOFIX_BRANCH}
+- Base: ${BASE_BRANCH}
+UPDATEBODY
+
+    gh pr edit "${EXISTING_PR_NUMBER}" --body-file "${UPDATE_BODY_FILE}" 2>/dev/null || true
+    rm -f "${UPDATE_BODY_FILE}"
+    echo "Updated PR #${EXISTING_PR_NUMBER} body with latest run context"
+  fi
+
   echo "created=true" >> "${GITHUB_OUTPUT}"
   echo "url=${EXISTING_PR_URL}" >> "${GITHUB_OUTPUT}"
   exit 0

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -63,7 +63,21 @@ if [ ${#FIX_ARRAY[@]} -eq 0 ]; then
   exit 0
 fi
 
-AUTOFIX_BRANCH="ci/autofix/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+# Stable branch name: reuse across cron runs so open-autofix-pr.sh dedup works.
+# Old behavior used GITHUB_RUN_ID which created a new branch (and PR) every run.
+if [[ "${GITHUB_REF:-}" == refs/heads/* ]]; then
+  BASE_BRANCH="${GITHUB_REF#refs/heads/}"
+else
+  BASE_BRANCH="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' 2>/dev/null || echo 'main')"
+fi
+AUTOFIX_BRANCH="ci/autofix/${COMP_ID}/${BASE_BRANCH}"
+
+# If the branch already exists remotely (from a previous cron run), delete it
+# and start fresh from HEAD. The old branch may be stale or conflict with
+# current main. Force-pushing a fresh branch is simpler and safer than rebasing.
+if git ls-remote --exit-code --heads origin "${AUTOFIX_BRANCH}" >/dev/null 2>&1; then
+  echo "Remote branch ${AUTOFIX_BRANCH} already exists; will force-push fresh changes"
+fi
 
 echo "Creating autofix branch: ${AUTOFIX_BRANCH}"
 git checkout -b "${AUTOFIX_BRANCH}"
@@ -180,14 +194,16 @@ GIT_COMMITTER_EMAIL="${BOT_EMAIL}" \
 
 # Use GitHub App token for push if available — pushes from a GitHub App
 # trigger workflow re-runs, while GITHUB_TOKEN pushes do not.
+# Force-push because the stable branch name may already exist from a previous
+# cron run. The fresh commit replaces the stale one.
 if [ -n "${APP_TOKEN:-}" ]; then
   echo "Pushing with GitHub App token (will trigger CI re-run)"
   git -c "http.https://github.com/.extraheader=" \
-    push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+    push --force "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
     "${AUTOFIX_BRANCH}"
 else
   echo "Pushing with default token (will NOT trigger CI re-run)"
-  git push origin "${AUTOFIX_BRANCH}"
+  git push --force origin "${AUTOFIX_BRANCH}"
 fi
 
 echo "committed=true" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- Autofix branch name was `ci/autofix/{run_id}-{attempt}` — unique per cron run, creating duplicate PRs every 15 minutes
- Changed to stable `ci/autofix/{component}/{base-branch}` so subsequent runs force-push to the same branch
- The existing PR dedup check in `open-autofix-pr.sh` now actually works (it checks by branch name)
- Also updates the existing PR body with the latest workflow run link when force-pushing

## Root Cause
Homeboy's 15-minute cron was creating 8+ duplicate "chore(ci): autofix homeboy from main" PRs because each run got a unique `GITHUB_RUN_ID` → unique branch → new PR. The dedup check on line 21-33 of `open-autofix-pr.sh` searched for an open PR with the same `--head` branch, but the branch was always new.

## Changes
- `prepare-autofix-branch.sh`: Stable branch name + `--force` push
- `open-autofix-pr.sh`: Update existing PR body with latest run context instead of creating new PR