### PR TITLE
feat: capture --output in PR autofix and include fixer categories in commit messages

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -104,10 +104,13 @@ reset_to_target_head() {
 }
 
 run_autofixes() {
+  AUTOFIX_OUTPUT_DIR=$(mktemp -d)
   echo "Applying autofixes..."
+  local fix_index=0
   for FIX_CMD in "${FIX_ARRAY[@]}"; do
     FIX_CMD=$(echo "${FIX_CMD}" | xargs)
-    BASE_CMD="$(build_autofix_command "${FIX_CMD}" "${COMP_ID}" "${WORKSPACE}")"
+    local output_file="${AUTOFIX_OUTPUT_DIR}/fix-${fix_index}.json"
+    BASE_CMD="$(build_autofix_command "${FIX_CMD}" "${COMP_ID}" "${WORKSPACE}" "${output_file}")"
 
     echo "Running autofix: ${BASE_CMD}"
     set +e
@@ -118,6 +121,7 @@ run_autofixes() {
     if [ "${FIX_EXIT}" -ne 0 ]; then
       echo "Autofix command exited non-zero (${FIX_EXIT}), continuing to check for file changes"
     fi
+    fix_index=$((fix_index + 1))
   done
 }
 
@@ -182,9 +186,13 @@ homeboy.json"
 
     AUTOFIX_DETAILS=""
     AUTOFIX_TOTAL_FIXES=""
-    if [ -n "${HOMEBOY_OUTPUT_DIR:-}" ] && [ -d "${HOMEBOY_OUTPUT_DIR}" ]; then
+    # Read fix details from the autofix run's own output (AUTOFIX_OUTPUT_DIR),
+    # not the diagnostic run's output (HOMEBOY_OUTPUT_DIR). The autofix run
+    # captures --output with the actual fix results and fixer categories.
+    local details_dir="${AUTOFIX_OUTPUT_DIR:-${HOMEBOY_OUTPUT_DIR:-}}"
+    if [ -n "${details_dir}" ] && [ -d "${details_dir}" ]; then
       local raw_details
-      raw_details="$(extract_fix_details_from_output "${HOMEBOY_OUTPUT_DIR}")"
+      raw_details="$(extract_fix_details_from_output "${details_dir}")"
       if [ -n "${raw_details}" ]; then
         AUTOFIX_TOTAL_FIXES="$(echo "${raw_details}" | head -1)"
         AUTOFIX_DETAILS="$(echo "${raw_details}" | tail -n +2)"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -121,19 +121,27 @@ extract_fix_details_from_output() {
         "file_move": "Files moved",
         "line_replacement": "Lines replaced",
         "line_removal": "Lines removed",
-        "missing_test_file": "Test files generated"
+        "missing_test_file": "Test files generated",
+        "missing_test_method": "Test stubs generated",
+        "unreferenced_export": "Unreferenced exports narrowed",
+        "duplicate_function": "Duplicate functions removed",
+        "god_file": "God files decomposed",
+        "high_item_count": "Large files decomposed"
       }[.] // .;
 
-    # Collect insertions with normalized category
+    # Collect insertions with normalized category (FixResult format)
     [.[].fixes // [] | .[] | .file as $file |
       .insertions[]? | {cat: (.kind | category), file: $file}
     ] as $insertions |
 
-    # Collect new files
+    # Collect new files (FixResult format)
     [.[].new_files // [] | .[] | {cat: .finding, file}] as $new_files |
 
-    # Combine and group by category
-    ($insertions + $new_files) | group_by(.cat) |
+    # Collect proposals (RefactorPlan format — from refactor --from all)
+    [.[].proposals // [] | .[] | {cat: .rule_id, file}] as $proposals |
+
+    # Combine all sources and group by category
+    ($insertions + $new_files + $proposals) | group_by(.cat) |
     map({
       cat: .[0].cat,
       count: length,


### PR DESCRIPTION
## Summary

Autofix commits now include which fixers ran and what they did.

**Before:**
```
chore(ci): homeboy autofix — refactor (3 files)

src/core/extension/grammar.rs
src/core/refactor/plan/mod.rs
src/core/refactor/plan/planner.rs
```

**After:**
```
chore(ci): homeboy autofix — refactor (3 files, 8 fixes)

Unreferenced exports narrowed: 4
  planner.rs, mod.rs
Test stubs generated: 3
  planner.rs
Missing imports added: 1
  grammar.rs
```

## Changes

1. **`apply-autofix-commit.sh`**: Pass `--output` to the autofix command so structured JSON is captured. Previously the 4th argument to `build_autofix_command()` was omitted, so no `--output` flag was added and the commit message fell back to just listing file names.

2. **`lib.sh`**: `extract_fix_details_from_output` now handles the `RefactorPlan` format (`.proposals[].rule_id`) in addition to the existing `FixResult` format (`.fixes[].insertions[].kind`). Added humanized labels for `missing_test_method`, `unreferenced_export`, `duplicate_function`, `god_file`, and `high_item_count`.

## Why this matters

When an autofix commit breaks a PR (as happened with homeboy PR#995), the commit message should tell you exactly which fixers ran so you know where to look in the code. Without this, you just see "refactor (3 files)" and have to reverse-engineer the diff to figure out what happened.