### PR TITLE
refactor(pr): use homeboy review report for comments

### DIFF
--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -346,6 +346,20 @@ build_run_command() {
   printf '%s\n' "${full_cmd}"
 }
 
+build_review_report_command() {
+  local component_id="$1"
+  local workspace="$2"
+  local full_cmd
+
+  full_cmd="homeboy review ${component_id} --path ${workspace} --report=pr-comment"
+
+  local scope
+  scope="$(scope_flags_for "review")"
+  [ -n "${scope}" ] && full_cmd="${full_cmd} ${scope}"
+
+  printf '%s\n' "${full_cmd}"
+}
+
 command_output_stem() {
   local cmd="$1"
   local stem
@@ -387,4 +401,3 @@ build_autofix_command() {
 
   printf '%s\n' "${full_cmd}"
 }
-

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -58,6 +58,11 @@ assert_equals \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
   "audit keeps path with changed-since"
 
+assert_equals \
+  "homeboy review data-machine --path /tmp/workspace --report=pr-comment --changed-since origin/main" \
+  "$(build_review_report_command "${COMPONENT}" "${WORKSPACE}")" \
+  "review report keeps path with changed-since"
+
 EXTRA_ARGS="--format json"
 assert_equals \
   "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
@@ -116,6 +121,11 @@ assert_equals \
   "homeboy refactor data-machine --all --path /tmp/workspace" \
   "$(build_run_command "refactor --all" "${COMPONENT}" "${WORKSPACE}")" \
   "refactor keeps workspace path"
+
+assert_equals \
+  "homeboy review data-machine --path /tmp/workspace --report=pr-comment" \
+  "$(build_review_report_command "${COMPONENT}" "${WORKSPACE}")" \
+  "review report keeps workspace path"
 
 PR_HEAD_REPO="some-contributor/homeboy-action"
 GITHUB_REPOSITORY="Extra-Chill/homeboy-action"

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -59,6 +59,48 @@ append_test_scope_section() {
   fi
 }
 
+commands_use_review_report() {
+  local normalized
+  normalized="$(canonicalize_commands "${COMMANDS}")"
+
+  [ "${normalized}" = "audit,lint,test" ] && [ -z "${EXTRA_ARGS:-}" ]
+}
+
+append_review_report_section() {
+  if ! commands_use_review_report; then
+    return 1
+  fi
+
+  local review_cmd review_md review_exit
+  review_cmd="$(build_review_report_command "${COMP_ID}" "${WORKSPACE}")"
+
+  set +e
+  review_md="$(eval "${review_cmd}" 2>/dev/null)"
+  review_exit=$?
+  set -e
+
+  if [ -z "${review_md}" ]; then
+    echo "::warning::homeboy review did not render a PR-comment report; falling back to command summaries."
+    return 1
+  fi
+
+  if [[ "${review_md}" != *"finding(s) across"* ]]; then
+    echo "::warning::homeboy review output was not a PR-comment report; falling back to command summaries."
+    return 1
+  fi
+
+  SECTION_BODY+="${review_md}"$'\n\n'
+
+  # Exit code 1 means the review found issues, which is exactly when the PR
+  # comment is most useful. Exit code >=2 is an execution problem; keep the
+  # rendered diagnostics if core emitted any, but surface a workflow warning.
+  if [ "${review_exit}" -ge 2 ]; then
+    echo "::warning::homeboy review report command exited ${review_exit}; posted rendered diagnostics."
+  fi
+
+  return 0
+}
+
 append_command_sections() {
   IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
 
@@ -90,6 +132,9 @@ build_section_body() {
   SECTION_BODY="### ${SECTION_TITLE}"$'\n\n'
   append_autofix_section
   append_binary_source_section
+  if append_review_report_section; then
+    return 0
+  fi
   append_digest_section
   append_scope_section
   append_test_scope_section

--- a/scripts/pr/comment/test-review-report-section.sh
+++ b/scripts/pr/comment/test-review-report-section.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    printf 'FAIL: %s\nmissing: %s\nbody:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    printf 'FAIL: %s\nunexpected: %s\nbody:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+fake_bin="$(mktemp -d)"
+trap 'rm -rf "${fake_bin}"' EXIT
+
+cat > "${fake_bin}/homeboy" <<'SH'
+#!/usr/bin/env bash
+printf ':zap: Scope: **changed files only** (since `origin/main`)\n\n'
+printf '**2** finding(s) across 2 stage(s)\n\n'
+printf ':x: **audit** — failed (2 finding(s))\n'
+exit 1
+SH
+chmod +x "${fake_bin}/homeboy"
+
+export PATH="${fake_bin}:${PATH}"
+export GITHUB_ACTION_PATH="${ROOT}"
+export COMMANDS="audit,lint,test"
+export RESULTS='{"audit":"fail","lint":"pass","test":"pass"}'
+export COMP_ID="data-machine"
+export WORKSPACE="/tmp/workspace"
+export SECTION_TITLE="Audit"
+export AUTOFIX_ENABLED="false"
+export BINARY_SOURCE="source"
+export SCOPE_MODE="changed"
+export SCOPE_BASE_REF="origin/main"
+export DIGEST_FILE=""
+
+source "${ROOT}/scripts/core/lib.sh"
+source "${ROOT}/scripts/pr/comment/sections.sh"
+
+build_section_body
+
+assert_contains "${SECTION_BODY}" "### Audit" "section title preserved"
+assert_contains "${SECTION_BODY}" "**2** finding(s) across 2 stage(s)" "review markdown appended"
+assert_contains "${SECTION_BODY}" ":x: **audit** — failed" "review stage markdown appended"
+assert_not_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "legacy per-command audit block skipped"
+
+export EXTRA_ARGS="--format json"
+build_section_body
+
+assert_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "custom args fall back to legacy command blocks"
+
+printf 'All review report section checks passed.\n'

--- a/scripts/scope/flags.sh
+++ b/scripts/scope/flags.sh
@@ -20,7 +20,7 @@ scope_flags_for() {
   fi
 
   case "${base_cmd}" in
-    audit|lint|test|refactor)
+    audit|lint|test|refactor|review)
       printf '%s' "--changed-since ${SCOPE_BASE_REF}"
       ;;
     # release, fleet, deploy, and other commands are never scoped


### PR DESCRIPTION
## Summary
- Routes the standard `audit,lint,test` PR comment body through `homeboy review --report=pr-comment` instead of the action's duplicated per-command markdown renderer.
- Keeps existing action-level banner/tooling shell glue while Homeboy core banner support remains tracked separately.

## Changes
- Add a review report command builder and include `review` in changed-scope flag generation.
- Prefer the core review markdown report for the canonical quality trio, falling back to legacy command blocks for custom command sets or extra command args.
- Add a shell smoke test that proves review markdown replaces legacy per-command blocks for the standard PR comment path.

## Tests
- `bash scripts/core/test-command-builders.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `python3 scripts/digest/test-audit-comment-render.py` (skipped: real audit log fixture not available)
- `bash scripts/setup/test-detect-runtime-env.sh`
- `bash scripts/release/test-release-workflow.sh`
- `bash -n scripts/pr/comment/test-review-report-section.sh scripts/pr/comment/sections.sh scripts/core/lib.sh scripts/scope/flags.sh scripts/pr/post-pr-comment.sh`
- `homeboy audit homeboy-action --path /Users/chubes/Developer/homeboy-action@refactor-pr-comment-review-report`

Closes #144

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the shell migration, focused validation, and PR preparation; Chris remains responsible for review and merge.