### PR TITLE
feat: merge guard — skip autofix and PR comments on merged/closed PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Works with **any Homeboy extension** — WordPress, Rust, Node, or your own cust
 name: CI
 on: [pull_request]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   homeboy:
     runs-on: ubuntu-latest
@@ -233,6 +237,8 @@ When enabled, the action will:
 
 For fork PRs, Homeboy Action now attempts the same direct-to-PR autofix flow first. Actual push success still depends on the token/permission model available to the workflow run.
 
+**Merge guard:** If the PR is merged or closed while CI is running, autofix and PR comments are automatically skipped. This prevents zombie commits to deleted branches and stale result noise on already-merged PRs. Pair with a `concurrency` group to cancel the entire run early.
+
 ### Auto-open Fix PRs on non-PR runs
 
 ```yaml
@@ -327,6 +333,7 @@ Use two workflows:
 1. **PR workflow** (fast + scoped)
    - `commands: lint,test,audit`
    - `scope: 'changed'`
+   - `concurrency` group per PR number to cancel stale runs
 
 2. **Release workflow** (continuous)
    - trigger on `schedule` (every 15 min) + `workflow_dispatch`

--- a/action.yml
+++ b/action.yml
@@ -335,6 +335,7 @@ runs:
         AUTOFIX_MODE: ${{ inputs.autofix-mode }}
         PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
         APP_TOKEN: ${{ inputs.app-token }}
       run: bash ${{ github.action_path }}/scripts/autofix/apply-autofix-commit.sh
 

--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -59,6 +59,14 @@ if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "h
   exit 0
 fi
 
+if ! pr_is_active; then
+  echo "Skipping autofix: PR #${PR_NUMBER} is no longer open (merged or closed)"
+  echo "attempted=false" >> "${GITHUB_OUTPUT}"
+  echo "status=skipped-pr-closed" >> "${GITHUB_OUTPUT}"
+  echo "committed=false" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
 LAST_SUBJECT=$(git log -1 --pretty=%s 2>/dev/null || true)
 if [[ "${LAST_SUBJECT}" == "${AUTOFIX_COMMIT_PREFIX}"* ]]; then
   echo "Skipping autofix: HEAD already an autofix commit"
@@ -274,6 +282,15 @@ while [ "${PUSH_ATTEMPT}" -le "${AUTOFIX_PUSH_ATTEMPTS}" ]; do
   fi
 
   echo "Autofix push failed on attempt ${PUSH_ATTEMPT}/${AUTOFIX_PUSH_ATTEMPTS}; refetching latest PR head and recomputing"
+
+  # Re-check PR state before retrying — it may have been merged while we were fixing
+  if ! pr_is_active; then
+    echo "PR #${PR_NUMBER} was merged or closed during autofix — aborting retries"
+    echo "committed=false" >> "${GITHUB_OUTPUT}"
+    echo "status=skipped-pr-closed" >> "${GITHUB_OUTPUT}"
+    exit 0
+  fi
+
   fetch_latest_target_head || true
   PUSH_ATTEMPT=$((PUSH_ATTEMPT + 1))
 done

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -10,6 +10,50 @@ source "${SCRIPT_DIR}/../scope/flags.sh"
 # so the subject line can vary after it (e.g. fix types, file count).
 AUTOFIX_COMMIT_PREFIX="chore(ci): homeboy autofix"
 
+# Check whether the current PR is still open.
+# Returns 0 (true) if the PR is open, 1 (false) if merged/closed/unknown.
+# Uses gh CLI when available, falls back to GitHub REST API via curl.
+# Requires: GITHUB_REPOSITORY and PR_NUMBER (or $1) in the environment.
+pr_is_active() {
+  local pr_number="${1:-${PR_NUMBER:-}}"
+  local repo="${GITHUB_REPOSITORY:-}"
+
+  if [ -z "${pr_number}" ] || [ -z "${repo}" ]; then
+    # Can't check — assume active to avoid false cancellations
+    return 0
+  fi
+
+  local state=""
+  if command -v gh >/dev/null 2>&1; then
+    state=$(gh pr view "${pr_number}" --repo "${repo}" --json state -q '.state' 2>/dev/null || true)
+  fi
+
+  if [ -z "${state}" ]; then
+    # Fallback to curl — use GH_TOKEN or GITHUB_TOKEN for auth
+    local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    if [ -n "${token}" ]; then
+      state=$(curl -sfL \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${repo}/pulls/${pr_number}" 2>/dev/null \
+        | jq -r '.state // empty' 2>/dev/null || true)
+    fi
+  fi
+
+  case "${state}" in
+    OPEN|open)
+      return 0
+      ;;
+    MERGED|CLOSED|merged|closed)
+      return 1
+      ;;
+    *)
+      # Unknown state — assume active to avoid false cancellations
+      return 0
+      ;;
+  esac
+}
+
 # Build an informative autofix commit message.
 # Subject: chore(ci): homeboy autofix — audit (7 files, 33 fixes)
 # Body: per-category fix counts with affected files.

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
 source "${GITHUB_ACTION_PATH}/scripts/pr/comment/lib.sh"
 source "${GITHUB_ACTION_PATH}/scripts/pr/comment/sections.sh"
 source "${GITHUB_ACTION_PATH}/scripts/pr/comment/publish.sh"
@@ -12,6 +13,11 @@ COMP_ID="${COMPONENT_NAME:-$(basename "${GITHUB_REPOSITORY}")}"
 
 if [ -z "${OUTPUT_DIR}" ] || [ -z "${PR_NUMBER}" ]; then
   echo "Skipping PR comment — missing output dir or PR number"
+  exit 0
+fi
+
+if ! pr_is_active; then
+  echo "Skipping PR comment — PR #${PR_NUMBER} is no longer open (merged or closed)"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Adds `pr_is_active()` to `lib.sh` — checks PR state via `gh` CLI (preferred) or GitHub REST API (fallback) before performing mutations
- **Autofix guard:** skips autofix entirely if the PR is merged/closed before the autofix step runs, and re-checks between push retries
- **PR comment guard:** skips posting stale CI results to already-merged PRs
- Passes `PR_NUMBER` env var to the autofix-commit step in `action.yml`
- Documents recommended `concurrency` group pattern in README

## Why

When a PR is merged while CI is still running, the action would:
1. Try to push autofix commits to a potentially-deleted branch (creating zombie branches)
2. Post stale CI results on merged PRs (noise)

The merge guard is a safety net. Consumers should also add `concurrency` groups to cancel runs early, but the action itself should never push to dead PRs regardless.

## Fail-safe design

- If PR state can't be determined (no token, API failure, missing PR number), the function returns "active" to avoid false cancellations
- Handles both `gh` CLI format (`OPEN`/`MERGED`/`CLOSED`) and REST API format (`open`/`closed`)