### PR TITLE
fix(issues): scope orphan reconciliation to expected-commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Use these outputs to gate downstream jobs:
 | `extension` | No | | Extension ID (e.g. `wordpress`, `rust`, `node`) |
 | `extension-source` | No | `Extra-Chill/homeboy-extensions` | Git URL to install the extension from |
 | `commands` | No | `lint,test` | Comma-separated commands to run |
+| `expected-commands` | No | *(falls back to `commands`)* | Full set of command types expected to run across the workflow (e.g. `audit,lint,test`). Set this on every invocation when a workflow splits audit/lint/test across separate steps, otherwise each invocation will close sibling invocations' issues during reconciliation. |
 | `component` | No | *(repo name)* | Component name (auto-detected from repo) |
 | `args` | No | | Extra arguments passed to each command |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: 'Override commands to run. If empty, inferred from event context: PR/push/manual → audit,lint,test; cron → release.'
     required: false
     default: ''
+  expected-commands:
+    description: 'Full set of command types expected to run across the workflow (e.g. "audit,lint,test"). Used by auto-issue reconciliation to avoid closing issues owned by sibling invocations when a workflow splits audit/lint/test across separate steps. Defaults to `commands` when empty.'
+    required: false
+    default: ''
   component:
     description: 'Component name override. Auto-detected from homeboy.json if not set.'
     required: false
@@ -526,6 +530,7 @@ runs:
         GH_TOKEN: ${{ inputs.app-token || github.token }}
         RESULTS: ${{ steps.select-results.outputs.results }}
         COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
+        EXPECTED_COMMANDS: ${{ inputs.expected-commands }}
         COMPONENT_NAME: ${{ inputs.component }}
         BINARY_SOURCE: ${{ steps.resolve-binary.outputs.binary-source }}
         AUTOFIX_ATTEMPTED: ${{ steps.autofix-prepare-nonpr.outputs.committed }}

--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -19,6 +19,13 @@
 #   HOMEBOY_OUTPUT_DIR    — directory with command log files
 #   COMPONENT_NAME        — component ID
 #   COMMANDS              — comma-separated list of commands that were run
+#   EXPECTED_COMMANDS     — optional; comma-separated list of command types
+#                           expected to run across the full workflow (e.g.
+#                           "audit,lint,test"). Used to scope the orphan-
+#                           reconciliation step so that workflows which split
+#                           audit/lint/test across separate invocations do
+#                           not close each other's issues. Defaults to
+#                           COMMANDS when empty.
 #   RESULTS               — JSON object with pass/fail per command
 #   AUTOFIX_ATTEMPTED     — whether autofix was tried before filing
 #   AUTOFIX_PR_CREATED    — whether an autofix PR was opened
@@ -751,11 +758,35 @@ done
 # If a command was removed from the workflow, its issues are never updated or
 # closed because the main loop only processes commands that ran this time.
 # Close any open issues for command types that were NOT in this CI run.
+#
+# Scope: workflows that split audit/lint/test across separate invocations
+# (e.g. one step per command + a final autofix step) must pass the full set
+# as `expected-commands` so each invocation only reconciles command types
+# that no invocation in the workflow will handle. Without it, an invocation
+# running only `audit` would treat every open lint/test issue as orphaned
+# and close it — even though a sibling invocation will file lint/test
+# issues seconds later.
+#
+# Default (EXPECTED_COMMANDS empty): fall back to COMMANDS so single-command
+# invocations still reconcile siblings the bot once owned but no longer runs.
+
+if [ -n "${EXPECTED_COMMANDS:-}" ]; then
+  IFS=',' read -ra EXPECTED_CMD_ARRAY <<< "${EXPECTED_COMMANDS}"
+  # Normalize whitespace on each element
+  for i in "${!EXPECTED_CMD_ARRAY[@]}"; do
+    EXPECTED_CMD_ARRAY[$i]=$(echo "${EXPECTED_CMD_ARRAY[$i]}" | xargs)
+  done
+else
+  EXPECTED_CMD_ARRAY=("${CMD_ARRAY[@]}")
+fi
 
 ALL_CMD_TYPES=('audit' 'lint' 'test')
 for CMD_TYPE in "${ALL_CMD_TYPES[@]}"; do
