### PR TITLE
chore(release): drop duplicate GitHub Release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@
 # Triggers on push to main (immediate release) and manual dispatch.
 # Checks for releasable conventional commits since the last tag. If found:
 #   1. Version bump + changelog generation
-#   2. Tag + push
+#   2. Tag + push + GitHub Release creation
 #   3. Post-release hook moves the floating v2 tag
 #
 # No binary builds, no extensions needed — homeboy reads homeboy.json
@@ -109,80 +109,6 @@ jobs:
           commands: release
           release-dry-run: ${{ inputs.dry-run || 'false' }}
           app-token: ${{ steps.app-token.outputs.token || '' }}
-
-  # ── Step 3: Create GitHub Release ──
-  # After a successful release, create a GitHub Release from the tag
-  # with changelog notes extracted from docs/CHANGELOG.md.
-  create-release:
-    name: Create GitHub Release
-    needs: release
-    if: ${{ needs.release.result == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: main
-
-      - name: Get release metadata
-        id: meta
-        run: |
-          # Get the latest semver tag (skip floating tags like v1, v2)
-          TAG="$(git tag --sort=-creatordate --list 'v[0-9]*.[0-9]*.[0-9]*' | head -1)"
-          if [ -z "${TAG}" ]; then
-            echo "::error::No semver tag found on HEAD"
-            exit 1
-          fi
-          VERSION="${TAG#v}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Release tag: ${TAG} (version: ${VERSION})"
-
-      - name: Extract changelog section
-        id: notes
-        run: |
-          VERSION="${{ steps.meta.outputs.version }}"
-          CHANGELOG="docs/CHANGELOG.md"
-
-          if [ ! -f "${CHANGELOG}" ]; then
-            echo "body=Release ${VERSION}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Extract the section for this version: from "## [VERSION]" to the next "## ["
-          BODY=$(awk -v ver="${VERSION}" '
-            /^## \[/ {
-              if (found) exit
-              if (index($0, "[" ver "]")) found=1
-              next
-            }
-            found { print }
-          ' "${CHANGELOG}" | sed '/^$/N;/^\n$/d')
-
-          if [ -z "${BODY}" ]; then
-            BODY="Release v${VERSION}"
-          fi
-
-          # Write to file to avoid quoting issues
-          echo "${BODY}" > /tmp/release-notes.md
-          echo "notes-file=/tmp/release-notes.md" >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${{ steps.meta.outputs.tag }}"
-
-          # Skip if release already exists
-          if gh release view "${TAG}" > /dev/null 2>&1; then
-            echo "Release ${TAG} already exists — skipping"
-            exit 0
-          fi
-
-          gh release create "${TAG}" \
-            --title "${TAG}" \
-            --notes-file "${{ steps.notes.outputs.notes-file }}" \
-            --verify-tag
 
   # ── Record failed SHA to prevent retry loops ──
   record-failure:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
 
 ### Continuous Release
 
-Fully automated releases — no human input needed. Triggers on every push to main, checks for releasable conventional commits since the last tag, computes the version, generates changelog, bumps version targets, tags, and publishes.
+Fully automated releases — no human input needed. Triggers on every push to main, checks for releasable conventional commits since the last tag, computes the version, generates changelog, bumps version targets, tags, creates a GitHub Release, and publishes.
 
 ```yaml
 name: Release
@@ -69,7 +69,7 @@ The release command:
 4. Generates changelog entries via `homeboy changelog add`
 5. Bumps version targets (Cargo.toml, package.json, VERSION, etc.)
 6. Finalizes changelog (`[Next]` → `[VERSION] - DATE`)
-7. Commits, creates an annotated tag, and pushes
+7. Commits, creates an annotated tag, pushes, and creates a GitHub Release
 
 After the tag push, downstream build/publish jobs can pick it up (e.g. cargo-dist, npm publish).
 
@@ -324,7 +324,7 @@ jobs:
   build:
     needs: prepare
     if: needs.prepare.outputs.released == 'true'
-    # ... cargo-dist, crates.io, Homebrew, GitHub Release
+    # ... cargo-dist, crates.io, Homebrew
 ```
 
 ### Recommended Org-wide CI Profile
@@ -371,7 +371,7 @@ When multiple jobs invoke Homeboy Action on the same PR, they **merge into one s
 2. **Installs Extension** — Clones and sets up the specified extension
 3. **Validates Portable Config** — Requires `homeboy.json` at repo root
 4. **Runs Commands** — Executes each command with `--path` pointing at your workspace
-5. **Release** — If `commands` includes `release`, checks for releasable commits, bumps version, generates changelog, tags, and pushes
+5. **Release** — If `commands` includes `release`, checks for releasable commits, bumps version, generates changelog, tags, pushes, and creates a GitHub Release
 
 ## Requirements
 

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/release.yml"
+RUN_RELEASE="${ROOT_DIR}/scripts/release/run-release.sh"
+
+assert_not_contains() {
+  local needle="$1"
+  local file_path="$2"
+  local label="$3"
+
+  if grep -q -- "${needle}" "${file_path}"; then
+    printf 'FAIL: %s\nfound forbidden pattern: %s\nfile: %s\n' "${label}" "${needle}" "${file_path}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_contains() {
+  local needle="$1"
+  local file_path="$2"
+  local label="$3"
+
+  if ! grep -q -- "${needle}" "${file_path}"; then
+    printf 'FAIL: %s\nmissing pattern: %s\nfile: %s\n' "${label}" "${needle}" "${file_path}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_not_contains '^  create-release:' "${WORKFLOW}" "release workflow has no duplicate GitHub Release job"
+assert_not_contains 'gh release create' "${WORKFLOW}" "release workflow does not shell out to gh release create"
+assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not parse changelog notes"
+
+assert_contains 'commands: release' "${WORKFLOW}" "release workflow delegates to homeboy-action release command"
+assert_not_contains '--no-github-release' "${RUN_RELEASE}" "run-release lets Homeboy core create GitHub Releases"
+
+printf 'All release workflow checks passed.\n'


### PR DESCRIPTION
## Summary
- Remove the release workflow's standalone `create-release` job now `homeboy release` creates GitHub Releases itself.
- Keep Homeboy Action as the thin caller of core release semantics and preserve the existing floating `v2` post-release hook.

## Changes
- Deletes the workflow-level `gh release create` job and changelog parsing shell.
- Updates README release wording so GitHub Release creation is documented as part of `commands: release`.
- Adds a small workflow smoke test that guards against reintroducing a duplicate release publisher or passing `--no-github-release`.

## Tests
- `bash scripts/core/test-command-builders.sh`
- `bash scripts/setup/test-detect-runtime-env.sh`
- `python3 scripts/digest/test-audit-comment-render.py`
- `bash scripts/release/test-release-workflow.sh`

Closes #148

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspecting the Homeboy core release behavior, removing the duplicate workflow release publisher, adding the guard test, and running local validation. Chris reviewed the scope through the issue prompt and CI/PR review remains authoritative.
