### PR TITLE
feat: detect PHP/Node versions via homeboy component env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -176,8 +176,6 @@ runs:
       env:
         COMPONENT_NAME: ${{ inputs.component }}
         EXTENSION_INPUT: ${{ inputs.extension }}
-        PHP_INPUT: ${{ inputs.php-version }}
-        NODE_INPUT: ${{ inputs.node-version }}
       run: bash ${{ github.action_path }}/scripts/setup/read-portable-config.sh
 
     # ── Phase 2: Resolve execution context ──
@@ -197,40 +195,10 @@ runs:
         COMMANDS_INPUT: ${{ inputs.commands }}
       run: bash ${{ github.action_path }}/scripts/core/resolve-commands.sh
 
-    # ── Phase 3: Environment setup ──
-
-    - name: Setup PHP
-      if: steps.read-config.outputs.portable-php != ''
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ steps.read-config.outputs.portable-php }}
-        extensions: mbstring, intl, pdo_sqlite, mysqli
-        tools: composer:v2
-        coverage: none
-
-    - name: Setup Node.js
-      if: steps.read-config.outputs.portable-node != ''
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ steps.read-config.outputs.portable-node }}
-
-    - name: Auto-setup environment
-      if: inputs.auto-setup == 'true'
-      shell: bash
-      run: bash ${{ github.action_path }}/scripts/setup/auto-setup-environment.sh
-
-    # ── Phase 3b: SSH setup (for fleet/deploy) ──
-
-    - name: Setup SSH
-      id: setup-ssh
-      if: contains(steps.resolve-commands.outputs.operations-commands, 'fleet') || contains(steps.resolve-commands.outputs.operations-commands, 'deploy') || inputs.ssh-key != ''
-      shell: bash
-      env:
-        SSH_KEY: ${{ inputs.ssh-key }}
-        SSH_KNOWN_HOSTS: ${{ inputs.ssh-known-hosts }}
-      run: bash ${{ github.action_path }}/scripts/setup/setup-ssh.sh
-
-    # ── Phase 4: Install Homeboy ──
+    # ── Phase 3: Install Homeboy ──
+    # Homeboy installs before PHP/Node so we can use `homeboy component env`
+    # to detect runtime requirements from the source files (e.g., WordPress
+    # "Requires PHP" header).
 
     - name: Install pre-built binary
       id: install-prebuilt
@@ -323,6 +291,51 @@ runs:
         ACTION_REF: ${{ github.action_ref }}
         ACTION_REPOSITORY: ${{ github.action_repository }}
       run: bash ${{ github.action_path }}/scripts/setup/capture-tooling-metadata.sh
+
+    # ── Phase 4: Detect runtime + setup environment ──
+    # Uses `homeboy component env` to detect PHP/Node versions from source
+    # files. For WordPress, reads "Requires PHP" from the plugin/theme header.
+    # Action input overrides take priority over detected values.
+
+    - name: Detect runtime environment
+      id: detect-env
+      shell: bash
+      env:
+        PHP_INPUT: ${{ inputs.php-version }}
+        NODE_INPUT: ${{ inputs.node-version }}
+        COMPONENT_DIR: ${{ steps.read-config.outputs.component-dir }}
+      run: bash ${{ github.action_path }}/scripts/setup/detect-runtime-env.sh
+
+    - name: Setup PHP
+      if: steps.detect-env.outputs.portable-php != ''
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ steps.detect-env.outputs.portable-php }}
+        extensions: mbstring, intl, pdo_sqlite, mysqli
+        tools: composer:v2
+        coverage: none
+
+    - name: Setup Node.js
+      if: steps.detect-env.outputs.portable-node != ''
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ steps.detect-env.outputs.portable-node }}
+
+    - name: Auto-setup environment
+      if: inputs.auto-setup == 'true'
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/setup/auto-setup-environment.sh
+
+    # ── Phase 4b: SSH setup (for fleet/deploy) ──
+
+    - name: Setup SSH
+      id: setup-ssh
+      if: contains(steps.resolve-commands.outputs.operations-commands, 'fleet') || contains(steps.resolve-commands.outputs.operations-commands, 'deploy') || inputs.ssh-key != ''
+      shell: bash
+      env:
+        SSH_KEY: ${{ inputs.ssh-key }}
+        SSH_KNOWN_HOSTS: ${{ inputs.ssh-known-hosts }}
+      run: bash ${{ github.action_path }}/scripts/setup/setup-ssh.sh
 
     # ── Phase 5: Run commands ──
 

