### PR TITLE
fix(setup): install extension node deps for playground tests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -308,6 +308,7 @@ runs:
         PHP_INPUT: ${{ inputs.php-version }}
         NODE_INPUT: ${{ inputs.node-version }}
         COMPONENT_DIR: ${{ steps.read-config.outputs.component-dir }}
+        PORTABLE_EXTENSION: ${{ steps.read-config.outputs.portable-extension }}
       run: bash ${{ github.action_path }}/scripts/setup/detect-runtime-env.sh
 
     - name: Setup PHP
@@ -546,6 +547,7 @@ runs:
         && steps.categorized-issues.outcome != 'success'
         && (inputs.auto-issue == 'true' || (inputs.auto-issue == '' && github.event_name != 'pull_request'))
       shell: bash
+      continue-on-error: true
       env:
         GH_TOKEN: ${{ inputs.app-token || github.token }}
         RESULTS: ${{ steps.select-results.outputs.results }}
@@ -554,4 +556,8 @@ runs:
         BINARY_SOURCE: ${{ steps.resolve-binary.outputs.binary-source }}
         AUTOFIX_ATTEMPTED: ${{ steps.autofix-prepare-nonpr.outputs.committed }}
         AUTOFIX_PR_CREATED: ${{ steps.autofix-open-pr.outputs.created }}
-      run: bash ${{ github.action_path }}/scripts/issues/auto-file-issue.sh
+      run: |
+        bash ${{ github.action_path }}/scripts/issues/auto-file-issue.sh || {
+          echo "::warning::Auto-issue filing failed; preserving the original Homeboy command failure as the primary signal"
+          exit 0
+        }

--- a/scripts/setup/auto-setup-environment.sh
+++ b/scripts/setup/auto-setup-environment.sh
@@ -34,6 +34,13 @@ if [ -f "composer.json" ]; then
   fi
 fi
 
+# ── Extension setup ──
+
+if [ -n "${EXTENSION}" ] && command -v homeboy &>/dev/null; then
+  echo "Setting up Homeboy extension dependencies (${EXTENSION})..."
+  homeboy extension setup "${EXTENSION}" 2>&1
+fi
+
 # ── npm install (Node projects) ──
 
 if [ -f "package.json" ] && [ -n "${PORTABLE_NODE:-}" ]; then

--- a/scripts/setup/detect-runtime-env.sh
+++ b/scripts/setup/detect-runtime-env.sh
@@ -7,7 +7,9 @@
 # file header instead of requiring manual configuration.
 #
 # Action input overrides (PHP_INPUT, NODE_INPUT) take priority over
-# detected values.
+# detected values. Extension runtime requirements are used as a fallback when
+# the component itself does not declare a runtime but the installed extension
+# needs one for setup or execution.
 #
 # Outputs (GITHUB_ENV + GITHUB_OUTPUT):
 #   PORTABLE_PHP  — PHP version to install
@@ -18,6 +20,8 @@ set -euo pipefail
 PHP_INPUT="${PHP_INPUT:-}"
 NODE_INPUT="${NODE_INPUT:-}"
 COMPONENT_DIR="${COMPONENT_DIR:-.}"
+PORTABLE_EXTENSION="${PORTABLE_EXTENSION:-}"
+DEFAULT_EXTENSION_NODE_VERSION="${DEFAULT_EXTENSION_NODE_VERSION:-24}"
 
 PORTABLE_PHP=""
 PORTABLE_NODE=""
@@ -36,6 +40,15 @@ else
   DETECTED_NODE=""
 fi
 
+EXTENSION_NODE_REQUIRED="false"
+if [ -n "${PORTABLE_EXTENSION}" ] && command -v homeboy &>/dev/null; then
+  EXTENSION_JSON="$(homeboy extension show "${PORTABLE_EXTENSION}" 2>/dev/null || true)"
+  EXTENSION_PATH="$(echo "${EXTENSION_JSON}" | jq -r '.data.extension.path // empty' 2>/dev/null || true)"
+  if [ -n "${EXTENSION_PATH}" ] && [ -f "${EXTENSION_PATH}/package.json" ]; then
+    EXTENSION_NODE_REQUIRED="true"
+  fi
+fi
+
 # Action input overrides take priority
 if [ -n "${PHP_INPUT}" ]; then
   PORTABLE_PHP="${PHP_INPUT}"
@@ -47,6 +60,8 @@ if [ -n "${NODE_INPUT}" ]; then
   PORTABLE_NODE="${NODE_INPUT}"
 elif [ -n "${DETECTED_NODE}" ]; then
   PORTABLE_NODE="${DETECTED_NODE}"
+elif [ "${EXTENSION_NODE_REQUIRED}" = "true" ]; then
+  PORTABLE_NODE="${DEFAULT_EXTENSION_NODE_VERSION}"
 fi
 
 echo "PORTABLE_PHP=${PORTABLE_PHP}" >> "${GITHUB_ENV}"
@@ -57,4 +72,11 @@ echo "portable-node=${PORTABLE_NODE}" >> "${GITHUB_OUTPUT}"
 
 echo "Runtime env detected:"
 echo "  php:  ${PORTABLE_PHP:-skip}${PHP_INPUT:+ (overridden by input)}"
