### PR TITLE
feat: multi-component support via subdirectory resolution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,6 +161,7 @@ runs:
       id: read-config
       shell: bash
       env:
+        COMPONENT_NAME: ${{ inputs.component }}
         EXTENSION_INPUT: ${{ inputs.extension }}
         PHP_INPUT: ${{ inputs.php-version }}
         NODE_INPUT: ${{ inputs.node-version }}

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -130,7 +130,15 @@ resolve_component_id() {
 }
 
 resolve_workspace() {
-  pwd
+  # When running in a multi-component repo, COMPONENT_DIR points to the
+  # subdirectory containing the component's homeboy.json. Homeboy core
+  # uses --path to read config and scope operations to this directory.
+  local component_dir="${COMPONENT_DIR:-}"
+  if [ -n "${component_dir}" ] && [ "${component_dir}" != "." ]; then
+    printf '%s/%s\n' "$(pwd)" "${component_dir}"
+  else
+    pwd
+  fi
 }
 
 resolve_pr_target_repo() {

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -20,9 +20,16 @@
 
 set -euo pipefail
 
-WORKSPACE="${GITHUB_WORKSPACE:-.}"
 RELEASE_BRANCH="${RELEASE_BRANCH:-main}"
 DRY_RUN="${RELEASE_DRY_RUN:-false}"
+
+# Resolve workspace — use component subdirectory when set
+COMPONENT_DIR="${COMPONENT_DIR:-.}"
+if [ -n "${COMPONENT_DIR}" ] && [ "${COMPONENT_DIR}" != "." ]; then
+  WORKSPACE="${GITHUB_WORKSPACE:-.}/${COMPONENT_DIR}"
+else
+  WORKSPACE="${GITHUB_WORKSPACE:-.}"
+fi
 
 json_field() {
   local file_path="$1"

--- a/scripts/setup/read-portable-config.sh
+++ b/scripts/setup/read-portable-config.sh
@@ -12,17 +12,30 @@
 
 set -euo pipefail
 
-if [ ! -f "homeboy.json" ]; then
-  echo "::error::homeboy.json is required at repository root"
+# ── Resolve config path ──
+# When COMPONENT_NAME is set and a homeboy.json exists in that subdirectory,
+# read config from there instead of the repo root. This supports multi-component
+# repos where each component has its own homeboy.json.
+
+COMPONENT_NAME="${COMPONENT_NAME:-}"
+CONFIG_DIR="."
+
+if [ -n "${COMPONENT_NAME}" ] && [ -f "${COMPONENT_NAME}/homeboy.json" ]; then
+  CONFIG_DIR="${COMPONENT_NAME}"
+  echo "Reading config from component subdirectory: ${CONFIG_DIR}/"
+elif [ ! -f "homeboy.json" ]; then
+  echo "::error::homeboy.json is required at repository root (or in component subdirectory when component input is set)"
   echo "::error::Create homeboy.json with at least an \"id\" field and re-run CI"
   exit 1
 fi
 
+CONFIG_FILE="${CONFIG_DIR}/homeboy.json"
+
 # ── Component ID ──
 
-PORTABLE_ID="$(jq -r '.id // empty' homeboy.json 2>/dev/null || true)"
+PORTABLE_ID="$(jq -r '.id // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
 if [ -z "${PORTABLE_ID}" ]; then
-  echo "::error::homeboy.json must include a top-level \"id\" field"
+  echo "::error::${CONFIG_FILE} must include a top-level \"id\" field"
   exit 1
 fi
 
@@ -34,7 +47,7 @@ EXTENSION_INPUT="${EXTENSION_INPUT:-}"
 if [ -n "${EXTENSION_INPUT}" ]; then
   PORTABLE_EXTENSION="${EXTENSION_INPUT}"
 else
-  PORTABLE_EXTENSION="$(jq -r '.extensions // {} | keys | first // empty' homeboy.json 2>/dev/null || true)"
+  PORTABLE_EXTENSION="$(jq -r '.extensions // {} | keys | first // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
 fi
 
 # ── PHP version inference ──
@@ -48,7 +61,7 @@ if [ -n "${PHP_INPUT}" ]; then
   PORTABLE_PHP="${PHP_INPUT}"
 elif [ -n "${PORTABLE_EXTENSION}" ]; then
   # Check extensions.<ext>.php in homeboy.json
-  PORTABLE_PHP="$(jq -r --arg ext "${PORTABLE_EXTENSION}" '.extensions[$ext].php // empty' homeboy.json 2>/dev/null || true)"
+  PORTABLE_PHP="$(jq -r --arg ext "${PORTABLE_EXTENSION}" '.extensions[$ext].php // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
 fi
 
 if [ -z "${PORTABLE_PHP}" ] && [ -f "composer.json" ]; then
@@ -74,7 +87,7 @@ PORTABLE_NODE=""
 if [ -n "${NODE_INPUT}" ]; then
   PORTABLE_NODE="${NODE_INPUT}"
 elif [ -n "${PORTABLE_EXTENSION}" ]; then
-  PORTABLE_NODE="$(jq -r --arg ext "${PORTABLE_EXTENSION}" '.extensions[$ext].node // empty' homeboy.json 2>/dev/null || true)"
+  PORTABLE_NODE="$(jq -r --arg ext "${PORTABLE_EXTENSION}" '.extensions[$ext].node // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
 fi
 
 if [ -z "${PORTABLE_NODE}" ] && [ -f "package.json" ]; then
@@ -90,14 +103,17 @@ echo "PORTABLE_ID=${PORTABLE_ID}" >> "${GITHUB_ENV}"
 echo "PORTABLE_EXTENSION=${PORTABLE_EXTENSION}" >> "${GITHUB_ENV}"
 echo "PORTABLE_PHP=${PORTABLE_PHP}" >> "${GITHUB_ENV}"
 echo "PORTABLE_NODE=${PORTABLE_NODE}" >> "${GITHUB_ENV}"
+echo "COMPONENT_DIR=${CONFIG_DIR}" >> "${GITHUB_ENV}"
 
 echo "portable-id=${PORTABLE_ID}" >> "${GITHUB_OUTPUT}"
 echo "portable-extension=${PORTABLE_EXTENSION}" >> "${GITHUB_OUTPUT}"
 echo "portable-php=${PORTABLE_PHP}" >> "${GITHUB_OUTPUT}"
 echo "portable-node=${PORTABLE_NODE}" >> "${GITHUB_OUTPUT}"
+echo "component-dir=${CONFIG_DIR}" >> "${GITHUB_OUTPUT}"
 
-echo "Config resolved from homeboy.json:"
+echo "Config resolved from ${CONFIG_FILE}:"
 echo "  id:        ${PORTABLE_ID}"
 echo "  extension: ${PORTABLE_EXTENSION:-none}"
 echo "  php:       ${PORTABLE_PHP:-skip}"
 echo "  node:      ${PORTABLE_NODE:-skip}"
+echo "  dir:       ${CONFIG_DIR}"


### PR DESCRIPTION
## Summary
- When `component` input is set and `{component}/homeboy.json` exists, resolve config from that subdirectory instead of repo root
- `COMPONENT_DIR` exported via `GITHUB_ENV` so all downstream scripts (commands, autofix, release) automatically scope to the correct subdirectory
- Enables multi-component repos (like `homeboy-extensions`) where each component has its own `homeboy.json`, changelog, and independent versioning

## Changes
- **`read-portable-config.sh`** — resolves `homeboy.json` from `{COMPONENT_NAME}/` when available; outputs `component-dir`
- **`action.yml`** — passes `COMPONENT_NAME` env to the read-config step
- **`lib.sh`** — `resolve_workspace()` returns the component subdirectory path when `COMPONENT_DIR` is set
- **`run-release.sh`** — resolves `WORKSPACE` from `COMPONENT_DIR` for release scoping

## Context
Unblocks independent versioning and continuous release for `homeboy-extensions`, where each extension (rust, wordpress, etc.) is its own component with its own `homeboy.json`.