### PR TITLE
fix: open non-PR autofix PRs without reruns

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -378,34 +378,14 @@ runs:
         APP_TOKEN: ${{ inputs.app-token }}
       run: bash ${{ github.action_path }}/scripts/autofix/prepare-autofix-branch.sh
 
-    # Rerun verifies that autofix actually repaired the failures. Skip when
-    # the command set is refactor-only — the autofix IS the same refactor
-    # command, so rerunning it is circular and wastes CI minutes.
-    - name: Re-run Homeboy commands after autofix
-      id: rerun-commands
-      continue-on-error: true
-      if: |
-        steps.resolve-commands.outputs.refactor-only != 'true'
-        && (
-          (github.event_name == 'pull_request' && steps.autofix-commit.outputs.committed == 'true')
-          || (github.event_name != 'pull_request' && steps.autofix-prepare-nonpr.outputs.committed == 'true')
-        )
-      shell: bash
-      env:
-        COMPONENT_NAME: ${{ inputs.component }}
-        EXTRA_ARGS: ${{ inputs.args }}
-        RUN_GROUP_PREFIX: homeboy rerun
-      run: bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
-
     - name: Open non-PR autofix PR
       id: autofix-open-pr
-      if: github.event_name != 'pull_request' && steps.autofix-prepare-nonpr.outputs.committed == 'true' && steps.rerun-commands.outputs.results != '' && !contains(steps.rerun-commands.outputs.results, '"fail"')
+      if: github.event_name != 'pull_request' && steps.autofix-prepare-nonpr.outputs.committed == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token || github.token }}
         COMPONENT_NAME: ${{ inputs.component }}
         AUTOFIX_BRANCH: ${{ steps.autofix-prepare-nonpr.outputs.autofix-branch }}
-        RESULTS: ${{ steps.rerun-commands.outputs.results }}
         AUTOFIX_FILE_COUNT: ${{ steps.autofix-prepare-nonpr.outputs.autofix-file-count }}
         AUTOFIX_FIX_TYPES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-fix-types }}
         AUTOFIX_FINDING_TYPES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-finding-types }}
@@ -419,7 +399,6 @@ runs:
       shell: bash
       env:
         FIRST_RESULTS: ${{ steps.run-commands.outputs.results }}
-        RERUN_RESULTS: ${{ steps.rerun-commands.outputs.results }}
       run: bash ${{ github.action_path }}/scripts/core/select-final-results.sh
 
     - name: Generate failure digest

--- a/scripts/autofix/open-autofix-pr.sh
+++ b/scripts/autofix/open-autofix-pr.sh
@@ -52,11 +52,11 @@ if [ -n "${EXISTING_PR_URL}" ]; then
       FINDING_DETAIL="- **Finding categories:** ${AUTOFIX_FINDING_TYPES}"
     fi
 
-    cat > "${UPDATE_BODY_FILE}" <<UPDATEBODY
+cat > "${UPDATE_BODY_FILE}" <<UPDATEBODY
 ## Summary
 ${AUTOFIX_DETAIL:+${AUTOFIX_DETAIL}
 }${FINDING_DETAIL:+${FINDING_DETAIL}
-}- Rerun after autofix passed for configured command set.
+}- Opened immediately after autofix without rerunning quality gates.
 - Generated automatically by Homeboy Action.
 
 ## Context
@@ -94,7 +94,7 @@ cat > "${BODY_FILE}" <<EOF
 ## Summary
 ${AUTOFIX_DETAIL:+${AUTOFIX_DETAIL}
 }${FINDING_DETAIL:+${FINDING_DETAIL}
-}- Rerun after autofix passed for configured command set.
+}- Opened immediately after autofix without rerunning quality gates.
 - Generated automatically by Homeboy Action.
 
 ## Context

--- a/scripts/core/select-final-results.sh
+++ b/scripts/core/select-final-results.sh
@@ -2,8 +2,4 @@
 
 set -euo pipefail
 
-if [ -n "${RERUN_RESULTS:-}" ] && [ "${RERUN_RESULTS}" != "{}" ]; then
-  echo "results=${RERUN_RESULTS}" >> "${GITHUB_OUTPUT}"
-else
-  echo "results=${FIRST_RESULTS}" >> "${GITHUB_OUTPUT}"
-fi
+echo "results=${FIRST_RESULTS}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- remove the non-PR post-autofix rerun of audit, lint, and test entirely
- open the autofix PR immediately after the autofix branch commit/push
- keep final results pinned to the first command run so issue filing and reporting reflect the original failures

## Why
The main/release flow was redundantly rerunning quality gates after , even though opening the PR triggers PR CI in the correct scope. That wasted CI time, delayed PR creation, and could erase original failures from issue filing.