--- a/scripts/setup/detect-runtime-env.sh
+++ b/scripts/setup/detect-runtime-env.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Detect runtime environment requirements via homeboy component env.
+#
+# Runs after homeboy is installed. Uses the extension's native detection
+# logic — for WordPress, this reads "Requires PHP" from the plugin/theme
+# file header instead of requiring manual configuration.
+#
+# Action input overrides (PHP_INPUT, NODE_INPUT) take priority over
+# detected values.
+#
+# Outputs (GITHUB_ENV + GITHUB_OUTPUT):
+#   PORTABLE_PHP  — PHP version to install
+#   PORTABLE_NODE — Node version to install
+
+set -euo pipefail
+
+PHP_INPUT="${PHP_INPUT:-}"
+NODE_INPUT="${NODE_INPUT:-}"
+COMPONENT_DIR="${COMPONENT_DIR:-.}"
+
+PORTABLE_PHP=""
+PORTABLE_NODE=""
+
+# Run homeboy component env to detect versions from source files
+ENV_JSON=""
+if command -v homeboy &>/dev/null; then
+  ENV_JSON="$(homeboy component env --path "${COMPONENT_DIR}" --output /dev/null 2>/dev/null || true)"
+fi
+
+if [ -n "${ENV_JSON}" ]; then
+  DETECTED_PHP="$(echo "${ENV_JSON}" | jq -r '.data.entity.php // empty' 2>/dev/null || true)"
+  DETECTED_NODE="$(echo "${ENV_JSON}" | jq -r '.data.entity.node // empty' 2>/dev/null || true)"
+else
+  DETECTED_PHP=""
+  DETECTED_NODE=""
+fi
+
+# Action input overrides take priority
+if [ -n "${PHP_INPUT}" ]; then
+  PORTABLE_PHP="${PHP_INPUT}"
+elif [ -n "${DETECTED_PHP}" ]; then
+  PORTABLE_PHP="${DETECTED_PHP}"
+fi
+
+if [ -n "${NODE_INPUT}" ]; then
+  PORTABLE_NODE="${NODE_INPUT}"
+elif [ -n "${DETECTED_NODE}" ]; then
+  PORTABLE_NODE="${DETECTED_NODE}"
+fi
+
+echo "PORTABLE_PHP=${PORTABLE_PHP}" >> "${GITHUB_ENV}"
+echo "PORTABLE_NODE=${PORTABLE_NODE}" >> "${GITHUB_ENV}"
+
+echo "portable-php=${PORTABLE_PHP}" >> "${GITHUB_OUTPUT}"
+echo "portable-node=${PORTABLE_NODE}" >> "${GITHUB_OUTPUT}"
+
+echo "Runtime env detected:"
+echo "  php:  ${PORTABLE_PHP:-skip}${PHP_INPUT:+ (overridden by input)}"
+echo "  node: ${PORTABLE_NODE:-skip}${NODE_INPUT:+ (overridden by input)}"

--- a/scripts/setup/read-portable-config.sh
+++ b/scripts/setup/read-portable-config.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 
-# Read homeboy.json — the single source of truth for project configuration.
+# Read homeboy.json for component identity (ID, extension, directory).
 #
-# Reads:
+# This runs early (Phase 1) before homeboy is installed, so it only reads
+# the minimal fields needed for cache keys and command routing. Runtime
+# version detection (PHP, Node) is handled later by detect-runtime-env.sh
+# after the homeboy binary is available.
+#
+# Outputs:
 #   PORTABLE_ID         — component id
 #   PORTABLE_EXTENSION  — extension id (first key from extensions object)
-#   PORTABLE_PHP        — php version (from extensions.<ext>.php)
-#   PORTABLE_NODE       — node version (from extensions.<ext>.node)
-#
-# Action inputs can override php and node versions. Everything else
-# comes from homeboy.json or it doesn't exist.
+#   COMPONENT_DIR       — directory containing homeboy.json
 #
 # All values are written to GITHUB_ENV and GITHUB_OUTPUT for use by subsequent steps.
 
@@ -42,7 +43,7 @@ if [ -z "${PORTABLE_ID}" ]; then
   exit 1
 fi
 
-# ── Extension inference ──
+# ── Extension ──
 # If the action input specifies an extension, use that. Otherwise infer from
 # the first (usually only) key in the extensions object.
 
