### PR TITLE
fix: add compilation validation gate before committing autofix changes

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -247,6 +247,16 @@ while [ "${PUSH_ATTEMPT}" -le "${AUTOFIX_PUSH_ATTEMPTS}" ]; do
   else
     echo "Skipping code fixes (autofix cap reached)"
   fi
+
+  # Validate generated code compiles before committing.
+  # If validation fails, all changes are reverted and no commit is made.
+  if ! validate_autofix_changes "${WORKSPACE}"; then
+    echo "Autofix changes failed compilation — skipping commit"
+    echo "status=compile-failed" >> "${GITHUB_OUTPUT}"
+    echo "committed=false" >> "${GITHUB_OUTPUT}"
+    exit 0
+  fi
+
   maybe_update_baseline
 
   if ! stage_autofix_changes; then

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -108,6 +108,16 @@ else
   echo "Skipping code fixes (autofix cap reached)"
 fi
 
+# Validate generated code compiles before committing.
+# If validation fails, all changes are reverted and no commit is made.
+if ! validate_autofix_changes "${WORKSPACE}"; then
+  echo "Autofix changes failed compilation — skipping commit"
+  git checkout -
+  git branch -D "${AUTOFIX_BRANCH}"
+  echo "committed=false" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
 # Update baseline so it stays current when this commit merges to main.
 # Full (unscoped) audit ensures the baseline reflects the entire codebase,
 # not just changed files. Tolerate failure — baseline update is best-effort.

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -302,3 +302,52 @@ build_autofix_command() {
 
   printf '%s\n' "${full_cmd}"
 }
+
+# Validate autofix changes compile before committing.
+#
+# Detects the project type and runs a compile check that covers test code.
+# Returns 0 on success, 1 on failure (with changes reverted).
+# If no known build tool is found, returns 0 (no validation possible).
+validate_autofix_changes() {
+  local workspace="${1:-.}"
+
+  # Skip if no files changed
+  if git diff --quiet && git diff --cached --quiet; then
+    return 0
+  fi
+
+  local check_cmd=""
+
+  # Rust: cargo check --tests validates #[cfg(test)] modules
+  if [ -f "${workspace}/Cargo.toml" ]; then
+    check_cmd="cargo check --tests"
+  # TypeScript: tsc --noEmit validates all TypeScript
+  elif [ -f "${workspace}/tsconfig.json" ]; then
+    check_cmd="npx tsc --noEmit"
+  # Go: go vet validates compilation
+  elif [ -f "${workspace}/go.mod" ]; then
+    check_cmd="go vet ./..."
+  fi
+
+  if [ -z "${check_cmd}" ]; then
+    return 0
+  fi
+
+  echo "Validating autofix changes compile: ${check_cmd}"
+  set +e
+  local output
+  output=$(cd "${workspace}" && eval "${check_cmd}" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [ "${exit_code}" -ne 0 ]; then
+    echo "::warning::Autofix generated code that does not compile — reverting all changes"
+    echo "${output}" | tail -20
+    git checkout -- .
+    git clean -fd
+    return 1
+  fi
+
+  echo "Compilation validation passed"
+  return 0
+}


### PR DESCRIPTION
## Problem

Autofix was committing generated code without verifying it compiles. The auto-refactor pipeline generated broken tests in homeboy (300 lines, 39 compilation errors) and committed them to main. Root cause: no compilation check between `run_autofixes()` and `git commit`.

The broken code had:
- Duplicate test function names (E0428)
- Wrong argument counts (E0061) — 0 args for 3-9 arg functions
- Wrong return types (E0599) — `.is_ok()` on `()`, `HashMap`, `Option`
- Invalid format strings — backticks breaking Rust format syntax

## Fix

### New `validate_autofix_changes()` function in `lib.sh`

Detects project type and runs a compile check before committing:

| Project | Check command | What it validates |
|---------|--------------|-------------------|
| Rust (`Cargo.toml`) | `cargo check --tests` | All code including `#[cfg(test)]` modules |
| TypeScript (`tsconfig.json`) | `npx tsc --noEmit` | All TypeScript files |
| Go (`go.mod`) | `go vet ./...` | All Go packages |

On failure: reverts all changes (`git checkout -- . && git clean -fd`) and exits with `committed=false`.

### Wired into both autofix paths

**`apply-autofix-commit.sh`** (PR autofix):
```
run_autofixes → validate_autofix_changes → maybe_update_baseline → stage → commit → push
                ^^^^^^^^^^^^^^^^^^^^^^^^
                NEW: compilation gate
```

**`prepare-autofix-branch.sh`** (non-PR/cron autofix):
```
fix loop → validate_autofix_changes → update baseline → stage → commit → push
           ^^^^^^^^^^^^^^^^^^^^^^^^
           NEW: compilation gate
```

## Defense in depth

This is the **second layer** of defense. The **first layer** is the companion PR in homeboy core (Extra-Chill/homeboy#931) which changes `validate_write()` from `cargo check` to `cargo check --tests` — so the refactor pipeline itself validates test code before writing. This action-level gate is a safety net in case the binary-level validation has gaps.

## Changes
- `scripts/core/lib.sh` — new `validate_autofix_changes()` function
- `scripts/autofix/apply-autofix-commit.sh` — call validation after fixes, before staging
- `scripts/autofix/prepare-autofix-branch.sh` — call validation after fixes, before baseline