### PR TITLE
refactor: migrate auto-file-issue and open-autofix-pr to `homeboy git` primitives

### DIFF
--- a/scripts/autofix/open-autofix-pr.sh
+++ b/scripts/autofix/open-autofix-pr.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Find-or-create/edit an autofix PR using `homeboy git pr` primitives.
+#
+# Primitives: Extra-Chill/homeboy#1334 (issue/PR CRUD), #1368 (--path flag).
+# Migration tracked in: Extra-Chill/homeboy-action#138.
+
 set -euo pipefail
 
 source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
@@ -16,67 +21,12 @@ else
   BASE_BRANCH="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch' 2>/dev/null || echo 'main')"
 fi
 COMP_ID="$(resolve_component_id)"
+WORKSPACE="$(resolve_workspace)"
 RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-EXISTING_PR_URL=$(gh pr list \
-  --state open \
-  --base "${BASE_BRANCH}" \
-  --head "${AUTOFIX_BRANCH}" \
-  --json url \
-  --jq '.[0].url // empty' 2>/dev/null || true)
-
-if [ -n "${EXISTING_PR_URL}" ]; then
-  echo "Autofix PR already exists: ${EXISTING_PR_URL}"
-
-  # Update the PR body with the latest run context (branch was force-pushed
-  # with fresh autofix changes, so the old workflow run link is stale).
-  EXISTING_PR_NUMBER=$(gh pr list \
-    --state open \
-    --base "${BASE_BRANCH}" \
-    --head "${AUTOFIX_BRANCH}" \
-    --json number \
-    --jq '.[0].number // empty' 2>/dev/null || true)
-
-  if [ -n "${EXISTING_PR_NUMBER}" ]; then
-    UPDATE_BODY_FILE="$(mktemp)"
-
-    AUTOFIX_DETAIL=""
-    if [ -n "${AUTOFIX_FILE_COUNT:-}" ] && [ -n "${AUTOFIX_FIX_TYPES:-}" ]; then
-      AUTOFIX_DETAIL="- **${AUTOFIX_FILE_COUNT}** file(s) fixed via **${AUTOFIX_FIX_TYPES}**"
-    elif [ -n "${AUTOFIX_FILE_COUNT:-}" ]; then
-      AUTOFIX_DETAIL="- **${AUTOFIX_FILE_COUNT}** file(s) fixed"
-    fi
-
-    FINDING_DETAIL=""
-    if [ -n "${AUTOFIX_FINDING_TYPES:-}" ]; then
-      FINDING_DETAIL="- **Finding categories:** ${AUTOFIX_FINDING_TYPES}"
-    fi
-
-cat > "${UPDATE_BODY_FILE}" <<UPDATEBODY
-## Summary
-${AUTOFIX_DETAIL:+${AUTOFIX_DETAIL}
-}${FINDING_DETAIL:+${FINDING_DETAIL}
-}- Opened immediately after autofix without rerunning quality gates.
-- Generated automatically by Homeboy Action.
-
-## Context
-- Workflow run: ${RUN_URL}
-- Branch: ${AUTOFIX_BRANCH}
-- Base: ${BASE_BRANCH}
-UPDATEBODY
-
-    gh pr edit "${EXISTING_PR_NUMBER}" --body-file "${UPDATE_BODY_FILE}" 2>/dev/null || true
-    rm -f "${UPDATE_BODY_FILE}"
-    echo "Updated PR #${EXISTING_PR_NUMBER} body with latest run context"
-  fi
-
-  echo "created=true" >> "${GITHUB_OUTPUT}"
-  echo "url=${EXISTING_PR_URL}" >> "${GITHUB_OUTPUT}"
-  exit 0
-fi
 
 TITLE="chore(ci): autofix ${COMP_ID} from ${BASE_BRANCH}"
 BODY_FILE="$(mktemp)"
+trap 'rm -f "${BODY_FILE}"' EXIT
 
 AUTOFIX_DETAIL=""
 if [ -n "${AUTOFIX_FILE_COUNT:-}" ] && [ -n "${AUTOFIX_FIX_TYPES:-}" ]; then
