### PR TITLE
fix: guard release and autofix against stale branch state

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -115,6 +115,16 @@ WORKSPACE="$(resolve_workspace)"
 TARGET_REPO="$(resolve_pr_target_repo)"
 TARGET_BRANCH="$(resolve_pr_target_branch)"
 TARGET_REF="refs/remotes/homeboy-autofix-target/${TARGET_BRANCH}"
+ORIGINAL_HEAD_SHA="$(git rev-parse HEAD 2>/dev/null || true)"
+BUILT_HEAD_SHA="${HOMEBOY_CLI_HEAD_SHA:-}"
+
+if [ -n "${BUILT_HEAD_SHA}" ] && [ -n "${ORIGINAL_HEAD_SHA}" ] && [ "${BUILT_HEAD_SHA}" != "${ORIGINAL_HEAD_SHA}" ]; then
+  echo "Skipping autofix: installed homeboy binary was built from ${BUILT_HEAD_SHA}, but checkout is at ${ORIGINAL_HEAD_SHA}" 
+  echo "attempted=false" >> "${GITHUB_OUTPUT}"
+  echo "status=skipped-stale-binary" >> "${GITHUB_OUTPUT}"
+  echo "committed=false" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
 
 fetch_latest_target_head() {
   local fetch_url
@@ -273,6 +283,16 @@ if ! fetch_latest_target_head; then
   echo "::warning::Could not fetch latest PR head ${TARGET_REPO}:${TARGET_BRANCH}; using current checkout"
 else
   echo "Fetched latest PR head ${TARGET_REPO}:${TARGET_BRANCH}"
+  if git show-ref --verify --quiet "${TARGET_REF}"; then
+    TARGET_HEAD_SHA="$(git rev-parse "${TARGET_REF}" 2>/dev/null || true)"
+    if [ -n "${BUILT_HEAD_SHA}" ] && [ -n "${TARGET_HEAD_SHA}" ] && [ "${BUILT_HEAD_SHA}" != "${TARGET_HEAD_SHA}" ]; then
+      echo "Skipping autofix: installed homeboy binary was built from ${BUILT_HEAD_SHA}, but latest PR head is ${TARGET_HEAD_SHA}"
+      echo "attempted=false" >> "${GITHUB_OUTPUT}"
+      echo "status=skipped-stale-binary" >> "${GITHUB_OUTPUT}"
+      echo "committed=false" >> "${GITHUB_OUTPUT}"
+      exit 0
+    fi
+  fi
 fi
 
 PUSH_ATTEMPT=1

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -75,6 +75,20 @@ if [ "${CURRENT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
   exit 0
 fi
 
+DEFAULT_BRANCH="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)"
+if [ -z "${DEFAULT_BRANCH}" ]; then
+  DEFAULT_BRANCH="main"
+fi
+
+if [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
+  echo "::error::Refusing to release from non-default branch '${CURRENT_BRANCH}' (default: '${DEFAULT_BRANCH}')"
+  {
+    echo "released=false"
+    echo "skipped-reason=wrong-default-branch"
+  } >> "${GITHUB_OUTPUT}"
+  exit 1
+fi
+
 # --- Step 2b: Sync with remote ---
 # The quality gate runs in separate jobs that may push autofix commits
 # or new PRs may merge while the pipeline is in flight. Pull to ensure

--- a/scripts/setup/capture-tooling-metadata.sh
+++ b/scripts/setup/capture-tooling-metadata.sh
@@ -8,14 +8,15 @@ HOMEBOY_CLI_VERSION="$(homeboy --version 2>/dev/null || echo 'unknown')"
 # "0.74.1 release" from "0.74.1+abc1234 built from HEAD"
 if [ -d ".git" ]; then
   HEAD_SHORT="$(git rev-parse --short HEAD 2>/dev/null || true)"
+  HEAD_FULL="$(git rev-parse HEAD 2>/dev/null || true)"
   if [ -n "${HEAD_SHORT}" ]; then
     VERSION_NUM="${HOMEBOY_CLI_VERSION#homeboy }"
     TAG_COMMIT="$(git rev-parse "v${VERSION_NUM}" 2>/dev/null || true)"
-    HEAD_FULL="$(git rev-parse HEAD 2>/dev/null || true)"
     if [ -n "${TAG_COMMIT}" ] && [ "${TAG_COMMIT}" != "${HEAD_FULL}" ]; then
       HOMEBOY_CLI_VERSION="${HOMEBOY_CLI_VERSION}+${HEAD_SHORT}"
     fi
   fi
+  echo "HOMEBOY_CLI_HEAD_SHA=${HEAD_FULL}" >> "${GITHUB_ENV}"
 fi
 
 # v2: use PORTABLE_EXTENSION (inferred from homeboy.json) as primary,


### PR DESCRIPTION
## Summary
- capture the installed homeboy binary HEAD SHA and skip PR autofix when the checkout has moved past that build
- block release runs from non-default branches in the action layer before core release runs
- surface branch/binary drift earlier so CI stops mutating newer heads with older tooling
