### PR TITLE
feat: add fleet and deploy as first-class action commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,16 @@ inputs:
     required: false
     default: ''
 
+  # ── SSH (for fleet/deploy) ──
+  ssh-key:
+    description: 'SSH private key for fleet/deploy commands. Writes to ~/.ssh, starts ssh-agent, configures known_hosts. If empty, assumes SSH is pre-configured.'
+    required: false
+    default: ''
+  ssh-known-hosts:
+    description: 'Extra known_hosts entries for SSH connections to your servers.'
+    required: false
+    default: ''
+
   # ── Release ──
   release-dry-run:
     description: 'Preview the release without making changes.'
@@ -139,6 +149,9 @@ outputs:
   scope-is-fork:
     description: 'Whether the PR is from a fork (true/false)'
     value: ${{ steps.resolve-scope.outputs.scope-is-fork }}
+  operations-results:
+    description: 'JSON object with pass/fail results for each fleet/deploy command'
+    value: ${{ steps.run-operations.outputs.results }}
   released:
     description: 'Whether a release was created (true/false)'
     value: ${{ steps.release.outputs.released }}
@@ -205,6 +218,17 @@ runs:
       if: inputs.auto-setup == 'true'
       shell: bash
       run: bash ${{ github.action_path }}/scripts/setup/auto-setup-environment.sh
+
+    # ── Phase 3b: SSH setup (for fleet/deploy) ──
+
+    - name: Setup SSH
+      id: setup-ssh
+      if: contains(steps.resolve-commands.outputs.operations-commands, 'fleet') || contains(steps.resolve-commands.outputs.operations-commands, 'deploy') || inputs.ssh-key != ''
+      shell: bash
+      env:
+        SSH_KEY: ${{ inputs.ssh-key }}
+        SSH_KNOWN_HOSTS: ${{ inputs.ssh-known-hosts }}
+      run: bash ${{ github.action_path }}/scripts/setup/setup-ssh.sh
 
     # ── Phase 4: Install Homeboy ──
 
@@ -324,7 +348,7 @@ runs:
     - name: Run Homeboy commands
       id: run-commands
       continue-on-error: true
-      if: steps.check-pr-state.outputs.active != 'false'
+      if: steps.check-pr-state.outputs.active != 'false' && steps.resolve-commands.outputs.resolved-commands != ''
       shell: bash
       env:
         COMPONENT_NAME: ${{ inputs.component }}
@@ -412,16 +436,6 @@ runs:
         AUTOFIX_COMMANDS: ${{ inputs.autofix-commands }}
       run: bash ${{ github.action_path }}/scripts/digest/generate-failure-digest.sh
 
-    - name: Enforce final status
-      id: enforce-status
-      if: always()
-      shell: bash
-      env:
-        RESULTS: ${{ steps.select-results.outputs.results }}
-        COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
-        PR_ACTIVE: ${{ steps.check-pr-state.outputs.active }}
-      run: bash ${{ github.action_path }}/scripts/core/enforce-final-status.sh
-
     - name: Run release
       id: release
       if: contains(steps.resolve-commands.outputs.resolved-commands, 'release') && github.event_name != 'pull_request'
@@ -432,6 +446,33 @@ runs:
         RELEASE_BRANCH: ${{ inputs.release-branch }}
         COMPONENT_NAME: ${{ inputs.component }}
       run: bash ${{ github.action_path }}/scripts/release/run-release.sh
+
+    # ── Phase 7b: Operations (fleet/deploy) ──
+    # Runs after quality gates and release — the primary use case is
+    # "release then deploy" or "release then fleet exec upgrade".
+    # Only runs when operations commands are present.
+
+    - name: Run operations (fleet/deploy)
+      id: run-operations
+      if: steps.resolve-commands.outputs.operations-commands != ''
+      continue-on-error: true
+      shell: bash
+      env:
+        OPERATIONS_COMMANDS: ${{ steps.resolve-commands.outputs.operations-commands }}
+        EXTRA_ARGS: ${{ inputs.args }}
+        RUN_GROUP_PREFIX: homeboy
+      run: bash ${{ github.action_path }}/scripts/operations/run-operations.sh
+
+    - name: Enforce final status
+      id: enforce-status
+      if: always()
+      shell: bash
+      env:
+        RESULTS: ${{ steps.select-results.outputs.results }}
+        COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
+        OPERATIONS_RESULTS: ${{ steps.run-operations.outputs.results }}
+        PR_ACTIVE: ${{ steps.check-pr-state.outputs.active }}
+      run: bash ${{ github.action_path }}/scripts/core/enforce-final-status.sh
 
     - name: Post PR comment
       if: always() && github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false'