@@ -103,13 +53,47 @@ ${AUTOFIX_DETAIL:+${AUTOFIX_DETAIL}
 - Base: ${BASE_BRANCH}
 EOF
 
-PR_URL=$(gh pr create \
+# Find an existing open PR for (base, head). `homeboy git pr find` emits typed
+# JSON with a stable shape regardless of `gh` version; jq extracts the first
+# item's number + url.
+EXISTING_PR=$(homeboy git pr find "${COMP_ID}" \
+  --path "${WORKSPACE}" \
+  --base "${BASE_BRANCH}" \
+  --head "${AUTOFIX_BRANCH}" \
+  --state open \
+  --limit 1 2>/dev/null \
+  | jq -c '.data.items[0] // empty' 2>/dev/null || true)
+
+if [ -n "${EXISTING_PR}" ]; then
+  EXISTING_PR_NUMBER=$(echo "${EXISTING_PR}" | jq -r '.number // empty')
+  EXISTING_PR_URL=$(echo "${EXISTING_PR}" | jq -r '.url // empty')
+
+  echo "Autofix PR already exists: ${EXISTING_PR_URL}"
+
+  if [ -n "${EXISTING_PR_NUMBER}" ]; then
+    if homeboy git pr edit "${COMP_ID}" \
+      --path "${WORKSPACE}" \
+      --number "${EXISTING_PR_NUMBER}" \
+      --body-file "${BODY_FILE}" >/dev/null 2>&1; then
+      echo "Updated PR #${EXISTING_PR_NUMBER} body with latest run context"
+    else
+      echo "::warning::Failed to update PR #${EXISTING_PR_NUMBER} body"
+    fi
+  fi
+
+  echo "created=true" >> "${GITHUB_OUTPUT}"
+  echo "url=${EXISTING_PR_URL}" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+# No existing PR — create one.
+PR_URL=$(homeboy git pr create "${COMP_ID}" \
+  --path "${WORKSPACE}" \
   --base "${BASE_BRANCH}" \
   --head "${AUTOFIX_BRANCH}" \
   --title "${TITLE}" \
-  --body-file "${BODY_FILE}" 2>/dev/null || true)
-
-rm -f "${BODY_FILE}"
+  --body-file "${BODY_FILE}" 2>/dev/null \
+  | jq -r '.data.url // empty' 2>/dev/null || true)
 
 if [ -z "${PR_URL}" ]; then
   echo "Failed to create autofix PR"

--- a/scripts/issues/auto-file-issue.sh
+++ b/scripts/issues/auto-file-issue.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 
+# File (or comment on) an issue describing a CI failure.
+#
+# Uses `homeboy git issue` primitives:
+#   - `issue find --title ... --label ci-failure --state open` for dedup
+#   - `issue comment --number N` to add a follow-up to an existing issue
+#   - `issue create --title ... --body-file ... --label ci-failure` otherwise
+#
+# Primitives: Extra-Chill/homeboy#1334 (issue/PR CRUD), #1368 (--path flag).
+# Migration tracked in: Extra-Chill/homeboy-action#138.
+
 set -euo pipefail
+
+source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
 
 compact_summary() {
   local command="$1"
@@ -21,7 +33,8 @@ summary_json_for() {
 }
 
 REPO="${GITHUB_REPOSITORY}"
-COMP_ID="${COMPONENT_NAME:-$(basename "${GITHUB_REPOSITORY}")}"
+COMP_ID="$(resolve_component_id)"
+WORKSPACE="$(resolve_workspace)"
 OUTPUT_DIR="${HOMEBOY_OUTPUT_DIR:-}"
 RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 WORKFLOW_NAME="${GITHUB_WORKFLOW:-workflow}"
@@ -92,115 +105,122 @@ TOOLING_MD+="- Action: \`${HOMEBOY_ACTION_REPOSITORY}@${HOMEBOY_ACTION_REF}\`"$'
 
 ISSUE_TITLE="CI failure: ${SCOPE_LABEL} • ${WORKFLOW_NAME} • ${GITHUB_EVENT_NAME} • ${REF_LABEL}"
 
-EXISTING_ISSUE=$(gh api "repos/${REPO}/issues" \
-  --jq "[.[] | select(.state == \"open\" and .title == \"${ISSUE_TITLE}\" and (.labels[]?.name == \"ci-failure\"))] | first | .number // empty" \
-  2>/dev/null || true)
+# Dedup: is there already an open ci-failure issue with this exact title?
+# `issue find --title --label --state` does the exact-match + all-of-labels
+# filtering that the previous `gh api ... --jq` line reinvented.
+EXISTING_ISSUE=$(homeboy git issue find "${COMP_ID}" \
+  --path "${WORKSPACE}" \
+  --title "${ISSUE_TITLE}" \
+  --label ci-failure \
+  --state open \
+  --limit 1 2>/dev/null \
+  | jq -r '.data.items[0].number // empty' 2>/dev/null || true)
 
 if [ -n "${EXISTING_ISSUE}" ]; then
   echo "Found existing open issue #${EXISTING_ISSUE} — adding comment instead of creating new issue"
 
-  COMMENT="### CI failure on ${TRIGGER_CONTEXT}"$'\n\n'
-  COMMENT+="### Primary failure"$'\n\n'
-  if [ -n "${PRIMARY_COMMAND}" ]; then
-    COMMENT+="- Command: \`homeboy ${PRIMARY_COMMAND}\`"$'\n'
-  fi
-  if [ -n "${PRIMARY_SUMMARY}" ]; then
-    COMMENT+="- Summary: ${PRIMARY_SUMMARY}"$'\n'
-  else
-    COMMENT+="- Summary: structured failure summary unavailable"$'\n'
-  fi
+  COMMENT_FILE="$(mktemp)"
+  trap 'rm -f "${COMMENT_FILE}"' EXIT
 
-  if [ -n "${SECONDARY_CMDS_MD}" ]; then
-    COMMENT+=$'\n'"### Secondary findings"$'\n\n'
-    COMMENT+="${SECONDARY_CMDS_MD}"
-  fi
-
-  COMMENT+=$'\n'"### Tooling versions"$'\n\n'
-  COMMENT+="${TOOLING_MD}"$'\n'
-
-  if [ "${AUTOFIX_ATTEMPTED}" = "true" ]; then
-    COMMENT+=$'\n'"### Autofix outcome"$'\n\n'
-    COMMENT+="- Safe autofix pass was attempted before filing this issue."$'\n'
-    COMMENT+="- Remaining failures are likely non-mechanical and need human decision-making."$'\n'
-    if [ "${AUTOFIX_PR_CREATED}" = "true" ]; then
-      COMMENT+="- Autofix PR was created, but unresolved failures still require follow-up."$'\n'
+  {
+    printf '### CI failure on %s\n\n' "${TRIGGER_CONTEXT}"
+    printf '### Primary failure\n\n'
+    if [ -n "${PRIMARY_COMMAND}" ]; then
+      printf -- '- Command: `homeboy %s`\n' "${PRIMARY_COMMAND}"
     fi
-  fi
+    if [ -n "${PRIMARY_SUMMARY}" ]; then
+      printf -- '- Summary: %s\n' "${PRIMARY_SUMMARY}"
+    else
+      printf -- '- Summary: structured failure summary unavailable\n'
+    fi
 
-  COMMENT+="### Triage order"$'\n\n'
-  COMMENT+="1. Fix \`${PRIMARY_COMMAND:-first failing command}\`"$'\n'
-  COMMENT+="2. Re-run CI"$'\n'
-  COMMENT+="3. Re-evaluate secondary failures"$'\n\n'
+    if [ -n "${SECONDARY_CMDS_MD}" ]; then
+      printf '\n### Secondary findings\n\n%s' "${SECONDARY_CMDS_MD}"
+    fi
 
-  COMMENT+="**Failed commands:**"$'\n'
-  COMMENT+="${FAILED_CMDS_MD}"$'\n'
-  COMMENT+="**Run:** ${RUN_URL}"$'\n'
+    printf '\n### Tooling versions\n\n%s\n' "${TOOLING_MD}"
 
-  gh api "repos/${REPO}/issues/${EXISTING_ISSUE}/comments" \
-    --method POST \
-    --field body="${COMMENT}" > /dev/null
+    if [ "${AUTOFIX_ATTEMPTED}" = "true" ]; then
+      printf '\n### Autofix outcome\n\n'
+      printf -- '- Safe autofix pass was attempted before filing this issue.\n'
+      printf -- '- Remaining failures are likely non-mechanical and need human decision-making.\n'
+      if [ "${AUTOFIX_PR_CREATED}" = "true" ]; then
+        printf -- '- Autofix PR was created, but unresolved failures still require follow-up.\n'
+      fi
+    fi
+
+    printf '### Triage order\n\n'
+    printf '1. Fix `%s`\n' "${PRIMARY_COMMAND:-first failing command}"
+    printf '2. Re-run CI\n'
+    printf '3. Re-evaluate secondary failures\n\n'
+
+    printf '**Failed commands:**\n%s\n' "${FAILED_CMDS_MD}"
+    printf '**Run:** %s\n' "${RUN_URL}"
+  } > "${COMMENT_FILE}"
+
+  homeboy git issue comment "${COMP_ID}" \
+    --path "${WORKSPACE}" \
+    --number "${EXISTING_ISSUE}" \
+    --body-file "${COMMENT_FILE}" >/dev/null
 
   echo "Comment added to issue #${EXISTING_ISSUE}"
 else
   echo "Creating new issue..."
 
-  BODY="## CI Failure Report"$'\n\n'
-  BODY+="**Component:** \`${COMP_ID}\`"$'\n'
-  BODY+="**Workflow:** \`${WORKFLOW_NAME}\`"$'\n'
-  BODY+="**Scope:** \`${SCOPE_LABEL}\`"$'\n'
-  BODY+="**Ref:** \`${REF_LABEL}\`"$'\n'
-  BODY+="**Trigger:** \`${GITHUB_EVENT_NAME}\` on ${TRIGGER_CONTEXT}"$'\n'
-  BODY+="**Binary:** ${BINARY_SOURCE}"$'\n'
-  BODY+="**Run:** ${RUN_URL}"$'\n\n'
+  BODY_FILE="$(mktemp)"
+  trap 'rm -f "${BODY_FILE}"' EXIT
 
-  BODY+="### Tooling versions"$'\n\n'
-  BODY+="${TOOLING_MD}"$'\n'
+  {
+    printf '## CI Failure Report\n\n'
+    printf '**Component:** `%s`\n' "${COMP_ID}"
+    printf '**Workflow:** `%s`\n' "${WORKFLOW_NAME}"
+    printf '**Scope:** `%s`\n' "${SCOPE_LABEL}"
+    printf '**Ref:** `%s`\n' "${REF_LABEL}"
+    printf '**Trigger:** `%s` on %s\n' "${GITHUB_EVENT_NAME}" "${TRIGGER_CONTEXT}"
+    printf '**Binary:** %s\n' "${BINARY_SOURCE}"
+    printf '**Run:** %s\n\n' "${RUN_URL}"
 
-  if [ "${AUTOFIX_ATTEMPTED}" = "true" ]; then
-    BODY+=$'\n'"### Autofix outcome"$'\n\n'
-    BODY+="- Safe autofix pass was attempted before filing this issue."$'\n'
-    BODY+="- Remaining failures are likely non-mechanical and need human decision-making."$'\n'
-    if [ "${AUTOFIX_PR_CREATED}" = "true" ]; then
-      BODY+="- Autofix PR was created, but unresolved failures still require follow-up."$'\n'
+    printf '### Tooling versions\n\n%s\n' "${TOOLING_MD}"
+
+    if [ "${AUTOFIX_ATTEMPTED}" = "true" ]; then
+      printf '\n### Autofix outcome\n\n'
+      printf -- '- Safe autofix pass was attempted before filing this issue.\n'
+      printf -- '- Remaining failures are likely non-mechanical and need human decision-making.\n'
+      if [ "${AUTOFIX_PR_CREATED}" = "true" ]; then
+        printf -- '- Autofix PR was created, but unresolved failures still require follow-up.\n'
+      fi
     fi
-  fi
 
-  BODY+="### Primary failure"$'\n\n'
-  if [ -n "${PRIMARY_COMMAND}" ]; then
-    BODY+="- Command: \`homeboy ${PRIMARY_COMMAND}\`"$'\n'
-  fi
-  if [ -n "${PRIMARY_SUMMARY}" ]; then
-    BODY+="- Summary: ${PRIMARY_SUMMARY}"$'\n'
-  else
-    BODY+="- Summary: structured failure summary unavailable"$'\n'
-  fi
+    printf '### Primary failure\n\n'
+    if [ -n "${PRIMARY_COMMAND}" ]; then
+      printf -- '- Command: `homeboy %s`\n' "${PRIMARY_COMMAND}"
+    fi
+    if [ -n "${PRIMARY_SUMMARY}" ]; then
+      printf -- '- Summary: %s\n' "${PRIMARY_SUMMARY}"
+    else
+      printf -- '- Summary: structured failure summary unavailable\n'
+    fi
 
-  if [ -n "${SECONDARY_CMDS_MD}" ]; then
-    BODY+=$'\n'"### Secondary findings"$'\n\n'
-    BODY+="${SECONDARY_CMDS_MD}"
-  fi
+    if [ -n "${SECONDARY_CMDS_MD}" ]; then
+      printf '\n### Secondary findings\n\n%s' "${SECONDARY_CMDS_MD}"
+    fi
 
-  BODY+=$'\n'"### Triage order"$'\n\n'
-  BODY+="1. Fix \`${PRIMARY_COMMAND:-first failing command}\`"$'\n'
-  BODY+="2. Re-run CI"$'\n'
-  BODY+="3. Re-evaluate secondary failures"$'\n\n'
+    printf '\n### Triage order\n\n'
+    printf '1. Fix `%s`\n' "${PRIMARY_COMMAND:-first failing command}"
+    printf '2. Re-run CI\n'
+    printf '3. Re-evaluate secondary failures\n\n'
 
-  BODY+="### Failed Commands"$'\n\n'
-  BODY+="${FAILED_CMDS_MD}"$'\n'
+    printf '### Failed Commands\n\n%s\n' "${FAILED_CMDS_MD}"
 
-  BODY+="---"$'\n'
-  BODY+="*Filed automatically by [Homeboy Action](https://github.com/Extra-Chill/homeboy-action)*"
+    printf '%s\n' '---'
+    printf '%s' '*Filed automatically by [Homeboy Action](https://github.com/Extra-Chill/homeboy-action)*'
+  } > "${BODY_FILE}"
 
-  gh api "repos/${REPO}/issues" \
-    --method POST \
-    --field title="${ISSUE_TITLE}" \
-    --field body="${BODY}" \
-    --field "labels[]=ci-failure" > /dev/null 2>&1 || {
-    gh api "repos/${REPO}/issues" \
-      --method POST \
-      --field title="${ISSUE_TITLE}" \
-      --field body="${BODY}" > /dev/null
-  }
+  homeboy git issue create "${COMP_ID}" \
+    --path "${WORKSPACE}" \
+    --title "${ISSUE_TITLE}" \
+    --body-file "${BODY_FILE}" \
+    --label ci-failure >/dev/null
 
   echo "Issue created: ${ISSUE_TITLE}"
 fi


### PR DESCRIPTION
## Summary

Migrate `scripts/issues/auto-file-issue.sh` and `scripts/autofix/open-autofix-pr.sh` from bash-over-`gh` GitHub API reimplementations to the typed primitives shipped in Extra-Chill/homeboy#1334 + #1368.

Closes #138.

## What changed

### `scripts/issues/auto-file-issue.sh`

| Before | After |
|---|---|
| `gh api repos/$R/issues` + `jq` title/label filter (dedup) | `homeboy git issue find --title --label --state --limit` |
| `gh api repos/$R/issues/$N/comments POST` | `homeboy git issue comment --number --body-file` |
| `gh api repos/$R/issues POST` | `homeboy git issue create --title --body-file --label` |

Body generation was also rewritten from `FOO+="..."$'\n'` string concatenation to `printf`-into-a-subshell-block style. Same output shape; much easier to audit.

### `scripts/autofix/open-autofix-pr.sh`

| Before | After |
|---|---|
| `gh pr list --base --head` (existence check) | `homeboy git pr find --base --head --state --limit 1` |
| `gh pr edit --body-file` | `homeboy git pr edit --number --body-file` |
| `gh pr create` | `homeboy git pr create --base --head --title --body-file` |

## Why

- **Typed JSON output.** `homeboy git` returns stable schemas; `gh`'s JSON shape varies across versions and `jq` queries silently drift.
- **Component-aware.** No more `$GITHUB_REPOSITORY` threading — repo resolves from component `remote_url` (via `homeboy.json` at `--path`) or falls back to `git remote get-url origin`.
- **Single auth gate.** homeboy's `ensure_gh_ready` probes `gh auth status` once; previously scattered `gh` invocations each re-authed implicitly.
- **Reusable beyond the action.** Non-action consumers (cron jobs, other CI systems, humans at the terminal) can drive the same flows via `homeboy git` without duplicating this bash. This was the original goal of #1333.

## Requirements

Requires homeboy with **both** #1334 (primitives) and #1368 (`--path` flag). As of this PR, neither has a cut release yet — the action will need a subsequent version-gate bump in `scripts/setup/resolve-homeboy-version.sh` once a homeboy release containing both lands.

Users who pin an older homeboy via the `version:` input will see `error: unrecognized subcommand 'issue'` and should bump. A minimum-version gate + clearer error message is a good follow-up.

## Dry-run validation

Both scripts were invoked end-to-end against a stubbed `homeboy` binary (trapping `git issue create|comment|find` and `git pr find|create|edit`) and confirmed:

1. **`auto-file-issue.sh` dedup-hit** — `issue find` returns an existing open issue → `issue comment --number 42 --body-file` called with correct body shape.
2. **`auto-file-issue.sh` dedup-miss** — `issue find` returns empty → `issue create --title ... --body-file ... --label ci-failure` called with correct flags.
3. **`open-autofix-pr.sh` find-hit** — `pr find` returns an existing PR → `pr edit --number 77 --body-file` called, `created=true` + existing URL written to `GITHUB_OUTPUT`.
4. **`open-autofix-pr.sh` find-miss** — `pr find` returns empty → `pr create --base main --head ci/autofix/... --title ... --body-file` called, new URL written to `GITHUB_OUTPUT`.

One real bug caught + fixed during dry-run: `printf '---\n'` was interpreting `---` as the options terminator. Switched to `printf '%s\n' '---'`.

## Line counts

Not the point, but:

| File | Before | After | Delta |
|---|---|---|---|
| `scripts/issues/auto-file-issue.sh` | 206 | 226 | +20 |
| `scripts/autofix/open-autofix-pr.sh` | 122 | 106 | -16 |

`auto-file-issue.sh` grew slightly because the body-generation style changed from terse concat to explicit `printf` block — the actual GitHub API call collapse is real (~30 lines of `gh api` + `jq` dedup/create/comment → 3 `homeboy git` calls). The win is typed JSON + testability, not line count.

## Out of scope for this PR

- **`scripts/issues/auto-file-categorized-issues.sh`** (778 lines). Larger migration, separate PR.
- **`scripts/pr/comment/*` + `scripts/pr/merge-pr-comment.py`** (~470 lines). Multi-section PR comment aggregation — needs Extra-Chill/homeboy#1348 (sectioned PR comment primitive) before migration.
- **`scripts/autofix/apply-autofix-commit.sh::push_autofix_commit`** (~12 lines). GitHub App token URL injection for fork-PR autofix push — needs Extra-Chill/homeboy#1349 (push override flags) before migration.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Drafted both migrated scripts based on #1334's primitive surface, identified the `--path` gap (which prompted filing #1368 and landing a follow-up PR that unblocks this), validated both scripts end-to-end via stubbed-`homeboy` dry runs, caught and fixed a `printf '---'` options-parsing bug during dry-run.

Closes #138. Unblocked by Extra-Chill/homeboy#1334, Extra-Chill/homeboy#1368.
