### PR TITLE
feat: create GitHub Releases after successful version releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,80 @@ jobs:
           release-dry-run: ${{ inputs.dry-run || 'false' }}
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
+  # ── Step 3: Create GitHub Release ──
+  # After a successful release, create a GitHub Release from the tag
+  # with changelog notes extracted from docs/CHANGELOG.md.
+  create-release:
+    name: Create GitHub Release
+    needs: release
+    if: ${{ needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Get release metadata
+        id: meta
+        run: |
+          # Get the latest semver tag (skip floating tags like v1, v2)
+          TAG="$(git tag --sort=-creatordate --list 'v[0-9]*.[0-9]*.[0-9]*' | head -1)"
+          if [ -z "${TAG}" ]; then
+            echo "::error::No semver tag found on HEAD"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Release tag: ${TAG} (version: ${VERSION})"
+
+      - name: Extract changelog section
+        id: notes
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          CHANGELOG="docs/CHANGELOG.md"
+
+          if [ ! -f "${CHANGELOG}" ]; then
+            echo "body=Release ${VERSION}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract the section for this version: from "## [VERSION]" to the next "## ["
+          BODY=$(awk -v ver="${VERSION}" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) found=1
+              next
+            }
+            found { print }
+          ' "${CHANGELOG}" | sed '/^$/N;/^\n$/d')
+
+          if [ -z "${BODY}" ]; then
+            BODY="Release v${VERSION}"
+          fi
+
+          # Write to file to avoid quoting issues
+          echo "${BODY}" > /tmp/release-notes.md
+          echo "notes-file=/tmp/release-notes.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+
+          # Skip if release already exists
+          if gh release view "${TAG}" > /dev/null 2>&1; then
+            echo "Release ${TAG} already exists — skipping"
+            exit 0
+          fi
+
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --notes-file "${{ steps.notes.outputs.notes-file }}" \
+            --verify-tag
+
   # ── Record failed SHA to prevent retry loops ──
   record-failure:
     name: Record failure


### PR DESCRIPTION
## Summary
- Adds a `create-release` job to the release workflow that creates a GitHub Release after each successful version release
- Extracts changelog notes from `docs/CHANGELOG.md` for the released version
- Uses `gh release create` with `--verify-tag` to ensure the tag exists
- Idempotent — skips if the release already exists
- Uses semver tag filtering (`v[0-9]*.[0-9]*.[0-9]*`) to avoid picking up floating tags like `v1` or `v2`

## Problem
The release workflow creates tags, changelogs, and moves the floating `v2` tag, but never created GitHub Releases. The Releases page stopped at v1.7.0 (manually created) while the actual versions went up to v1.13.7.

## Flow after this change
```
check → release (tag + push + v2 hook) → create-release (GitHub Release)
                                        → clear-failure
```