-echo "  node: ${PORTABLE_NODE:-skip}${NODE_INPUT:+ (overridden by input)}"
+if [ -n "${NODE_INPUT}" ]; then
+  NODE_NOTE=" (overridden by input)"
+elif [ -z "${DETECTED_NODE}" ] && [ "${EXTENSION_NODE_REQUIRED}" = "true" ]; then
+  NODE_NOTE=" (required by ${PORTABLE_EXTENSION} extension setup)"
+else
+  NODE_NOTE=""
+fi
+echo "  node: ${PORTABLE_NODE:-skip}${NODE_NOTE}"

--- a/scripts/setup/test-detect-runtime-env.sh
+++ b/scripts/setup/test-detect-runtime-env.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+FAKE_BIN="${TMPDIR}/bin"
+FAKE_EXTENSION="${TMPDIR}/extensions/wordpress"
+mkdir -p "${FAKE_BIN}" "${FAKE_EXTENSION}"
+printf '{"engines":{"node":">=18.12.0"}}\n' > "${FAKE_EXTENSION}/package.json"
+
+cat > "${FAKE_BIN}/homeboy" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "component" ] && [ "$2" = "env" ]; then
+  printf '{"success":true,"data":{"entity":{"php":"8.2"}}}\n'
+  exit 0
+fi
+
+if [ "$1" = "extension" ] && [ "$2" = "show" ]; then
+  printf '{"success":true,"data":{"extension":{"path":"%s"}}}\n' "${FAKE_EXTENSION_PATH}"
+  exit 0
+fi
+
+printf 'unexpected fake homeboy invocation: %s\n' "$*" >&2
+exit 1
+SH
+chmod +x "${FAKE_BIN}/homeboy"
+
+GITHUB_ENV_FILE="${TMPDIR}/env"
+GITHUB_OUTPUT_FILE="${TMPDIR}/output"
+LOG_FILE="${TMPDIR}/log"
+
+PATH="${FAKE_BIN}:${PATH}" \
+FAKE_EXTENSION_PATH="${FAKE_EXTENSION}" \
+GITHUB_ENV="${GITHUB_ENV_FILE}" \
+GITHUB_OUTPUT="${GITHUB_OUTPUT_FILE}" \
+COMPONENT_DIR="${TMPDIR}" \
+PORTABLE_EXTENSION="wordpress" \
+DEFAULT_EXTENSION_NODE_VERSION="24" \
+bash "${SCRIPT_DIR}/detect-runtime-env.sh" > "${LOG_FILE}"
+
+assert_equals "PORTABLE_PHP=8.2" "$(grep '^PORTABLE_PHP=' "${GITHUB_ENV_FILE}")" "detects component PHP"
+assert_equals "PORTABLE_NODE=24" "$(grep '^PORTABLE_NODE=' "${GITHUB_ENV_FILE}")" "uses extension-required Node fallback"
+assert_equals "portable-node=24" "$(grep '^portable-node=' "${GITHUB_OUTPUT_FILE}")" "writes portable-node output"
+
+if ! grep -q 'node: 24 (required by wordpress extension setup)' "${LOG_FILE}"; then
+  printf 'FAIL: extension Node requirement is explained in log\n'
+  exit 1
+fi
+printf 'PASS: extension Node requirement is explained in log\n'
+
+GITHUB_ENV_FILE="${TMPDIR}/env-input"
+GITHUB_OUTPUT_FILE="${TMPDIR}/output-input"
+PATH="${FAKE_BIN}:${PATH}" \
+FAKE_EXTENSION_PATH="${FAKE_EXTENSION}" \
+GITHUB_ENV="${GITHUB_ENV_FILE}" \
+GITHUB_OUTPUT="${GITHUB_OUTPUT_FILE}" \
+COMPONENT_DIR="${TMPDIR}" \
+PORTABLE_EXTENSION="wordpress" \
+NODE_INPUT="20" \
+bash "${SCRIPT_DIR}/detect-runtime-env.sh" > /dev/null
+
+assert_equals "PORTABLE_NODE=20" "$(grep '^PORTABLE_NODE=' "${GITHUB_ENV_FILE}")" "node input overrides extension fallback"


### PR DESCRIPTION
## Summary
- Detect installed Homeboy extension Node requirements during runtime setup, so WordPress Playground tests set up Node even when the target repo has no `package.json`.
- Run `homeboy extension setup` during auto-setup so the WordPress extension installs `@wp-playground/cli` before `homeboy test` runs.
- Treat generic auto-issue filing failures as warning-only so permissions problems do not obscure the original command failure.

## Tests
- `bash scripts/setup/test-detect-runtime-env.sh`
- `bash scripts/core/test-command-builders.sh`
- `python3 scripts/digest/test-audit-comment-render.py` (skips when fixture is absent)
- `bash -n scripts/setup/detect-runtime-env.sh scripts/setup/auto-setup-environment.sh scripts/setup/test-detect-runtime-env.sh scripts/issues/auto-file-issue.sh`
- `ruby -e 'require "yaml"; YAML.load_file("action.yml"); puts "action.yml parsed"'`
- `git diff --check`

## Notes
- `homeboy test homeboy-action --path /Users/chubes/Developer/homeboy-action@fix-wordpress-playground-node-bootstrap` still fails before tests because `homeboy-action` has no extension configured; this is the existing repository shape, not a regression from this change.

Closes #146

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the runtime setup gap, implemented the shell/YAML changes and smoke test, and ran targeted validation. Chris remains responsible for review and merge.