--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -2,26 +2,55 @@
 
 set -euo pipefail
 
+OPERATIONS_RESULTS="${OPERATIONS_RESULTS:-}"
+HAS_QUALITY_COMMANDS=true
+HAS_OPERATIONS_COMMANDS=true
+
 if [ -z "${RESULTS:-}" ] || [ "${RESULTS}" = "{}" ]; then
+  HAS_QUALITY_COMMANDS=false
+
   # If the PR was merged/closed before commands ran, empty results are expected
   if [ "${PR_ACTIVE:-}" = "false" ]; then
     echo "PR was merged or closed before commands ran — nothing to enforce"
     exit 0
   fi
 
-  # If the only command is "release", empty results are expected (release runs separately)
+  # If the only commands are release/operations, empty quality results are expected
   COMMANDS="${COMMANDS:-}"
   NON_RELEASE="$(echo "${COMMANDS}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^release$' | grep -v '^$' || true)"
-  if [ -z "${NON_RELEASE}" ]; then
+  if [ -z "${NON_RELEASE}" ] && [ -z "${OPERATIONS_RESULTS}" ]; then
     echo "Release-only mode — no quality gate commands to enforce"
     exit 0
   fi
-  echo "::error::No command results were produced"
-  exit 1
+
+  # If we have operations results but no quality results, that's fine
+  if [ -z "${NON_RELEASE}" ] && [ -n "${OPERATIONS_RESULTS}" ]; then
+    HAS_QUALITY_COMMANDS=false
+  elif [ -z "${OPERATIONS_RESULTS}" ]; then
+    echo "::error::No command results were produced"
+    exit 1
+  fi
 fi
 
-if echo "${RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
-  echo "::error::One or more Homeboy commands failed"
+FAILED=false
+
+# Check quality command results
+if [ "${HAS_QUALITY_COMMANDS}" = true ]; then
+  if echo "${RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
+    echo "::error::One or more quality commands failed"
+    FAILED=true
+  fi
+fi
+
+# Check operations command results
+if [ -n "${OPERATIONS_RESULTS}" ] && [ "${OPERATIONS_RESULTS}" != "{}" ]; then
+  if echo "${OPERATIONS_RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
+    echo "::error::One or more operations commands (fleet/deploy) failed"
+    FAILED=true
+  fi
+fi
+
+if [ "${FAILED}" = true ]; then
   exit 1
 fi
 

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -295,7 +295,8 @@ resolve_push_target() {
 
 # Sort commands into canonical order: audit → lint → test → refactor.
 # Audit/lint/test are the core quality gates; real refactor commands run after
-# them when explicitly requested.
+# them when explicitly requested. Fleet/deploy are operations commands handled
+# separately by run-operations.sh and are filtered out here.
 canonicalize_commands() {
   local commands="$1"
   local audit="" lint="" test="" refactor="" others=()
@@ -310,6 +311,8 @@ canonicalize_commands() {
       lint)    lint="lint" ;;
       test)    test="test" ;;
       refactor) refactor="${cmd}" ;;
+      # Fleet/deploy are operations commands — handled by run-operations.sh
+      fleet|deploy) ;;
       *)       others+=("${cmd}") ;;
     esac
   done

--- a/scripts/core/resolve-commands.sh
+++ b/scripts/core/resolve-commands.sh
@@ -5,12 +5,20 @@
 # If the COMMANDS input is explicitly set (non-empty and not the old v1 default),
 # use it as-is. Otherwise, infer from the GitHub event context.
 #
