### PR TITLE
feat(ci): add opt-in differential gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Use these outputs to gate downstream jobs:
 | `expected-commands` | No | *(falls back to `commands`)* | Full set of command types expected to run across the workflow (e.g. `audit,lint,test`). Set this on every invocation when a workflow splits audit/lint/test across separate steps, otherwise each invocation will close sibling invocations' issues during reconciliation. |
 | `component` | No | *(repo name)* | Component name (auto-detected from repo) |
 | `args` | No | | Extra arguments passed to each command |
+| `differential-gating` | No | `false` | On PRs, compare `audit`/`test` counts against the base SHA and fail only when the PR is worse. Opt-in; `lint` still gates on exit code. PR autofix is skipped while enabled. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |
 | `node-version` | No | | Node.js version (sets up via `actions/setup-node`) |
 | `autofix` | No | `false` | On PR failures, run safe autofixes, commit, push, and re-run checks |
@@ -454,6 +455,27 @@ Use changed scope for a command only when the installed Homeboy CLI and extensio
 
 The action does **not** probe for or emulate missing CLI features. If the installed Homeboy version does not support a requested scoped command, that is a Homeboy CLI compatibility problem to fix in Homeboy itself.
 
+### Differential gating
+
+Set `differential-gating: 'true'` to make PR `audit` and `test` checks compare against the pull request base SHA instead of failing solely because the current branch has existing debt:
+
+```yaml
+- uses: Extra-Chill/homeboy-action@v1
+  with:
+    extension: rust
+    commands: audit,test,lint
+    differential-gating: 'true'
+```
+
+When enabled on pull requests:
+
+1. `audit` and `test` run in full-scope mode on the PR branch.
+2. The action temporarily checks out the base SHA in the same workspace and captures base `audit`/`test` JSON.
+3. The final gate passes `audit`/`test` failures when the parsed PR count is less than or equal to the parsed base count.
+4. `lint` is unchanged and still gates on the command exit code.
+
+If the baseline checkout cannot be run safely or the structured counts cannot be parsed, the original failure is preserved.
+
 #### Audit signal hygiene
 
 Use auto-filed issues as a **task queue**, not as a dumping ground for every metric Homeboy can calculate. A good auto-filed issue should be current, concrete, and safe for a human or coding agent to act on.
@@ -470,7 +492,6 @@ Recommended policy:
 The main lane is the right place to maintain issue state because it runs against the full repository and can update, close, or suppress stale findings consistently. PR lanes should focus on author feedback and should not maintain long-lived audit issues from partial data.
 
 When a rule is useful as a health metric but not safe as an actionable task list, configure it as dashboard-only or suppress it from issue reconciliation in Homeboy's audit config. Homeboy Action passes `--suppress-from-config` to `homeboy issues reconcile`, so repository-level audit policy is honored during auto-issue maintenance.
-
 ### Fork PR Note
 
 On fork-based pull requests, GitHub may provide a restricted `GITHUB_TOKEN` that cannot write PR comments. Homeboy Action treats the PR comment step as best-effort — lint/test/audit execution still runs and determines job pass/fail.

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
     description: 'Additional arguments to pass to each command.'
     required: false
     default: ''
+  differential-gating:
+    description: 'On PRs, compare audit/test failure counts against the base SHA and fail only when the PR is worse. Opt-in; lint remains normal exit-code gating. PR autofix is skipped while enabled.'
+    required: false
+    default: 'false'
 
   # ── Environment setup ──
   auto-setup:
@@ -371,8 +375,26 @@ runs:
       env:
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
+        HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
         RUN_GROUP_PREFIX: homeboy
       run: bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
+
+    - name: Run baseline Homeboy commands
+      id: run-baseline-commands
+      continue-on-error: true
+      if: |
+        steps.check-pr-state.outputs.active != 'false'
+        && github.event_name == 'pull_request'
+        && inputs.differential-gating == 'true'
+        && steps.resolve-commands.outputs.resolved-commands != ''
+      shell: bash
+      env:
+        COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
+        COMPONENT_NAME: ${{ inputs.component }}
+        EXTRA_ARGS: ${{ inputs.args }}
+        HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
+        RUN_GROUP_PREFIX: homeboy baseline
+      run: bash ${{ github.action_path }}/scripts/core/run-baseline-commands.sh
 
     # ── Phase 6: Autofix ──
     # Autofix defaults: enabled when app-token is provided.
@@ -385,6 +407,7 @@ runs:
         && github.event_name == 'pull_request'
         && steps.run-commands.outputs.results != ''
         && inputs.autofix == 'true'
+        && inputs.differential-gating != 'true'
         && (inputs.autofix-mode == 'always' || contains(steps.run-commands.outputs.results, '"fail"'))
       shell: bash
       env:
@@ -441,6 +464,7 @@ runs:
       shell: bash
       env:
         FIRST_RESULTS: ${{ steps.run-commands.outputs.results }}
+        HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
       run: bash ${{ github.action_path }}/scripts/core/select-final-results.sh
 
     - name: Generate failure digest

--- a/scripts/core/apply-differential-gate.py
+++ b/scripts/core/apply-differential-gate.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Downgrade audit/test failures when PR metrics do not exceed base metrics."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+
+def read_json(path: str) -> dict[str, Any] | None:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return payload if isinstance(payload, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def unwrap(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not payload:
+        return {}
+    if "success" in payload and isinstance(payload.get("data"), dict):
+        return payload["data"]
+    return payload
+
+
+def audit_count(payload: dict[str, Any] | None) -> int | None:
+    data = unwrap(payload)
+    summary = data.get("summary", {}) if isinstance(data, dict) else {}
+    if isinstance(summary, dict) and isinstance(summary.get("outliers_found"), int):
+        return int(summary["outliers_found"])
+
+    findings = data.get("findings", []) if isinstance(data, dict) else []
+    if isinstance(findings, list) and findings:
+        return len(findings)
+
+    conventions = data.get("conventions", []) if isinstance(data, dict) else []
+    if isinstance(conventions, list):
+        total = 0
+        saw_conventions = False
+        for convention in conventions:
+            if not isinstance(convention, dict):
+                continue
+            saw_conventions = True
+            outliers = convention.get("outliers", [])
+            if isinstance(outliers, list):
+                total += len(outliers)
+        if saw_conventions:
+            return total
+
+    baseline = data.get("baseline_comparison", {}) if isinstance(data, dict) else {}
+    new_items = baseline.get("new_items", []) if isinstance(baseline, dict) else []
+    if isinstance(baseline, dict) and "new_items" in baseline and isinstance(new_items, list):
+        return len(new_items)
+
+    return None
+
+
+def test_count(payload: dict[str, Any] | None) -> int | None:
+    data = unwrap(payload)
+    counts = data.get("test_counts", {}) if isinstance(data, dict) else {}
+    if isinstance(counts, dict):
+        failed = int(counts.get("failed", 0) or 0)
+        errors = int(counts.get("errors", 0) or 0)
+        if failed or errors or any(key in counts for key in ("failed", "errors")):
+            return failed + errors
+
+    failed_tests = data.get("failed_tests", []) if isinstance(data, dict) else []
+    if isinstance(data, dict) and "failed_tests" in data and isinstance(failed_tests, list):
+        return len(failed_tests)
+
+    summary = data.get("summary", {}) if isinstance(data, dict) else {}
+    if isinstance(summary, dict) and isinstance(summary.get("failures"), int):
+        return int(summary["failures"])
+
+    return None
+
+
+def output_stem(command: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in command).strip("-") or "homeboy-output"
+
+
+def metric_for(command: str, directory: str) -> int | None:
+    payload = read_json(os.path.join(directory, f"{output_stem(command)}.json"))
+    if command == "audit":
+        return audit_count(payload)
+    if command == "test":
+        return test_count(payload)
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print("usage: apply-differential-gate.py RESULTS_JSON CURRENT_DIR BASE_DIR", file=sys.stderr)
+        return 2
+
+    results = json.loads(sys.argv[1] or "{}")
+    current_dir = sys.argv[2]
+    base_dir = sys.argv[3]
+
+    if not isinstance(results, dict):
+        print(sys.argv[1])
+        return 0
+
+    adjusted = dict(results)
+    for command in ("audit", "test"):
+        if adjusted.get(command) != "fail":
+            continue
+
+        current = metric_for(command, current_dir)
+        base = metric_for(command, base_dir)
+        if current is None or base is None:
+            print(
+                f"::warning::Differential gate could not parse {command} counts; preserving failure",
+                file=sys.stderr,
+            )
+            continue
+
+        if current <= base:
+            adjusted[command] = "pass"
+            print(
+                f"::notice::Differential gate accepted {command}: current={current} base={base}",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"::error::Differential gate rejected {command}: current={current} base={base}",
+                file=sys.stderr,
+            )
+
+    print(json.dumps(adjusted, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
+
+EFFECTIVE_COMMANDS="${COMMANDS:-audit,lint,test}"
+
+if [ "${HOMEBOY_DIFFERENTIAL_GATING:-false}" != "true" ]; then
+  echo "Differential gating disabled; skipping baseline run"
+  exit 0
+fi
+
+if [ "${SCOPE_CONTEXT:-}" != "pr" ] || [ -z "${SCOPE_BASE_REF:-}" ]; then
+  echo "Differential gating requires PR scope with a resolved base ref; skipping baseline run"
+  exit 0
+fi
+
+TRACKED_DIRTY="$(git status --porcelain --untracked-files=no)"
+if [ -n "${TRACKED_DIRTY}" ]; then
+  echo "::warning::Tracked changes exist before the baseline checkout; skipping differential baseline run"
+  exit 0
+fi
+
+BASELINE_COMMANDS=()
+ORDERED_COMMANDS="$(canonicalize_commands "${EFFECTIVE_COMMANDS}")"
+IFS=',' read -ra CMD_ARRAY <<< "${ORDERED_COMMANDS}"
+for CMD in "${CMD_ARRAY[@]}"; do
+  CMD="$(echo "${CMD}" | xargs)"
+  case "${CMD}" in
+    audit|test)
+      BASELINE_COMMANDS+=("${CMD}")
+      ;;
+  esac
+done
+
+if [ "${#BASELINE_COMMANDS[@]}" -eq 0 ]; then
+  echo "No audit/test commands requested; skipping differential baseline run"
+  exit 0
+fi
+
+ORIGINAL_REF="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse HEAD)"
+BASE_OUTPUT_DIR="$(mktemp -d)"
+echo "HOMEBOY_BASE_OUTPUT_DIR=${BASE_OUTPUT_DIR}" >> "${GITHUB_ENV}"
+
+restore_original_ref() {
+  git checkout -q "${ORIGINAL_REF}" || true
+}
+trap restore_original_ref EXIT
+
+echo "Checking out baseline ref ${SCOPE_BASE_REF} for differential gating"
+git checkout -q --detach "${SCOPE_BASE_REF}"
+
+COMP_ID="$(resolve_component_id)"
+WORKSPACE="$(resolve_workspace)"
+GROUP_PREFIX="${RUN_GROUP_PREFIX:-homeboy baseline}"
+
+for CMD in "${BASELINE_COMMANDS[@]}"; do
+  OUTPUT_STEM="$(command_output_stem "${CMD}")"
+  OUTPUT_JSON="${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.json"
+  FULL_CMD="$(build_run_command "${CMD}" "${COMP_ID}" "${WORKSPACE}" "${OUTPUT_JSON}")"
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Running baseline: ${FULL_CMD}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  echo "::group::${GROUP_PREFIX} ${CMD}"
+  set +e
+  eval "${FULL_CMD}" 2>&1 | tee "${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.log"
+  CMD_EXIT=${PIPESTATUS[0]}
+  set -e
+  echo "::endgroup::"
+
+  if [ ! -s "${OUTPUT_JSON}" ]; then
+    echo "::warning::baseline homeboy ${CMD} did not write structured output to ${OUTPUT_JSON}"
+  fi
+
+  echo "Baseline homeboy ${CMD} exited ${CMD_EXIT}"
+done
+
+echo "Baseline outputs captured in ${BASE_OUTPUT_DIR}"

--- a/scripts/core/select-final-results.sh
+++ b/scripts/core/select-final-results.sh
@@ -2,4 +2,17 @@
 
 set -euo pipefail
 
-echo "results=${FIRST_RESULTS}" >> "${GITHUB_OUTPUT}"
+RESULTS="${FIRST_RESULTS:-{}}"
+
+if [ "${HOMEBOY_DIFFERENTIAL_GATING:-false}" = "true" ] \
+  && [ -n "${HOMEBOY_OUTPUT_DIR:-}" ] \
+  && [ -d "${HOMEBOY_OUTPUT_DIR:-}" ] \
+  && [ -n "${HOMEBOY_BASE_OUTPUT_DIR:-}" ] \
+  && [ -d "${HOMEBOY_BASE_OUTPUT_DIR:-}" ]; then
+  RESULTS="$(python3 "${GITHUB_ACTION_PATH}/scripts/core/apply-differential-gate.py" \
+    "${RESULTS}" \
+    "${HOMEBOY_OUTPUT_DIR}" \
+    "${HOMEBOY_BASE_OUTPUT_DIR}")"
+fi
+
+echo "results=${RESULTS}" >> "${GITHUB_OUTPUT}"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -38,6 +38,7 @@ assert_equals \
 # ── Scoped (changed mode) ──
 SCOPE_MODE="changed"
 SCOPE_BASE_REF="origin/main"
+unset HOMEBOY_DIFFERENTIAL_GATING || true
 assert_equals \
   "homeboy lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
@@ -57,6 +58,24 @@ assert_equals \
   "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
   "audit keeps path with changed-since"
+
+HOMEBOY_DIFFERENTIAL_GATING="true"
+assert_equals \
+  "homeboy audit data-machine --path /tmp/workspace" \
+  "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
+  "differential audit uses full scope"
+
+assert_equals \
+  "homeboy test data-machine --path /tmp/workspace" \
+  "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
+  "differential test uses full scope"
+
+assert_equals \
+  "homeboy lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
+  "differential lint keeps changed scope"
+
+unset HOMEBOY_DIFFERENTIAL_GATING
 
 assert_equals \
   "homeboy review data-machine --path /tmp/workspace --report=pr-comment --changed-since origin/main" \

--- a/scripts/core/test-differential-gate.py
+++ b/scripts/core/test-differential-gate.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "core" / "apply-differential-gate.py"
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def run_gate(results: dict, current: Path, base: Path) -> dict:
+    completed = subprocess.run(
+        ["python3", str(SCRIPT), json.dumps(results), str(current), str(base)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def assert_equal(expected, actual, label: str) -> None:
+    if expected != actual:
+        raise AssertionError(f"{label}\nexpected: {expected!r}\nactual:   {actual!r}")
+    print(f"PASS: {label}")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        current = root / "current"
+        base = root / "base"
+        current.mkdir()
+        base.mkdir()
+
+        write_json(base / "audit.json", {"success": False, "data": {"summary": {"outliers_found": 5}}})
+        write_json(current / "audit.json", {"success": False, "data": {"summary": {"outliers_found": 5}}})
+        assert_equal(
+            {"audit": "pass"},
+            run_gate({"audit": "fail"}, current, base),
+            "audit failure passes when outliers do not increase",
+        )
+
+        write_json(current / "audit.json", {"success": False, "data": {"summary": {"outliers_found": 6}}})
+        assert_equal(
+            {"audit": "fail"},
+            run_gate({"audit": "fail"}, current, base),
+            "audit failure remains when outliers increase",
+        )
+
+        write_json(base / "test.json", {"success": False, "data": {"test_counts": {"failed": 2, "errors": 1}}})
+        write_json(current / "test.json", {"success": False, "data": {"test_counts": {"failed": 2, "errors": 1}}})
+        assert_equal(
+            {"test": "pass"},
+            run_gate({"test": "fail"}, current, base),
+            "test failure passes when failures do not increase",
+        )
+
+        write_json(current / "test.json", {"success": False, "data": {"test_counts": {"failed": 3, "errors": 1}}})
+        assert_equal(
+            {"test": "fail"},
+            run_gate({"test": "fail"}, current, base),
+            "test failure remains when failures increase",
+        )
+
+        assert_equal(
+            {"lint": "fail", "audit": "pass"},
+            run_gate({"lint": "fail", "audit": "pass"}, current, base),
+            "non-audit-test results are left untouched",
+        )
+
+        (base / "audit.json").unlink()
+        (current / "audit.json").unlink()
+        assert_equal(
+            {"audit": "fail"},
+            run_gate({"audit": "fail"}, current, base),
+            "missing metric files preserve failures",
+        )
+
+    print("All differential gate checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scope/flags.sh
+++ b/scripts/scope/flags.sh
@@ -20,6 +20,12 @@ scope_flags_for() {
   fi
 
   case "${base_cmd}" in
+    audit|test)
+      if [ "${HOMEBOY_DIFFERENTIAL_GATING:-false}" = "true" ]; then
+        return
+      fi
+      printf '%s' "--changed-since ${SCOPE_BASE_REF}"
+      ;;
     audit|lint|test|refactor|review)
       printf '%s' "--changed-since ${SCOPE_BASE_REF}"
       ;;


### PR DESCRIPTION
## Summary
- Adds an opt-in `differential-gating` mode for PR `audit` and `test` commands.
- Captures base-SHA structured output, then only preserves `audit`/`test` failures when the PR count is worse than base.
- Leaves default behavior unchanged and keeps `lint` on normal exit-code gating.

## Changes
- Adds `scripts/core/run-baseline-commands.sh` to capture base `audit`/`test` JSON from the PR base SHA.
- Adds `scripts/core/apply-differential-gate.py` to compare parsed audit/test counts and adjust final results.
- Runs `audit`/`test` in full scope when differential gating is enabled so PR/base counts are comparable.
- Skips PR autofix while differential gating is enabled to avoid autofixing raw failures that the differential gate may accept.
- Documents the opt-in mode and fallback behavior.

## Tests
- `bash scripts/core/test-command-builders.sh`
- `python3 scripts/core/test-differential-gate.py`
- `bash -n scripts/core/run-baseline-commands.sh scripts/core/select-final-results.sh scripts/scope/flags.sh scripts/core/run-homeboy-commands.sh`
- `python3 -m py_compile scripts/core/apply-differential-gate.py scripts/core/test-differential-gate.py`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file("action.yml"); puts "action.yml parses"'`
- `bash scripts/setup/test-detect-runtime-env.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `bash scripts/release/test-release-workflow.sh`
- `python3 scripts/digest/test-audit-comment-render.py` (skips because the real audit fixture is not present)

## Refs
- Refs #49

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the opt-in MVP, drafted tests, and prepared this PR description. Chris remains responsible for review and merge.
