### PR TITLE
fix: remove composer.json and package.json config fallbacks

### DIFF
--- a/scripts/setup/read-portable-config.sh
+++ b/scripts/setup/read-portable-config.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
-# Read homeboy.json and infer configuration that consumers no longer need to specify.
+# Read homeboy.json — the single source of truth for project configuration.
 #
-# Infers:
+# Reads:
 #   PORTABLE_ID         — component id
 #   PORTABLE_EXTENSION  — extension id (first key from extensions object)
-#   PORTABLE_PHP        — php version (from extensions.<ext>.php or composer.json)
-#   PORTABLE_NODE       — node version (from extensions.<ext>.node or package.json)
+#   PORTABLE_PHP        — php version (from extensions.<ext>.php)
+#   PORTABLE_NODE       — node version (from extensions.<ext>.node)
+#
+# Action inputs can override php and node versions. Everything else
+# comes from homeboy.json or it doesn't exist.
 #
 # All values are written to GITHUB_ENV and GITHUB_OUTPUT for use by subsequent steps.
 
@@ -50,9 +53,8 @@ else
   PORTABLE_EXTENSION="$(jq -r '.extensions // {} | keys | first // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
 fi
 
-# ── PHP version inference ──
-# Priority: action input > extensions.<ext>.php > composer.json require.php > default
-# Default is only set when extension is wordpress (PHP extensions need PHP).
+# ── PHP version ──
+# Source: action input override > extensions.<ext>.php in homeboy.json
 
 PHP_INPUT="${PHP_INPUT:-}"
 PORTABLE_PHP=""
@@ -60,26 +62,11 @@ PORTABLE_PHP=""
 if [ -n "${PHP_INPUT}" ]; then
   PORTABLE_PHP="${PHP_INPUT}"
 elif [ -n "${PORTABLE_EXTENSION}" ]; then
-  # Check extensions.<ext>.php in homeboy.json
   PORTABLE_PHP="$(jq -r --arg ext "${PORTABLE_EXTENSION}" '.extensions[$ext].php // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
 fi
 
-if [ -z "${PORTABLE_PHP}" ] && [ -f "composer.json" ]; then
-  # Parse minimum PHP version from composer.json require.php constraint
-  # Handles: ">=8.2", "^8.2", "~8.2", "8.2.*", ">=8.2 <8.4", "8.2"
-  RAW_PHP="$(jq -r '.require.php // empty' composer.json 2>/dev/null || true)"
-  if [ -n "${RAW_PHP}" ]; then
-    PORTABLE_PHP="$(printf '%s' "${RAW_PHP}" | grep -oP '\d+\.\d+' | head -1 || true)"
-  fi
-fi
-
-# Default for WordPress extension when nothing else resolved
-if [ -z "${PORTABLE_PHP}" ] && [ "${PORTABLE_EXTENSION}" = "wordpress" ]; then
-  PORTABLE_PHP="8.2"
-fi
-
-# ── Node version inference ──
-# Priority: action input > extensions.<ext>.node > package.json engines.node > skip
+# ── Node version ──
+# Source: action input override > extensions.<ext>.node in homeboy.json
 
 NODE_INPUT="${NODE_INPUT:-}"
 PORTABLE_NODE=""
@@ -88,13 +75,6 @@ if [ -n "${NODE_INPUT}" ]; then
   PORTABLE_NODE="${NODE_INPUT}"
 elif [ -n "${PORTABLE_EXTENSION}" ]; then
   PORTABLE_NODE="$(jq -r --arg ext "${PORTABLE_EXTENSION}" '.extensions[$ext].node // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
-fi
-
-if [ -z "${PORTABLE_NODE}" ] && [ -f "package.json" ]; then
-  RAW_NODE="$(jq -r '.engines.node // empty' package.json 2>/dev/null || true)"
-  if [ -n "${RAW_NODE}" ]; then
-    PORTABLE_NODE="$(printf '%s' "${RAW_NODE}" | grep -oP '\d+' | head -1 || true)"
-  fi
 fi
 
 # ── Write outputs ──


### PR DESCRIPTION
## Summary

homeboy.json is the single source of truth. Removes all fallback version detection from package manager files.

## What was removed

- **composer.json `require.php` parsing** — was guessing PHP version from constraint strings like `>=8.2`, `^8.2`, etc.
- **package.json `engines.node` parsing** — was guessing Node version from engine constraints
- **Implicit WordPress PHP 8.2 default** — was assuming 8.2 when extension was wordpress but no version was configured

## What remains

PHP and Node versions come from exactly two sources, in order:
1. Action input override (`php-version` / `node-version`)
2. `extensions.<ext>.php` / `extensions.<ext>.node` in homeboy.json

If neither is set, the version is empty and the setup step is skipped. That's correct — if you need PHP/Node, declare it in homeboy.json.