### PR TITLE
fix(pr): reduce comment noise

### DIFF
--- a/scripts/digest/fixtures/audit-comment-quality-expected.md
+++ b/scripts/digest/fixtures/audit-comment-quality-expected.md
@@ -1,0 +1,24 @@
+:x: **3 new finding(s) on this PR:**
+
+1. **docs** — Broken file reference `scripts/build/build.sh` (line 19) — target does not exist (`docs::runner::build`)
+2. **docs** — Broken file reference `scripts/lint/lint-runner.sh` (line 17) — target does not exist (`docs::runner::lint`)
+3. **docs** — Broken file reference `scripts/test/test-runner.sh` (line 18) — target does not exist (`docs::runner::test`)
+
+_Full audit state below._
+- Alignment score: **0.900**
+- Outliers in current run: **4**
+- Drift increased: **yes**
+- Severity counts: **warning: 3**
+
+<details><summary>Audit findings (6 shown)</summary>
+
+```text
+1. **docs/architecture/runner-contract.md** — broken_doc_reference — Broken file reference `scripts/build/build.sh` (line 19) — target does not exist
+2. **docs/architecture/runner-contract.md** — broken_doc_reference — Broken file reference `scripts/lint/lint-runner.sh` (line 17) — target does not exist
+3. **docs/architecture/runner-contract.md** — broken_doc_reference — Broken file reference `scripts/test/test-runner.sh` (line 18) — target does not exist
+4. **src/commands/docs.rs** — outlier — (outlier)
+5. **src/core/engine/undo/entry.rs** — outlier — (outlier)
+6. **src/core/engine/undo/snapshot.rs** — outlier — (outlier)
+```
+
+</details>

--- a/scripts/digest/fixtures/audit-comment-quality-input.json
+++ b/scripts/digest/fixtures/audit-comment-quality-input.json
@@ -1,0 +1,67 @@
+{
+  "success": false,
+  "data": {
+    "summary": {
+      "alignment_score": 0.9,
+      "outliers_found": 4
+    },
+    "baseline_comparison": {
+      "drift_increased": true,
+      "new_items": [
+        {
+          "context_label": "docs",
+          "description": "Broken file reference `scripts/build/build.sh` (line 19) — target does not exist",
+          "fingerprint": "docs::runner::build"
+        },
+        {
+          "context_label": "docs",
+          "description": "Broken file reference `scripts/lint/lint-runner.sh` (line 17) — target does not exist",
+          "fingerprint": "docs::runner::lint"
+        },
+        {
+          "context_label": "docs",
+          "description": "Broken file reference `scripts/test/test-runner.sh` (line 18) — target does not exist",
+          "fingerprint": "docs::runner::test"
+        }
+      ]
+    },
+    "findings": [
+      {
+        "file": "docs/architecture/runner-contract.md",
+        "rule": "broken_doc_reference",
+        "description": "Broken file reference `scripts/build/build.sh` (line 19) — target does not exist",
+        "severity": "warning"
+      },
+      {
+        "file": "docs/architecture/runner-contract.md",
+        "rule": "broken_doc_reference",
+        "description": "Broken file reference `scripts/lint/lint-runner.sh` (line 17) — target does not exist",
+        "severity": "warning"
+      },
+      {
+        "file": "docs/architecture/runner-contract.md",
+        "rule": "broken_doc_reference",
+        "description": "Broken file reference `scripts/test/test-runner.sh` (line 18) — target does not exist",
+        "severity": "warning"
+      },
+      {
+        "file": "src/commands/docs.rs",
+        "rule": "outlier",
+        "description": "(outlier)",
+        "severity": "unknown"
+      },
+      {
+        "file": "src/core/engine/undo/entry.rs",
+        "rule": "outlier",
+        "description": "(outlier)",
+        "severity": "unknown"
+      },
+      {
+        "file": "src/core/engine/undo/snapshot.rs",
+        "rule": "outlier",
+        "description": "(outlier)",
+        "severity": "unknown"
+      }
+    ]
+  }
+}