@@ -53,47 +54,17 @@ else
   PORTABLE_EXTENSION="$(jq -r '.extensions // {} | keys | first // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
 fi
 
-# ── PHP version ──
-# Source: action input override > extensions.<ext>.php in homeboy.json
-
-PHP_INPUT="${PHP_INPUT:-}"
-PORTABLE_PHP=""
-
-if [ -n "${PHP_INPUT}" ]; then
-  PORTABLE_PHP="${PHP_INPUT}"
-elif [ -n "${PORTABLE_EXTENSION}" ]; then
-  PORTABLE_PHP="$(jq -r --arg ext "${PORTABLE_EXTENSION}" '.extensions[$ext].php // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
-fi
-
-# ── Node version ──
-# Source: action input override > extensions.<ext>.node in homeboy.json
-
-NODE_INPUT="${NODE_INPUT:-}"
-PORTABLE_NODE=""
-
-if [ -n "${NODE_INPUT}" ]; then
-  PORTABLE_NODE="${NODE_INPUT}"
-elif [ -n "${PORTABLE_EXTENSION}" ]; then
-  PORTABLE_NODE="$(jq -r --arg ext "${PORTABLE_EXTENSION}" '.extensions[$ext].node // empty' "${CONFIG_FILE}" 2>/dev/null || true)"
-fi
-
 # ── Write outputs ──
 
 echo "PORTABLE_ID=${PORTABLE_ID}" >> "${GITHUB_ENV}"
 echo "PORTABLE_EXTENSION=${PORTABLE_EXTENSION}" >> "${GITHUB_ENV}"
-echo "PORTABLE_PHP=${PORTABLE_PHP}" >> "${GITHUB_ENV}"
-echo "PORTABLE_NODE=${PORTABLE_NODE}" >> "${GITHUB_ENV}"
 echo "COMPONENT_DIR=${CONFIG_DIR}" >> "${GITHUB_ENV}"
 
 echo "portable-id=${PORTABLE_ID}" >> "${GITHUB_OUTPUT}"
 echo "portable-extension=${PORTABLE_EXTENSION}" >> "${GITHUB_OUTPUT}"
-echo "portable-php=${PORTABLE_PHP}" >> "${GITHUB_OUTPUT}"
-echo "portable-node=${PORTABLE_NODE}" >> "${GITHUB_OUTPUT}"
 echo "component-dir=${CONFIG_DIR}" >> "${GITHUB_OUTPUT}"
 
 echo "Config resolved from ${CONFIG_FILE}:"
 echo "  id:        ${PORTABLE_ID}"
 echo "  extension: ${PORTABLE_EXTENSION:-none}"
-echo "  php:       ${PORTABLE_PHP:-skip}"
-echo "  node:      ${PORTABLE_NODE:-skip}"
 echo "  dir:       ${CONFIG_DIR}"


### PR DESCRIPTION
## Summary

Replaces manual PHP/Node version reading from homeboy.json with `homeboy component env`, which detects versions from the source files themselves. For WordPress, this reads `Requires PHP` from the plugin/theme file header — the same source of truth WordPress uses.

**Depends on:** Extra-Chill/homeboy#1068 (adds `homeboy component env` command)

## What Changed

### Phase reorder

Homeboy now installs **before** PHP/Node setup so it can detect the runtime requirements:

```
Before:                        After:
1. Read config (jq — all)      1. Read config (jq — ID/ext only)
2. Resolve scope               2. Resolve scope
3. Setup PHP/Node              3. Install homeboy + extension
4. Install homeboy             4. Detect env → setup PHP/Node
5. Run commands                5. Run commands
```

### Files changed

- **`read-portable-config.sh`** — Stripped to only read component ID, extension, and directory. No more PHP/Node version reading.
- **`detect-runtime-env.sh`** (new) — Runs `homeboy component env --path .` after homeboy is installed. Parses the JSON output for `php` and `node` fields. Action input overrides still win.
- **`action.yml`** — Reordered phases; PHP/Node setup now references `steps.detect-env.outputs` instead of `steps.read-config.outputs`.

### Why

The plugin file header `Requires PHP: 8.2` is the canonical source for what PHP version a WordPress plugin needs. Having a separate `extensions.wordpress.php` field in homeboy.json that can drift out of sync is a bug waiting to happen. Now the extension's own detection logic is the authority.