### PR TITLE
fix: skip circular rerun for refactor-only commands and bail early on merged PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -302,9 +302,29 @@ runs:
 
     # ── Phase 5: Run commands ──
 
+    # Bail early if the PR was merged or closed while earlier jobs ran.
+    # The concurrency group cancels stale runs when a NEW push arrives,
+    # but merging doesn't trigger a new PR event — so the run continues.
+    # This guard prevents wasting CI minutes on zombie runs.
+    - name: Check PR state
+      id: check-pr-state
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
+        if ! pr_is_active; then
+          echo "::warning::PR #${PR_NUMBER} is no longer open (merged or closed) — skipping remaining steps"
+          echo "active=false" >> "${GITHUB_OUTPUT}"
+        else
+          echo "active=true" >> "${GITHUB_OUTPUT}"
+        fi
+
     - name: Run Homeboy commands
       id: run-commands
       continue-on-error: true
+      if: steps.check-pr-state.outputs.active != 'false'
       shell: bash
       env:
         COMPONENT_NAME: ${{ inputs.component }}
@@ -358,10 +378,18 @@ runs:
         APP_TOKEN: ${{ inputs.app-token }}
       run: bash ${{ github.action_path }}/scripts/autofix/prepare-autofix-branch.sh
 
+    # Rerun verifies that autofix actually repaired the failures. Skip when
+    # the command set is refactor-only — the autofix IS the same refactor
+    # command, so rerunning it is circular and wastes CI minutes.
     - name: Re-run Homeboy commands after autofix
       id: rerun-commands
       continue-on-error: true
-      if: (github.event_name == 'pull_request' && steps.autofix-commit.outputs.committed == 'true') || (github.event_name != 'pull_request' && steps.autofix-prepare-nonpr.outputs.committed == 'true')
+      if: |
+        steps.resolve-commands.outputs.refactor-only != 'true'
+        && (
+          (github.event_name == 'pull_request' && steps.autofix-commit.outputs.committed == 'true')
+          || (github.event_name != 'pull_request' && steps.autofix-prepare-nonpr.outputs.committed == 'true')
+        )
       shell: bash
       env:
         COMPONENT_NAME: ${{ inputs.component }}
@@ -412,6 +440,7 @@ runs:
       env:
         RESULTS: ${{ steps.select-results.outputs.results }}
         COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
+        PR_ACTIVE: ${{ steps.check-pr-state.outputs.active }}
       run: bash ${{ github.action_path }}/scripts/core/enforce-final-status.sh
 
     - name: Run release
@@ -426,7 +455,7 @@ runs:
       run: bash ${{ github.action_path }}/scripts/release/run-release.sh
 
     - name: Post PR comment
-      if: always() && github.event_name == 'pull_request'
+      if: always() && github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token || github.token }}

--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -3,6 +3,12 @@
 set -euo pipefail
 
 if [ -z "${RESULTS:-}" ] || [ "${RESULTS}" = "{}" ]; then
+  # If the PR was merged/closed before commands ran, empty results are expected
+  if [ "${PR_ACTIVE:-}" = "false" ]; then
+    echo "PR was merged or closed before commands ran — nothing to enforce"
+    exit 0
+  fi
+
   # If the only command is "release", empty results are expected (release runs separately)
   COMMANDS="${COMMANDS:-}"
   NON_RELEASE="$(echo "${COMMANDS}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^release$' | grep -v '^$' || true)"

--- a/scripts/core/resolve-commands.sh
+++ b/scripts/core/resolve-commands.sh
@@ -42,5 +42,24 @@ else
   echo "Commands inferred from context (${SCOPE_CONTEXT}): ${RESOLVED_COMMANDS}"
 fi
 
+# Detect refactor-only command sets (e.g., "refactor --from all").
+# When all commands are refactor variants, the rerun after autofix is circular
+# because the autofix command IS the same refactor — rerunning it is pointless.
+REFACTOR_ONLY="false"
+IFS=',' read -ra _CHECK_ARRAY <<< "${RESOLVED_COMMANDS}"
+_ALL_REFACTOR=true
+for _cmd in "${_CHECK_ARRAY[@]}"; do
+  _base=$(echo "${_cmd}" | xargs | awk '{print $1}')
+  if [ "${_base}" != "refactor" ]; then
+    _ALL_REFACTOR=false
+    break
+  fi
+done
+if [ "${_ALL_REFACTOR}" = true ]; then
+  REFACTOR_ONLY="true"
+  echo "Commands are refactor-only — rerun after autofix will be skipped"
+fi
+
 echo "RESOLVED_COMMANDS=${RESOLVED_COMMANDS}" >> "${GITHUB_ENV}"
 echo "resolved-commands=${RESOLVED_COMMANDS}" >> "${GITHUB_OUTPUT}"
+echo "refactor-only=${REFACTOR_ONLY}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

Two CI waste fixes observed from [homeboy CI run #23550835636](https://github.com/Extra-Chill/homeboy/actions/runs/23550835636/job/68564745285):

### 1. Skip rerun for refactor-only command sets

The rerun step re-executes all commands after autofix commits to verify that the fixes actually resolved failures. This is valuable when diagnostic commands (`audit,lint,test`) fail and autofix (`refactor --from all --write`) repairs them — the rerun confirms they pass now.

**But when the command set is `refactor --from all`** (as in homeboy's `Auto-refactor` CI job), the autofix command is also `refactor --from all --write`. Rerunning `refactor --from all` after autofix is circular — the same broken refactor just fails twice, wasting ~5 minutes per run.

**Fix:** `resolve-commands.sh` now detects refactor-only command sets and outputs `refactor-only=true`. The rerun step checks this output and skips when true.

### 2. `pr_is_active()` guard before Phase 5

The `concurrency` group cancels stale runs when a *new push* arrives on the same PR. But **merging** doesn't trigger a new `pull_request` event — so the run keeps going. In the observed run, PR #1016 was merged at `16:04:09Z`, but the Auto-refactor job started at `16:05:35Z` (1m 26s after merge) and ran the full refactor command for nothing.

`pr_is_active()` already existed in `apply-autofix-commit.sh` (Phase 6), but Phase 5 had no guard at all.

**Fix:** New `Check PR state` step before Phase 5 calls `pr_is_active()`. If the PR is merged/closed, it outputs `active=false` and all subsequent steps (run-commands, autofix, rerun, PR comment) are gated on this output. The `enforce-final-status` step also handles the empty-results case gracefully instead of erroring.