--- a/scripts/digest/fixtures/refactor-noop-expected.md
+++ b/scripts/digest/fixtures/refactor-noop-expected.md
@@ -1,0 +1,1 @@
+- No fixable changes

--- a/scripts/digest/fixtures/refactor-noop-input.json
+++ b/scripts/digest/fixtures/refactor-noop-input.json
@@ -1,0 +1,26 @@
+{
+  "success": true,
+  "data": {
+    "files_modified": 0,
+    "plan_totals": {
+      "total_fixes_proposed": 0
+    },
+    "stages": [
+      {
+        "stage": "audit",
+        "fixes_proposed": 0,
+        "files_modified": 0,
+        "detected_findings": 3
+      },
+      {
+        "stage": "lint",
+        "fixes_proposed": 0,
+        "files_modified": 0,
+        "detected_findings": 0
+      }
+    ],
+    "warnings": [
+      "No automated fixes accumulated across audit/lint/test"
+    ]
+  }
+}

--- a/scripts/digest/render-command-summary.py
+++ b/scripts/digest/render-command-summary.py
@@ -44,6 +44,18 @@ def append_details(lines: list[str], summary: str, body_lines: list[str]) -> Non
     lines.append("</details>")
 
 
+def format_new_audit_item(item: dict[str, Any]) -> str:
+    context = str(item.get("context_label") or item.get("file") or "unknown")
+    message = str(item.get("description") or item.get("message") or "(new finding)")
+    fingerprint = str(item.get("fingerprint") or "")
+    entry = f"**{context}**"
+    if message:
+        entry += f" — {message}"
+    if fingerprint:
+        entry += f" (`{fingerprint}`)"
+    return entry
+
+
 # ── Compact summaries (one-line for issue filing) ─────────────────────
 
 def compact_summary(command: str, raw: dict[str, Any]) -> str:
@@ -222,6 +234,18 @@ def markdown_audit(data: dict[str, Any], lines: list[str]) -> None:
     findings = data.get("findings", []) if isinstance(data, dict) else []
     conventions = data.get("conventions", []) if isinstance(data, dict) else []
 
+    new_items = baseline.get("new_items", []) if isinstance(baseline, dict) else []
+    if isinstance(new_items, list) and new_items:
+        lines.append(f":x: **{len(new_items)} new finding(s) on this PR:**")
+        lines.append("")
+        for idx, item in enumerate(new_items[:5], start=1):
+            if isinstance(item, dict):
+                lines.append(f"{idx}. {format_new_audit_item(item)}")
+        if len(new_items) > 5:
+            lines.append(f"... and {len(new_items) - 5} more")
+        lines.append("")
+        lines.append("_Full audit state below._")
+
     alignment = summary.get("alignment_score") if isinstance(summary, dict) else None
     if isinstance(alignment, (int, float)):
         lines.append(f"- Alignment score: **{alignment:.3f}**")
@@ -232,23 +256,6 @@ def markdown_audit(data: dict[str, Any], lines: list[str]) -> None:
 
     drift = baseline.get("drift_increased", False) if isinstance(baseline, dict) else False
     lines.append(f"- Drift increased: **{'yes' if drift else 'no'}**")
-
-    # New findings from baseline comparison
-    new_items = baseline.get("new_items", []) if isinstance(baseline, dict) else []
-    if isinstance(new_items, list) and new_items:
-        lines.append(f"- New findings since baseline: **{len(new_items)}**")
-        for idx, item in enumerate(new_items[:5], start=1):
-            if not isinstance(item, dict):
-                continue
-            context = str(item.get("context_label") or item.get("file") or "unknown")
-            message = str(item.get("description") or item.get("message") or "(new finding)")
-            fingerprint = str(item.get("fingerprint") or "")
-            entry = f"  {idx}. **{context}**"
-            if message:
-                entry += f" — {message}"
-            if fingerprint:
-                entry += f" (`{fingerprint}`)"
-            lines.append(entry)
 
     # Collect outlier items from conventions
     outlier_items: list[dict[str, Any]] = []
@@ -279,30 +286,39 @@ def markdown_audit(data: dict[str, Any], lines: list[str]) -> None:
         })
 
     if severity_counts:
