### PR TITLE
fix: skip autofix when a previous autofix was reverted on the branch

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -86,6 +86,22 @@ if [ -n "${AUTOFIX_LABEL:-}" ]; then
   fi
 fi
 
+# Check if a previous autofix commit was reverted on this branch.
+# A revert is a clear signal that the autofix output was broken — don't
+# push the same broken code again.
+REVERT_BASE="${BASE:-}"
+if [ -z "${REVERT_BASE}" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  REVERT_BASE="origin/${GITHUB_BASE_REF}"
+fi
+if has_reverted_autofix "${REVERT_BASE}"; then
+  echo "Skipping autofix: a previous autofix commit was reverted on this branch"
+  echo "This indicates the autofix output was incorrect — manual review required."
+  echo "attempted=false" >> "${GITHUB_OUTPUT}"
+  echo "status=skipped-reverted" >> "${GITHUB_OUTPUT}"
+  echo "committed=false" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
 COMP_ID="$(resolve_component_id)"
 WORKSPACE="$(resolve_workspace)"
 TARGET_REPO="$(resolve_pr_target_repo)"

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -45,6 +45,15 @@ if [[ "${GITHUB_REF_NAME:-}" == ci/autofix/* ]]; then
   exit 0
 fi
 
+# Check if a previous autofix commit was reverted in recent history.
+# A revert signals broken autofix output — back off until a human intervenes.
+if has_reverted_autofix; then
+  echo "Skipping non-PR autofix: a previous autofix commit was reverted in recent history"
+  echo "This indicates the autofix output was incorrect — manual review required."
+  echo "committed=false" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
 COMP_ID="$(resolve_component_id)"
 WORKSPACE="$(resolve_workspace)"
 

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -10,6 +10,29 @@ source "${SCRIPT_DIR}/../scope/flags.sh"
 # so the subject line can vary after it (e.g. fix types, file count).
 AUTOFIX_COMMIT_PREFIX="chore(ci): homeboy autofix"
 
+# Check whether any autofix commit was reverted on this branch.
+# A revert indicates the autofix output was broken — the bot should back off
+# instead of pushing the same broken code again.
+#
+# Checks the commit range (base..HEAD for PRs, last N commits otherwise)
+# for subjects matching: Revert "chore(ci): homeboy autofix*"
+#
+# Arguments:
+#   $1 - optional base ref for range scoping (e.g., origin/main)
+# Returns 0 if a reverted autofix was found, 1 otherwise.
+has_reverted_autofix() {
+  local base="${1:-}"
+  local revert_pattern="Revert \"${AUTOFIX_COMMIT_PREFIX}"
+
+  if [ -n "${base}" ]; then
+    # PR context: check only commits on this branch
+    git log --format=%s "${base}..HEAD" 2>/dev/null | grep -qF "${revert_pattern}"
+  else
+    # Non-PR context: check recent history (generous window)
+    git log --format=%s -n 20 2>/dev/null | grep -qF "${revert_pattern}"
+  fi
+}
+
 # Check whether the current PR is still open.
 # Returns 0 (true) if the PR is open, 1 (false) if merged/closed/unknown.
 # Uses gh CLI when available, falls back to GitHub REST API via curl.


### PR DESCRIPTION
## Summary

- Adds revert detection to the autofix pipeline — if a human reverted an autofix commit on the branch, the bot stops trying instead of pushing the same broken code again
- Breaks the infinite revert-reapply loop observed on homeboy PR#999 and PR#1005

## How it works

New `has_reverted_autofix()` function in `lib.sh` checks git log for commits matching:
```
Revert "chore(ci): homeboy autofix*"
```

- **PR path** (`apply-autofix-commit.sh`): Scopes the check to `base..HEAD` so only reverts on *this* branch are detected, not historical reverts on main
- **Non-PR path** (`prepare-autofix-branch.sh`): Checks the last 20 commits as a generous window

When detected, the autofix step exits cleanly with `status=skipped-reverted` — no commit, no push, no loop.

## Why this matters

The autofix bot builds from the binary on main. When a PR fixes the fixer code itself, the bot still runs the OLD (broken) fixer against the PR. The human reverts the broken output, CI re-triggers, and the bot pushes the same broken code again. This guard breaks that cycle.

More generally: any time the fixer produces bad output and a human corrects it, the bot should defer to the human's judgment and stop.

## Files changed

| File | What |
|------|------|
| `scripts/core/lib.sh` | `has_reverted_autofix()` — shared revert detection function |
| `scripts/autofix/apply-autofix-commit.sh` | Call revert check before running fixes (PR path) |
| `scripts/autofix/prepare-autofix-branch.sh` | Call revert check before running fixes (non-PR path) |

Closes #113