-  # Skip if this command type was processed in the main loop
-  if echo ",${CMD_ARRAY[*]}," | grep -q ",${CMD_TYPE},"; then
+  # Skip if this command type is expected somewhere in the workflow.
+  # Force comma separator when joining the expected array so the haystack
+  # matches the ",${CMD_TYPE}," needle regardless of ambient IFS.
+  EXPECTED_JOINED=$(IFS=','; echo "${EXPECTED_CMD_ARRAY[*]}")
+  if echo ",${EXPECTED_JOINED}," | grep -q ",${CMD_TYPE},"; then
     continue
   fi
   echo "Reconciling orphaned ${CMD_TYPE} issues for ${COMP_ID}..."


### PR DESCRIPTION
## Summary

Workflows that split `audit`/`lint`/`test` across separate `homeboy-action` invocations (e.g. `Extra-Chill/homeboy`'s `release.yml`, which has four: audit, lint, test, autofix-all) were getting caught by the auto-issue reconciliation block. Each invocation treated every command type NOT in its own `CMD_ARRAY` as orphaned and closed the matching issues. In a four-step workflow the later steps kept closing the issues the earlier steps had just created or updated, producing ~15 open-then-close events per run with **identical finding bodies modulo timestamps**.

This PR adds an `expected-commands` input so each invocation can declare the full set of command types the workflow will run across all its steps. Reconciliation only closes issues whose command type is missing from `expected-commands`. When the input is empty, behavior falls back to `commands` (preserving legacy semantics for single-invocation workflows).

## Evidence

Audit of `Extra-Chill/homeboy` showed 211 bot-filed issues, **all closed**, with some buckets refiled 12+ times in 26 hours:

| Bucket | Refiles | Pattern |
|---|---:|---|
| `audit: near duplicate (18)` | 12 | byte-identical body x12 |
| `audit: god file (22)` | 10 | count stuck at 22 |
| `audit: missing test method` | 14 | count drifts 305→466→482 |
| `lint: lint failure (exit 1)` | 21 | since March |

Run log for `24867610666` (2026-04-24) shows the exact symptom:
```
01:43:42 Filing categorized audit issues   ← updates 13 audit issues
01:43:55 Filing categorized lint issues
01:43:55 Reconciling orphaned audit issues ← WRONG
01:43:58 Closed issue #1384 "zero findings remaining"
01:43:59 Closed issue #1383 "zero findings remaining"
...13 fresh audit issues closed, then re-filed on the next run...
```

## Root cause

`close_resolved_issues` via `file_categorized_issues` is correct — it passes the current run's finding kinds and only closes buckets whose kind vanished. The bug is localized to the final orphan-reconciliation loop (`scripts/issues/auto-file-categorized-issues.sh:750-763`), which had no way to distinguish:

- **Command removed from workflow** → real orphan, should close
- **Command ran in a sibling invocation this workflow** → not orphan, must not close

It treated both cases as real orphans.

Also incidentally fixed: a latent IFS bug. The previous `${CMD_ARRAY[*]}` expansion in the haystack relied on ambient `IFS` still being a comma after `IFS=',' read`, which in bash is only true when `IFS` was explicitly set *before* the read. A freshly-inherited `IFS` reverts to whitespace and the needle `,CMD,` would never match for multi-element arrays. The join is now done in a subshell with explicit `IFS=','`.

## Changes

- **`action.yml`** — add `expected-commands` input (default empty), pipe into the auto-file-categorized-issues step as `$EXPECTED_COMMANDS`.
- **`scripts/issues/auto-file-categorized-issues.sh`** — when `EXPECTED_COMMANDS` is set, use it as the reconciliation reference set. Empty falls back to `CMD_ARRAY` (legacy behavior). Explicit `IFS=','` subshell for the array join.
- **`README.md`** — document `expected-commands`.

## Migration

Single-invocation workflows (`commands: audit,lint,test` in one step) need no change — fall-through to `CMD_ARRAY` covers them.

Multi-invocation workflows should add `expected-commands: audit,lint,test` to **every** invocation that runs with `auto-issue` enabled. A companion PR on `Extra-Chill/homeboy` will do this for `release.yml`.

## Smoke coverage

- Multi-step workflow + expected-commands set → no closes ✓
- Legacy single-invocation, expected empty → no closes (unchanged) ✓
- Legacy single-command, command truly removed → closes orphans ✓
- Whitespace in expected-commands → tolerated ✓
- Partial expected-commands → closes only the gap ✓

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Traced the bug from the on-disk bot issue stream (12 refiles of `audit: near duplicate (18)` in 26h on Extra-Chill/homeboy), read the reconciliation block, wrote the fix and the smoke harness. Chris reviewed and approved the approach before implementation.