-        sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(severity_counts.items()))
-        lines.append(f"- Severity counts: **{sev_text}**")
+        known_counts = {k: v for k, v in severity_counts.items() if k != "unknown"}
+        if known_counts:
+            sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(known_counts.items()))
+            lines.append(f"- Severity counts: **{sev_text}**")
 
     if top_findings:
-        lines.append("- Top actionable findings:")
         detail_lines: list[str] = []
         for idx, finding in enumerate(top_findings[:10], start=1):
             file_value = finding["file"]
             rule_value = finding["rule"]
             message = finding["message"]
-            line = f"  {idx}. **{file_value}** — {rule_value}"
             detail = f"{idx}. **{file_value}** — {rule_value}"
             if message:
-                line += f" — {message}"
                 detail += f" — {message}"
-            lines.append(line)
             detail_lines.append(detail)
-        append_details(lines, f"Audit findings ({min(len(top_findings), 10)} shown)", detail_lines)
+        if len(top_findings) <= 5:
+            lines.append("- Actionable findings:")
+            for line in detail_lines:
+                lines.append(f"  {line}")
+        else:
+            append_details(lines, f"Audit findings ({min(len(top_findings), 10)} shown)", detail_lines)
 
 
 def markdown_refactor(data: dict[str, Any], lines: list[str]) -> None:
     files_modified = int(data.get("files_modified", 0) or 0)
     totals = data.get("plan_totals", {})
     total_fixes = int(totals.get("total_fixes_proposed", 0) or 0) if isinstance(totals, dict) else 0
+    warnings = data.get("warnings", [])
+
+    if total_fixes == 0 and files_modified == 0:
+        lines.append("- No fixable changes")
+        return
+
     lines.append(f"- Total fixes proposed: **{total_fixes}**")
     lines.append(f"- Files modified: **{files_modified}**")
 
@@ -326,7 +342,6 @@ def markdown_refactor(data: dict[str, Any], lines: list[str]) -> None:
             detail_lines.append(f"... and {len(changed_files) - 15} more")
         append_details(lines, f"Changed files ({len(changed_files)})", detail_lines)
 
-    warnings = data.get("warnings", [])
     if isinstance(warnings, list):
         notable = [str(w) for w in warnings if isinstance(w, str) and "merge order" not in w.lower()]
         if notable:

--- a/scripts/digest/render.py
+++ b/scripts/digest/render.py
@@ -13,6 +13,34 @@ def _format_audit_finding(finding: dict[str, Any]) -> str:
     return " — ".join(parts)
 
 
+def _format_new_audit_finding(finding: dict[str, Any]) -> str:
+    context = str(finding.get("context", "unknown"))
+    message = str(finding.get("message", ""))
+    fingerprint = str(finding.get("fingerprint", ""))
+    line = f"**{context}**"
+    if message:
+        line += f" — {message}"
+    if fingerprint:
+        line += f" (`{fingerprint}`)"
+    return line
+
+
+def _status_summary(results: dict[str, Any], audit_digest: dict[str, Any]) -> str:
+    parts: list[str] = []
+    ordered_commands = [cmd for cmd in ["lint", "test", "audit", "refactor"] if cmd in results]
+    ordered_commands.extend(cmd for cmd in results if cmd not in ordered_commands)
+    for command in ordered_commands:
+        status = str(results.get(command, "unknown"))
+        icon = ":white_check_mark:" if status == "pass" else ":x:"
+        label = command
+        if command == "audit":
+            new_count = audit_digest.get("new_findings_count", 0)
+            if isinstance(new_count, int) and new_count > 0:
+                label += f" ({new_count} new)"
+        parts.append(f"{icon} {label}")
+    return " · ".join(parts)
+
+
 def _append_details_block(lines: list[str], summary: str, block_lines: list[str]) -> None:
     content = [str(line) for line in block_lines if str(line) != ""]
     if not content:
@@ -58,6 +86,10 @@ def render_markdown(
 ) -> str:
     lines: list[str] = []
     lines.append("## Failure Digest")
+    summary = _status_summary(results, audit_digest)
+    if summary:
+        lines.append("")
+        lines.append(f"**TL;DR:** {summary}")
     lines.append("")
 
     if "lint" in results:
