### PR TITLE
fix: persist autofix-disabled state across force pushes via PR label

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -18,6 +18,18 @@ fi
 BASE="$(scope_base_ref)"
 AUTOFIX_CAP_HIT=false
 
+# ── Persistent kill switch ─────────────────────────────────────────────
+# Check the label first — it survives force pushes and is the single source
+# of truth for "should autofix run on this PR?" (#1095, #1096)
+if has_autofix_disabled_label; then
+  echo "Skipping autofix: '${AUTOFIX_DISABLED_LABEL}' label is present on PR #${PR_NUMBER}"
+  echo "A previous autofix commit was reverted or force-pushed away — manual review required."
+  echo "attempted=false" >> "${GITHUB_OUTPUT}"
+  echo "status=skipped-disabled-label" >> "${GITHUB_OUTPUT}"
+  echo "committed=false" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
 if [ "${GITHUB_ACTOR:-}" = "github-actions[bot]" ] || [ "${GITHUB_ACTOR:-}" = "homeboy-ci[bot]" ]; then
   echo "Skipping autofix: workflow actor is ${GITHUB_ACTOR} (bot loop guard)"
   echo "attempted=false" >> "${GITHUB_OUTPUT}"
@@ -143,8 +155,19 @@ guard_synced_pr_head() {
   if has_reverted_autofix "${REVERT_BASE}"; then
     echo "Skipping autofix: a previous autofix commit was reverted on this branch"
     echo "This indicates the autofix output was incorrect — manual review required."
+    disable_autofix_on_pr
     echo "attempted=false" >> "${GITHUB_OUTPUT}"
     echo "status=skipped-reverted" >> "${GITHUB_OUTPUT}"
+    echo "committed=false" >> "${GITHUB_OUTPUT}"
+    exit 0
+  fi
+
+  if has_force_pushed_autofix; then
+    echo "Skipping autofix: a previous autofix commit was force-pushed away from this branch"
+    echo "This indicates the autofix output was incorrect — manual review required."
+    disable_autofix_on_pr
+    echo "attempted=false" >> "${GITHUB_OUTPUT}"
+    echo "status=skipped-force-pushed" >> "${GITHUB_OUTPUT}"
     echo "committed=false" >> "${GITHUB_OUTPUT}"
     exit 0
   fi

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -35,6 +35,126 @@ has_reverted_autofix() {
   fi
 }
 
+# Label used to persistently disable autofix on a PR.
+# Applied when a revert or force push removes a bot commit. Survives
+# force pushes (unlike git history checks) and is the single source of
+# truth for "should autofix run on this PR?"
+AUTOFIX_DISABLED_LABEL="autofix-disabled"
+
+# Check whether autofix has been permanently disabled on this PR via label.
+# Returns 0 if the label is present (autofix disabled), 1 otherwise.
+# Requires: GITHUB_REPOSITORY and PR_NUMBER in the environment.
+has_autofix_disabled_label() {
+  local pr_number="${1:-${PR_NUMBER:-}}"
+  local repo="${GITHUB_REPOSITORY:-}"
+
+  if [ -z "${pr_number}" ] || [ -z "${repo}" ]; then
+    return 1
+  fi
+
+  local labels=""
+  if command -v gh >/dev/null 2>&1; then
+    labels=$(gh pr view "${pr_number}" --repo "${repo}" --json labels -q '.labels[].name' 2>/dev/null || true)
+  fi
+
+  if [ -z "${labels}" ]; then
+    local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    if [ -n "${token}" ]; then
+      labels=$(curl -sfL \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${repo}/issues/${pr_number}/labels" 2>/dev/null \
+        | jq -r '.[].name // empty' 2>/dev/null || true)
+    fi
+  fi
+
+  echo "${labels}" | grep -qxF "${AUTOFIX_DISABLED_LABEL}"
+}
+
+# Permanently disable autofix on a PR by adding the disabled label.
+# Creates the label if it doesn't exist yet (idempotent).
+# Requires: GITHUB_REPOSITORY and GH_TOKEN/GITHUB_TOKEN in the environment.
+disable_autofix_on_pr() {
+  local pr_number="${1:-${PR_NUMBER:-}}"
+  local repo="${GITHUB_REPOSITORY:-}"
+
+  if [ -z "${pr_number}" ] || [ -z "${repo}" ]; then
+    echo "Cannot disable autofix: missing PR number or repository"
+    return 1
+  fi
+
+  local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [ -z "${token}" ]; then
+    echo "Cannot disable autofix: no GitHub token available"
+    return 1
+  fi
+
+  # Create the label if it doesn't exist (409 = already exists, that's fine)
+  curl -sfL -o /dev/null -w '' \
+    -X POST \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${repo}/labels" \
+    -d "{\"name\":\"${AUTOFIX_DISABLED_LABEL}\",\"color\":\"e4e669\",\"description\":\"Autofix permanently disabled on this PR (bot commit was reverted or force-pushed away)\"}" \
+    2>/dev/null || true
+
+  # Add the label to the PR
+  curl -sfL -o /dev/null -w '' \
+    -X POST \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${repo}/issues/${pr_number}/labels" \
+    -d "{\"labels\":[\"${AUTOFIX_DISABLED_LABEL}\"]}" \
+    2>/dev/null || true
+
+  echo "Added '${AUTOFIX_DISABLED_LABEL}' label to PR #${pr_number} — autofix permanently disabled"
+}
+
+# Check whether prior bot commits were force-pushed away from this PR branch.
+# Compares the bot commits GitHub knows about (from PR commit list) against
+# what's currently in git history. If GitHub shows bot commits that are no
+# longer in the branch, a force push removed them.
+#
+# Arguments:
+#   $1 - optional base ref for range scoping
+# Returns 0 if force-pushed bot commits detected, 1 otherwise.
+has_force_pushed_autofix() {
+  local pr_number="${1:-${PR_NUMBER:-}}"
+  local repo="${GITHUB_REPOSITORY:-}"
+
+  if [ -z "${pr_number}" ] || [ -z "${repo}" ]; then
+    return 1
+  fi
+
+  local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [ -z "${token}" ]; then
+    return 1
+  fi
+
+  # Get all bot commit SHAs that GitHub recorded on this PR
+  local bot_shas
+  bot_shas=$(curl -sfL \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${repo}/pulls/${pr_number}/commits?per_page=100" 2>/dev/null \
+    | jq -r ".[] | select(.commit.author.name == \"${AUTOFIX_BOT_NAME}\") | .sha" 2>/dev/null || true)
+
+  if [ -z "${bot_shas}" ]; then
+    return 1
+  fi
+
+  # Check if any of those bot commits are missing from current branch history
+  local sha
+  while IFS= read -r sha; do
+    if [ -n "${sha}" ] && ! git cat-file -t "${sha}" >/dev/null 2>&1; then
+      echo "Detected force-pushed autofix: bot commit ${sha:0:10} is no longer in branch history"
+      return 0
+    fi
+  done <<< "${bot_shas}"
+
+  return 1
+}
+
 # Check whether the current HEAD commit was authored by the autofix bot.
 # PR autofix should run only after human commits; bot-authored HEAD commits
 # indicate we're in a rerun after an autofix push and must not write again.

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -22,6 +22,12 @@ append_autofix_section() {
     SECTION_BODY+="> :warning: Autofix generated changes but could not push them back to **${AUTOFIX_TARGET_REPO:-${REPO}}:${AUTOFIX_TARGET_BRANCH:-unknown}**"$'\n\n'
   elif [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "skipped-head-bot-author" ]; then
     SECTION_BODY+="> :information_source: Autofix skipped — PR head is already a **homeboy-ci[bot]** commit, so PR autofix only runs after human commits"$'\n\n'
+  elif [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "skipped-disabled-label" ]; then
+    SECTION_BODY+="> :no_entry_sign: Autofix **permanently disabled** on this PR — a previous autofix commit was reverted or force-pushed away"$'\n\n'
+  elif [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "skipped-reverted" ]; then
+    SECTION_BODY+="> :no_entry_sign: Autofix **disabled** — a previous autofix commit was reverted on this branch"$'\n\n'
+  elif [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "skipped-force-pushed" ]; then
+    SECTION_BODY+="> :no_entry_sign: Autofix **disabled** — a previous autofix commit was force-pushed away from this branch"$'\n\n'
   elif [ "${AUTOFIX_ENABLED}" = "true" ]; then
     SECTION_BODY+="> :information_source: Autofix enabled, but no fixable file changes were produced"$'\n\n'
   fi


### PR DESCRIPTION
## Summary
- **Fixes #1095** — autofix now stops permanently after a revert or force push on a PR
- **Addresses #1096** — uses a PR label as single source of truth instead of scattered git history checks

## Problem

When a bot autofix commit was reverted on a PR branch, the `has_reverted_autofix()` check fired once (`skipped-reverted`). But after a new human commit or force push, the revert commit disappeared from history and the bot ran autofix again — pushing the same destructive changes in a loop.

## Solution

**PR label as persistent state.** When a revert or force push of a bot commit is detected:

1. An `autofix-disabled` label is added to the PR via GitHub API
2. On every subsequent CI run, the label is checked **first** — before any git history checks
3. Labels survive force pushes, branch resets, and history rewrites

### New functions in `lib.sh`

| Function | Purpose |
|----------|---------|
| `has_autofix_disabled_label()` | Check if PR has the kill-switch label |
| `disable_autofix_on_pr()` | Add the label (creates it repo-wide if needed) |
| `has_force_pushed_autofix()` | Detect bot commits that GitHub recorded but are no longer in branch history |

### New status values

| Status | Trigger |
|--------|---------|
| `skipped-disabled-label` | `autofix-disabled` label present on PR |
| `skipped-force-pushed` | Bot commits detected in GitHub PR data but missing from git history |

### Guard order in `apply-autofix-commit.sh`

```
1. autofix-disabled label  ← NEW (persistent, survives force push)
2. bot actor loop guard
3. HEAD author guard
4. label requirement guard
5. stale binary guard
6. (in retry loop) revert detection → adds label  ← UPDATED
7. (in retry loop) force push detection → adds label  ← NEW
```

## PR comment rendering

New statuses render with 🚫 icon:
- `skipped-disabled-label`: "Autofix **permanently disabled** on this PR..."
- `skipped-reverted`: "Autofix **disabled** — a previous autofix commit was reverted..."
- `skipped-force-pushed`: "Autofix **disabled** — a previous autofix commit was force-pushed away..."