+# Commands are split into two categories:
+#   1. Quality commands: audit, lint, test, refactor, release
+#      These run in canonical order with component/workspace/scope handling.
+#   2. Operations commands: fleet, deploy
+#      These are passthrough commands that talk to remote servers via SSH.
+#      They're never auto-inferred — must be explicitly specified.
+#
 # Reads:
 #   COMMANDS_INPUT     — raw input from action consumer (may be empty)
 #   SCOPE_CONTEXT      — pr | push | cron | manual (set by scope/resolve.sh)
 #
 # Outputs (GITHUB_ENV + GITHUB_OUTPUT):
-#   RESOLVED_COMMANDS  — comma-separated command list
+#   RESOLVED_COMMANDS     — comma-separated quality command list
+#   OPERATIONS_COMMANDS   — comma-separated operations command list (fleet/deploy)
 
 set -euo pipefail
 
@@ -18,48 +26,92 @@ COMMANDS_INPUT="${COMMANDS_INPUT:-}"
 SCOPE_CONTEXT="${SCOPE_CONTEXT:-manual}"
 
 if [ -n "${COMMANDS_INPUT}" ]; then
-  RESOLVED_COMMANDS="${COMMANDS_INPUT}"
-  echo "Commands from input: ${RESOLVED_COMMANDS}"
+  ALL_COMMANDS="${COMMANDS_INPUT}"
+  echo "Commands from input: ${ALL_COMMANDS}"
 else
-  # Context-aware defaults
+  # Context-aware defaults (never include operations commands)
   case "${SCOPE_CONTEXT}" in
     pr)
-      RESOLVED_COMMANDS="audit,lint,test"
+      ALL_COMMANDS="audit,lint,test"
       ;;
     push)
-      RESOLVED_COMMANDS="audit,lint,test"
+      ALL_COMMANDS="audit,lint,test"
       ;;
     cron)
-      RESOLVED_COMMANDS="release"
+      ALL_COMMANDS="release"
       ;;
     manual)
-      RESOLVED_COMMANDS="audit,lint,test"
+      ALL_COMMANDS="audit,lint,test"
       ;;
     *)
-      RESOLVED_COMMANDS="audit,lint,test"
+      ALL_COMMANDS="audit,lint,test"
       ;;
   esac