@@ -137,13 +169,27 @@ def render_markdown(
 
     if "audit" in results:
         lines.append("### Audit Failure Digest")
+        new_findings = audit_digest.get("new_findings", []) or []
+        new_findings_count = audit_digest.get("new_findings_count", 0)
+        if isinstance(new_findings_count, int) and new_findings_count > 0:
+            lines.append(f":x: **{new_findings_count} new finding(s) on this PR:**")
+            lines.append("")
+            for idx, finding in enumerate(new_findings[:5], start=1):
+                lines.append(f"{idx}. {_format_new_audit_finding(finding)}")
+            if new_findings_count > 5:
+                lines.append(f"... and {new_findings_count - 5} more")
+            lines.append("")
+            lines.append("_Full audit state below._")
+
         alignment_score = audit_digest.get("alignment_score")
         if isinstance(alignment_score, (int, float)):
             lines.append(f"- Alignment score: **{alignment_score:.3f}**")
         severity_counts = audit_digest.get("severity_counts", {}) or {}
         if severity_counts:
-            sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(severity_counts.items()))
-            lines.append(f"- Severity counts: **{sev_text}**")
+            known_counts = {k: v for k, v in severity_counts.items() if str(k).lower() != "unknown"}
+            if known_counts:
+                sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(known_counts.items()))
+                lines.append(f"- Severity counts: **{sev_text}**")
         outliers = audit_digest.get("outliers_found")
         if isinstance(outliers, int):
             lines.append(f"- Outliers in current run: **{outliers}**")
@@ -152,27 +198,8 @@ def render_markdown(
             lines.append(f"- Parsed outlier entries: **{parsed_outliers}**")
         lines.append(f"- Drift increased: **{'yes' if audit_digest.get('drift_increased') else 'no'}**")
 
-        new_findings = audit_digest.get("new_findings", []) or []
-        new_findings_count = audit_digest.get("new_findings_count", 0)
-        if isinstance(new_findings_count, int) and new_findings_count > 0:
-            lines.append(f"- New findings since baseline: **{new_findings_count}**")
-            for idx, finding in enumerate(new_findings[:5], start=1):
-                context = str(finding.get("context", "unknown"))
-                message = str(finding.get("message", ""))
-                fingerprint = str(finding.get("fingerprint", ""))
-                line = f"  {idx}. **{context}**"
-                if message:
-                    line += f" — {message}"
-                if fingerprint:
-                    line += f" (`{fingerprint}`)"
-                lines.append(line)
-
         top_findings = audit_digest.get("top_findings", []) or []
         if top_findings:
-            lines.append("- Top actionable findings:")
-            for idx, finding in enumerate(top_findings[:5], start=1):
-                lines.append(f"  {idx}. {_format_audit_finding(finding)}")
-
             max_full_findings = 300
             full_findings = top_findings[:max_full_findings]
             detail_lines = [
@@ -184,7 +211,12 @@ def render_markdown(
                 detail_lines.append(
                     f"_Truncated to {max_full_findings} findings to avoid oversized PR comments ({len(top_findings)} total parsed)._"
                 )
-            _append_details_block(lines, f"All parsed audit findings ({len(top_findings)})", detail_lines)
+            if len(top_findings) <= 5:
+                lines.append("- Actionable findings:")
+                for line in detail_lines:
+                    lines.append(f"  {line}")
+            else:
+                _append_details_block(lines, f"Audit findings ({len(top_findings)})", detail_lines)
         else:
             lines.append("- No structured audit findings available.")
 

--- a/scripts/digest/test-comment-quality-render.py
+++ b/scripts/digest/test-comment-quality-render.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Smoke tests for PR comment signal/noise rendering."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "scripts/digest/fixtures"
+RENDERER = ROOT / "scripts/digest/render-command-summary.py"
+sys.path.insert(0, str(ROOT / "scripts/digest"))
+
+from render import render_markdown  # noqa: E402
+
+
+def assert_equal(actual: str, expected: str, label: str) -> None:
+    if actual != expected:
+        raise AssertionError(f"{label} mismatch\n--- actual ---\n{actual}\n--- expected ---\n{expected}")
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"missing {label}: {needle!r}\n---\n{text}")
+
+
+def assert_not_contains(text: str, needle: str, label: str) -> None:
+    if needle in text:
+        raise AssertionError(f"unexpected {label}: {needle!r}\n---\n{text}")
+
+
+def render(command: str, fixture: str) -> str:
+    return subprocess.check_output(
+        [sys.executable, str(RENDERER), command, str(FIXTURES / fixture), "markdown"],
+        text=True,
+    ).strip()
+
+
+def main() -> int:
+    audit = render("audit", "audit-comment-quality-input.json")
+    expected_audit = (FIXTURES / "audit-comment-quality-expected.md").read_text(encoding="utf-8").strip()
+    assert_equal(audit, expected_audit, "audit markdown")
+    assert_not_contains(audit, "Top actionable findings", "duplicated top findings heading")
+    assert_not_contains(audit, "unknown:", "unknown severity count")
+    assert_contains(audit, ":x: **3 new finding(s) on this PR:**", "promoted delta block")
+
+    refactor = render("refactor --from all", "refactor-noop-input.json")
+    expected_refactor = (FIXTURES / "refactor-noop-expected.md").read_text(encoding="utf-8").strip()
+    assert_equal(refactor, expected_refactor, "refactor no-op markdown")
+    assert_not_contains(refactor, "Warnings", "no-op warnings detail")
+    assert_not_contains(refactor, "Stages", "no-op stage listing")
+
+    full_digest = render_markdown(
+        lint_digest={},
+        test_digest={},
+        audit_digest={
+            "alignment_score": 0.9,
+            "severity_counts": {"unknown": 4, "warning": 3},
+            "outliers_found": 4,
+            "parsed_outlier_items": 4,
+            "drift_increased": True,
+            "new_findings_count": 3,
+            "new_findings": [
+                {"context": "docs", "message": "Broken file reference", "fingerprint": "docs::broken"}
+            ],
+            "top_findings": [
+                {"file": f"src/file-{idx}.rs", "rule": "broken_doc_reference", "message": "missing target"}
+                for idx in range(6)
+            ],
+        },
+        autofixability={"overall": "human_needed", "autofix_enabled": False, "autofix_attempted": False},
+        run_url="https://github.com/Extra-Chill/homeboy/actions/runs/1",
+        tooling={},
+        job_links={},
+        results={"audit": "fail"},
+    )
+    assert_contains(full_digest, "**TL;DR:** :x: audit (3 new)", "failure digest TL;DR")
+    assert_contains(full_digest, ":x: **3 new finding(s) on this PR:**", "failure digest delta promotion")
+    assert_contains(full_digest, "<details><summary>Audit findings (6)</summary>", "deduped details block")
+    assert_not_contains(full_digest, "Top actionable findings", "failure digest duplicated top list")
+    assert_not_contains(full_digest, "unknown:", "failure digest unknown severity")
+
+    print("comment quality rendering checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr/comment/lib.sh
+++ b/scripts/pr/comment/lib.sh
@@ -17,7 +17,7 @@ derive_comment_key() {
 }
 
 derive_section_key() {
-  local command_count
+  local command_count raw_key
   command_count=$(python3 - <<'PY'
 import os
 commands = [part.strip() for part in os.environ.get("COMMANDS", "").split(",") if part.strip()]
@@ -26,16 +26,27 @@ PY
 )
 
   if [ -n "${COMMENT_SECTION_KEY_INPUT:-}" ]; then
-    printf '%s\n' "${COMMENT_SECTION_KEY_INPUT}"
+    raw_key="${COMMENT_SECTION_KEY_INPUT}"
   elif [ "${command_count}" = "1" ]; then
-    python3 - <<'PY'
+    raw_key="$(python3 - <<'PY'
 import os
 commands = [part.strip() for part in os.environ.get("COMMANDS", "").split(",") if part.strip()]
 print(commands[0] if commands else os.environ.get("GITHUB_JOB", "homeboy"))
 PY
+    )"
   else
-    printf '%s\n' "${GITHUB_JOB:-homeboy}"
+    raw_key="${GITHUB_JOB:-homeboy}"
   fi
+
+  SECTION_KEY_RAW="${raw_key}" python3 - <<'PY'
+import os
+import re
+
+raw = os.environ.get("SECTION_KEY_RAW", "homeboy")
+slug = re.sub(r"[^A-Za-z0-9._-]+", "-", raw.strip().lower())
+slug = re.sub(r"-+", "-", slug).strip("-._")
+print(slug or "homeboy")
+PY
 }
 
 derive_section_title() {

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -22,8 +22,6 @@ append_autofix_section() {
     SECTION_BODY+="> :warning: Autofix generated changes but could not push them back to **${AUTOFIX_TARGET_REPO:-${REPO}}:${AUTOFIX_TARGET_BRANCH:-unknown}**"$'\n\n'
   elif [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "skipped-head-bot-author" ]; then
     SECTION_BODY+="> :information_source: Autofix skipped — PR head is already a **homeboy-ci[bot]** commit, so PR autofix only runs after human commits"$'\n\n'
-  elif [ "${AUTOFIX_ENABLED}" = "true" ]; then
-    SECTION_BODY+="> :information_source: Autofix enabled, but no fixable file changes were produced"$'\n\n'
   fi
 }
 

--- a/scripts/pr/comment/test-section-key-slug.sh
+++ b/scripts/pr/comment/test-section-key-slug.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+export GITHUB_ACTION_PATH="${ROOT}"
+
+source "${ROOT}/scripts/pr/comment/lib.sh"
+
+assert_key() {
+  local label="$1"
+  local expected="$2"
+  shift 2
+
+  env -i \
+    PATH="${PATH}" \
+    GITHUB_ACTION_PATH="${ROOT}" \
+    "$@" \
+    bash -c 'source "${GITHUB_ACTION_PATH}/scripts/pr/comment/lib.sh"; derive_section_key' > /tmp/homeboy-section-key-test.out
+
+  local actual
+  actual="$(cat /tmp/homeboy-section-key-test.out)"
+  rm -f /tmp/homeboy-section-key-test.out
+
+  if [ "${actual}" != "${expected}" ]; then
+    printf 'FAIL: %s expected %s got %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_key "compound command" "refactor-from-all" COMMANDS="refactor --from all"
+assert_key "explicit section key" "audit-lint" COMMANDS="audit" COMMENT_SECTION_KEY_INPUT="Audit & Lint"
+assert_key "job fallback" "homeboy-build-lint-test" COMMANDS="audit,lint,test" GITHUB_JOB="Homeboy Build (Lint & Test)"
+
+printf 'All section key slug checks passed.\n'


### PR DESCRIPTION
## Summary
- Tightens Homeboy PR comments so reviewers see the delta first and avoid duplicated/no-op sections.
- Adds fixture-backed smokes for audit/refactor markdown rendering and section-key slugification.

## Root cause
- The renderer treated every audit field as equal signal, so new findings were buried below summary metadata.
- Audit findings were rendered twice, zero-fix refactor runs expanded into verbose no-op sections, and raw command strings leaked into section keys.

## Changes
- Promote new audit findings into a leading delta block and add a compact failure-digest TL;DR.
- Collapse audit top-list/details duplication, suppress unknown-only severity buckets, and keep zero-fix refactor summaries to one line.
- Slugify generated and explicit PR comment section keys.

## Tests
- `python3 scripts/digest/test-comment-quality-render.py`
- `bash scripts/pr/comment/test-section-key-slug.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `bash scripts/setup/test-detect-runtime-env.sh`
- `bash scripts/release/test-release-workflow.sh`
- `python3 scripts/digest/test-audit-comment-render.py` (skips when the optional real-log fixture is unavailable)
- `bash scripts/core/test-command-builders.sh`
- `homeboy audit homeboy-action`
- `homeboy test homeboy-action` (blocked: component has no Homeboy extension configured)

Closes #143

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the renderer changes, fixtures, tests, and verification steps; Chris remains responsible for review and merge.