-  echo "Commands inferred from context (${SCOPE_CONTEXT}): ${RESOLVED_COMMANDS}"
+  echo "Commands inferred from context (${SCOPE_CONTEXT}): ${ALL_COMMANDS}"
+fi
+
+# Split commands into quality vs operations categories.
+# Operations commands (fleet/deploy) are passthrough — they use their own
+# argument structure and don't take component/workspace/scope flags.
+QUALITY_COMMANDS=()
+OPS_COMMANDS=()
+
+IFS=',' read -ra _ALL_ARRAY <<< "${ALL_COMMANDS}"
+for _cmd in "${_ALL_ARRAY[@]}"; do
+  _cmd="$(echo "${_cmd}" | xargs)"
+  [ -z "${_cmd}" ] && continue
+  _base=$(echo "${_cmd}" | awk '{print $1}')
+  case "${_base}" in
+    fleet|deploy)
+      OPS_COMMANDS+=("${_cmd}")
+      ;;
+    *)
+      QUALITY_COMMANDS+=("${_cmd}")
+      ;;
+  esac
+done
+
+# Join arrays back to comma-separated strings
+RESOLVED_COMMANDS=""
+if [ ${#QUALITY_COMMANDS[@]} -gt 0 ]; then
+  RESOLVED_COMMANDS="$(IFS=','; printf '%s' "${QUALITY_COMMANDS[*]}")"
+fi
+
+OPERATIONS_COMMANDS=""
+if [ ${#OPS_COMMANDS[@]} -gt 0 ]; then
+  OPERATIONS_COMMANDS="$(IFS=','; printf '%s' "${OPS_COMMANDS[*]}")"
+fi
+
+if [ -n "${RESOLVED_COMMANDS}" ]; then
+  echo "Quality commands: ${RESOLVED_COMMANDS}"
+fi
+if [ -n "${OPERATIONS_COMMANDS}" ]; then
+  echo "Operations commands: ${OPERATIONS_COMMANDS}"
 fi
 
 # Detect refactor-only command sets (e.g., "refactor --from all").
 # When all commands are refactor variants, the rerun after autofix is circular
 # because the autofix command IS the same refactor — rerunning it is pointless.
 REFACTOR_ONLY="false"
-IFS=',' read -ra _CHECK_ARRAY <<< "${RESOLVED_COMMANDS}"
-_ALL_REFACTOR=true
-for _cmd in "${_CHECK_ARRAY[@]}"; do
-  _base=$(echo "${_cmd}" | xargs | awk '{print $1}')
-  if [ "${_base}" != "refactor" ]; then
-    _ALL_REFACTOR=false
-    break
+if [ -n "${RESOLVED_COMMANDS}" ]; then
+  IFS=',' read -ra _CHECK_ARRAY <<< "${RESOLVED_COMMANDS}"
+  _ALL_REFACTOR=true
+  for _cmd in "${_CHECK_ARRAY[@]}"; do
+    _base=$(echo "${_cmd}" | xargs | awk '{print $1}')
+    if [ "${_base}" != "refactor" ]; then
+      _ALL_REFACTOR=false
+      break
+    fi
+  done
+  if [ "${_ALL_REFACTOR}" = true ]; then
+    REFACTOR_ONLY="true"
+    echo "Commands are refactor-only — rerun after autofix will be skipped"
   fi
-done
-if [ "${_ALL_REFACTOR}" = true ]; then
-  REFACTOR_ONLY="true"
-  echo "Commands are refactor-only — rerun after autofix will be skipped"
 fi
 
 echo "RESOLVED_COMMANDS=${RESOLVED_COMMANDS}" >> "${GITHUB_ENV}"
 echo "resolved-commands=${RESOLVED_COMMANDS}" >> "${GITHUB_OUTPUT}"
 echo "refactor-only=${REFACTOR_ONLY}" >> "${GITHUB_OUTPUT}"
+
+echo "OPERATIONS_COMMANDS=${OPERATIONS_COMMANDS}" >> "${GITHUB_ENV}"
+echo "operations-commands=${OPERATIONS_COMMANDS}" >> "${GITHUB_OUTPUT}"

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -4,14 +4,21 @@ set -euo pipefail
 
 source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
 
+# v2: prefer RESOLVED_COMMANDS (from resolve-commands.sh), fall back to COMMANDS for compat
+EFFECTIVE_COMMANDS="${RESOLVED_COMMANDS:-${COMMANDS:-audit,lint,test}}"
+
+# If no quality commands to run (e.g. operations-only mode), exit cleanly
+if [ -z "${EFFECTIVE_COMMANDS}" ]; then
+  echo "No quality commands to run"
+  echo "results={}" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
 COMP_ID="$(resolve_component_id)"
 WORKSPACE="$(resolve_workspace)"
 RESULTS='{}'
 OVERALL_EXIT=0
 GROUP_PREFIX="${RUN_GROUP_PREFIX:-homeboy}"
-
-# v2: prefer RESOLVED_COMMANDS (from resolve-commands.sh), fall back to COMMANDS for compat
-EFFECTIVE_COMMANDS="${RESOLVED_COMMANDS:-${COMMANDS:-audit,lint,test}}"
 
 HOMEBOY_OUTPUT_DIR=$(mktemp -d)
 echo "HOMEBOY_OUTPUT_DIR=${HOMEBOY_OUTPUT_DIR}" >> "${GITHUB_ENV}"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -156,4 +156,26 @@ assert_equals \
   "$(resolve_push_target "some-contributor/homeboy-action" "secret123")" \
   "fork push with token uses authenticated remote url"
 
+# ── Canonicalize: fleet/deploy commands are filtered out ──
+
+assert_equals \
+  "audit,lint,test" \
+  "$(canonicalize_commands "audit,lint,test,fleet exec my-fleet -- homeboy upgrade")" \
+  "canonicalize strips fleet commands"
+
+assert_equals \
+  "audit,lint,test" \
+  "$(canonicalize_commands "audit,deploy my-project --all,lint,test")" \
+  "canonicalize strips deploy commands"
+
+assert_equals \
+  "audit,lint,test,refactor --all" \
+  "$(canonicalize_commands "deploy --fleet prod data-machine,audit,lint,test,fleet status my-fleet,refactor --all")" \
+  "canonicalize strips all operations and preserves order"
+
+assert_equals \
+  "" \
+  "$(canonicalize_commands "fleet exec my-fleet -- homeboy upgrade,deploy my-project --all")" \
+  "canonicalize returns empty when only operations commands"
+
 printf 'All command builder checks passed.\n'

--- a/scripts/operations/run-operations.sh
+++ b/scripts/operations/run-operations.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Run fleet and deploy commands.
+#
+# Unlike quality-gate commands (audit/lint/test), fleet and deploy are
+# "operations" commands that talk to remote servers via SSH. They use
+# their own argument structure and don't take component/workspace/scope
+# flags from the action — the full command is passed through as-is.
+#
+# Commands are specified as the full homeboy invocation after the base
+# command, e.g.:
+#   fleet exec my-fleet -- homeboy upgrade
+#   deploy my-project --all
+#   deploy data-machine --fleet production
+#   fleet check my-fleet
+#   fleet status my-fleet
+#
+# Env vars:
+#   OPERATIONS_COMMANDS — newline or comma-separated list of commands
+#   EXTRA_ARGS          — additional args appended to each command
+#   RUN_GROUP_PREFIX    — log group prefix (default: homeboy)
+#
+# Outputs (GITHUB_OUTPUT):
+#   results — JSON object { "fleet exec ...": "pass"|"fail", ... }
+#   any-failed — true|false
+
+set -euo pipefail
+
+OPERATIONS_COMMANDS="${OPERATIONS_COMMANDS:-}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+GROUP_PREFIX="${RUN_GROUP_PREFIX:-homeboy}"
+
+if [ -z "${OPERATIONS_COMMANDS}" ]; then
+  echo "No operations commands to run"
+  echo "results={}" >> "${GITHUB_OUTPUT}"
+  echo "any-failed=false" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+HOMEBOY_OUTPUT_DIR="${HOMEBOY_OUTPUT_DIR:-$(mktemp -d)}"
+RESULTS='{}'
+OVERALL_EXIT=0
+CMD_INDEX=0
+
+# Parse commands: support both comma-separated and newline-separated
+# Normalize newlines to commas, then split
+NORMALIZED_COMMANDS="$(printf '%s' "${OPERATIONS_COMMANDS}" | tr '\n' ',' | sed 's/,,*/,/g; s/^,//; s/,$//')"
+IFS=',' read -ra CMD_ARRAY <<< "${NORMALIZED_COMMANDS}"
+
+for CMD in "${CMD_ARRAY[@]}"; do
+  CMD="$(echo "${CMD}" | xargs)"
+  [ -z "${CMD}" ] && continue
+
+  CMD_INDEX=$((CMD_INDEX + 1))
+
+  # Build the full command
+  # Fleet and deploy commands are passthrough — we prepend "homeboy" and pass as-is
+  FULL_CMD="homeboy ${CMD}"
+
+  # Add output file for structured results
+  OUTPUT_STEM="operations-${CMD_INDEX}"
+  OUTPUT_JSON="${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.json"
+  FULL_CMD="homeboy --output ${OUTPUT_JSON} ${CMD}"
+
+  # Append extra args if provided
+  if [ -n "${EXTRA_ARGS}" ]; then
+    FULL_CMD="${FULL_CMD} ${EXTRA_ARGS}"
+  fi
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Running: ${FULL_CMD}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  echo "::group::${GROUP_PREFIX} ${CMD}"
+  CMD_EXIT=0
+  set +e
+  eval "${FULL_CMD}" 2>&1 | tee "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log"
+  CMD_EXIT=${PIPESTATUS[0]}
+  set -e
+  echo "::endgroup::"
+
+  # Use a short label for the results key
+  RESULT_KEY="${CMD}"
+
+  if [ "${CMD_EXIT}" -eq 0 ]; then
+    echo "::notice::homeboy ${CMD}: PASSED"
+    RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${RESULT_KEY}" '. + {($cmd): "pass"}')
+  else
+    echo "::error::homeboy ${CMD}: FAILED (exit code ${CMD_EXIT})"
+    RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${RESULT_KEY}" '. + {($cmd): "fail"}')
+    OVERALL_EXIT=1
+  fi
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Operations results: ${RESULTS}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+echo "results=${RESULTS}" >> "${GITHUB_OUTPUT}"
+
+if [ "${OVERALL_EXIT}" -ne 0 ]; then
+  echo "any-failed=true" >> "${GITHUB_OUTPUT}"
+else
+  echo "any-failed=false" >> "${GITHUB_OUTPUT}"
+fi
+
+exit "${OVERALL_EXIT}"

--- a/scripts/scope/flags.sh
+++ b/scripts/scope/flags.sh
@@ -23,6 +23,6 @@ scope_flags_for() {
     audit|lint|test|refactor)
       printf '%s' "--changed-since ${SCOPE_BASE_REF}"
       ;;
-    # release and other commands are never scoped
+    # release, fleet, deploy, and other commands are never scoped
   esac
 }

--- a/scripts/setup/setup-ssh.sh
+++ b/scripts/setup/setup-ssh.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Configure SSH for fleet/deploy commands.
+#
+# Supports two modes:
+#   1. SSH_KEY provided: writes the key, starts ssh-agent, adds known_hosts
+#   2. SSH_KEY empty: assumes SSH is already configured (e.g. webfactory/ssh-agent)
+#
+# Env vars:
+#   SSH_KEY         — SSH private key content (optional)
+#   SSH_KNOWN_HOSTS — extra known_hosts entries (optional)
+#
+# Outputs (GITHUB_OUTPUT):
+#   ssh-configured — true|false
+
+set -euo pipefail
+
+SSH_KEY="${SSH_KEY:-}"
+SSH_KNOWN_HOSTS="${SSH_KNOWN_HOSTS:-}"
+
+SSH_DIR="${HOME}/.ssh"
+mkdir -p "${SSH_DIR}"
+chmod 700 "${SSH_DIR}"
+
+if [ -n "${SSH_KEY}" ]; then
+  echo "Configuring SSH from provided key..."
+
+  # Write the private key
+  KEY_FILE="${SSH_DIR}/id_ed25519"
+  printf '%s\n' "${SSH_KEY}" > "${KEY_FILE}"
+  chmod 600 "${KEY_FILE}"
+
+  # Ensure the key has a trailing newline (some secrets managers strip it)
+  if [ "$(tail -c 1 "${KEY_FILE}" | wc -l)" -eq 0 ]; then
+    printf '\n' >> "${KEY_FILE}"
+  fi
+
+  # Start ssh-agent if not already running
+  if [ -z "${SSH_AUTH_SOCK:-}" ]; then
+    eval "$(ssh-agent -s)"
+    echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "${GITHUB_ENV}"
+    echo "SSH_AGENT_PID=${SSH_AGENT_PID}" >> "${GITHUB_ENV}"
+  fi
+
+  # Add the key to the agent
+  ssh-add "${KEY_FILE}"
+
+  # Configure known_hosts — start with GitHub and common providers
+  KNOWN_HOSTS_FILE="${SSH_DIR}/known_hosts"
+  touch "${KNOWN_HOSTS_FILE}"
+  chmod 644 "${KNOWN_HOSTS_FILE}"
+
+  # Add GitHub's SSH keys (always useful in CI)
+  ssh-keyscan -t ed25519,rsa github.com >> "${KNOWN_HOSTS_FILE}" 2>/dev/null || true
+
+  # Add user-provided known_hosts entries
+  if [ -n "${SSH_KNOWN_HOSTS}" ]; then
+    printf '%s\n' "${SSH_KNOWN_HOSTS}" >> "${KNOWN_HOSTS_FILE}"
+  fi
+
+  # Configure SSH to accept new host keys for non-GitHub hosts
+  # This is a CI-specific tradeoff — we trust the user's servers
+  SSH_CONFIG_FILE="${SSH_DIR}/config"
+  if [ ! -f "${SSH_CONFIG_FILE}" ] || ! grep -q "StrictHostKeyChecking" "${SSH_CONFIG_FILE}" 2>/dev/null; then
+    cat >> "${SSH_CONFIG_FILE}" << 'SSHCONFIG'
+
+# Added by homeboy-action for fleet/deploy commands
+Host *
+  StrictHostKeyChecking accept-new
+  ServerAliveInterval 60
+  ServerAliveCountMax 3
+SSHCONFIG
+    chmod 600 "${SSH_CONFIG_FILE}"
+  fi
+
+  echo "SSH configured: key loaded, agent running, known_hosts populated"
+  echo "ssh-configured=true" >> "${GITHUB_OUTPUT}"
+
+elif [ -n "${SSH_AUTH_SOCK:-}" ]; then
+  echo "SSH agent already running (SSH_AUTH_SOCK=${SSH_AUTH_SOCK})"
+
+  # Still add user-provided known_hosts if any
+  if [ -n "${SSH_KNOWN_HOSTS}" ]; then
+    KNOWN_HOSTS_FILE="${SSH_DIR}/known_hosts"
+    touch "${KNOWN_HOSTS_FILE}"
+    printf '%s\n' "${SSH_KNOWN_HOSTS}" >> "${KNOWN_HOSTS_FILE}"
+    echo "Added extra known_hosts entries"
+  fi
+
+  echo "ssh-configured=true" >> "${GITHUB_OUTPUT}"
+
+else
+  echo "No SSH key provided and no SSH agent detected"
+  echo "Fleet/deploy commands requiring SSH will fail unless SSH is configured by a prior step"
+  echo "ssh-configured=false" >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
## Summary

Adds native support for `fleet` and `deploy` commands in homeboy-action, enabling CI-driven remote operations like automated CLI upgrades across server fleets and WordPress plugin deployments.

## What Changed

### New: Operations Commands (fleet/deploy)

Fleet and deploy are **operations commands** — they talk to remote servers via SSH, unlike quality-gate commands (audit/lint/test) which run locally. They're treated as a separate category:

- **Never auto-inferred** — must be explicitly specified via `commands` input
- **Passthrough execution** — the full command string is passed to homeboy as-is (no component/workspace/scope wrapping)
- **Run after quality gates and release** — the natural flow is "release → deploy to fleet"
- **No autofix, no PR comments, no issue filing** — just pass/fail results

### New: SSH Setup

Two new inputs for SSH configuration:

- `ssh-key` — writes the key to `~/.ssh`, starts `ssh-agent`, configures `known_hosts`
- `ssh-known-hosts` — extra known_hosts entries for your servers

Also supports pre-configured SSH (e.g., `webfactory/ssh-agent` in a prior step).

### Command Resolution

Commands are now split into two categories during resolution:
- **Quality commands**: `audit`, `lint`, `test`, `refactor`, `release` → canonical order, component/workspace/scope handling
- **Operations commands**: `fleet`, `deploy` → passthrough, run after quality + release

### Phase Ordering

```
Phase 1:  Read config
Phase 2:  Resolve scope + commands
Phase 3:  Environment setup
Phase 3b: SSH setup (new — for fleet/deploy)
Phase 4:  Install Homeboy
Phase 5:  Run quality commands
Phase 6:  Autofix
Phase 7:  Results + release
Phase 7b: Operations (new — fleet/deploy)
Phase 7c: Enforce final status (now checks both quality + operations)
Phase 8:  PR comments + auto-issues
```

## Usage Examples

### Self-update across fleet after release

```yaml
# In homeboy's own release workflow
- uses: Extra-Chill/homeboy-action@v2
  with:
    commands: 'fleet exec my-fleet -- homeboy upgrade'
    ssh-key: ${{ secrets.FLEET_SSH_KEY }}
```

### Quality gates + deploy

```yaml
- uses: Extra-Chill/homeboy-action@v2
  with:
    commands: 'audit,lint,test,deploy data-machine --fleet production'
    ssh-key: ${{ secrets.DEPLOY_SSH_KEY }}
```

### Operations-only (no quality gates)

```yaml
- uses: Extra-Chill/homeboy-action@v2
  with:
    commands: 'fleet status my-fleet'
    ssh-key: ${{ secrets.FLEET_SSH_KEY }}
```

## Tests

- All 28 command builder tests pass (including 4 new tests for fleet/deploy filtering)
- Autofix author guard tests pass
- All scripts pass `bash -n` syntax check
- `action.yml` validates as clean YAML