### PR TITLE
fix(pr): clarify zero-failure test comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,9 +492,14 @@ Recommended policy:
 The main lane is the right place to maintain issue state because it runs against the full repository and can update, close, or suppress stale findings consistently. PR lanes should focus on author feedback and should not maintain long-lived audit issues from partial data.
 
 When a rule is useful as a health metric but not safe as an actionable task list, configure it as dashboard-only or suppress it from issue reconciliation in Homeboy's audit config. Homeboy Action passes `--suppress-from-config` to `homeboy issues reconcile`, so repository-level audit policy is honored during auto-issue maintenance.
+
+### PR Comment Identity
+
+PR comments are posted only with `app-token`. This keeps Homeboy comments under the `homeboy-ci[bot]` identity and avoids silently falling back to `github-actions[bot]`. Configure `app-token` with `actions/create-github-app-token`; when it is unavailable, checks still run but the comment step is skipped with a warning.
+
 ### Fork PR Note
 
-On fork-based pull requests, GitHub may provide a restricted `GITHUB_TOKEN` that cannot write PR comments. Homeboy Action treats the PR comment step as best-effort — lint/test/audit execution still runs and determines job pass/fail.
+On fork-based pull requests, GitHub App secrets may be unavailable. Homeboy Action treats the PR comment step as best-effort — lint/test/audit execution still runs and determines job pass/fail.
 
 ## Failure Digest
 

--- a/action.yml
+++ b/action.yml
@@ -520,7 +520,7 @@ runs:
       if: always() && github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.app-token || github.token }}
+        GH_TOKEN: ${{ inputs.app-token }}
         COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
         COMPONENT_NAME: ${{ inputs.component }}
         RESULTS: ${{ steps.select-results.outputs.results }}

--- a/scripts/digest/build-failure-digest.py
+++ b/scripts/digest/build-failure-digest.py
@@ -125,7 +125,20 @@ def build_lint_digest_from_json(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def build_test_digest_from_json(payload: dict[str, Any]) -> dict[str, Any]:
+def read_log_excerpt(output_dir: str, stem: str, max_lines: int = 25) -> list[str]:
+    """Return a compact tail excerpt from a command log."""
+    path = os.path.join(output_dir, f"{stem}.log")
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            lines = [line.rstrip() for line in f]
+    except OSError:
+        return []
+
+    compact = [line for line in lines if line.strip()]
+    return compact[-max_lines:]
+
+
+def build_test_digest_from_json(payload: dict[str, Any], raw_excerpt: list[str] | None = None) -> dict[str, Any]:
     """Build test digest from structured JSON output."""
     data = payload.get("data", {})
     test_counts = data.get("test_counts", {})
@@ -149,7 +162,10 @@ def build_test_digest_from_json(payload: dict[str, Any]) -> dict[str, Any]:
     return {
         "failed_tests_count": failed_count,
         "top_failed_tests": top_failed,
-        "raw_excerpt": [],
+        "raw_excerpt": raw_excerpt or [],
+        "status": str(data.get("status", "")),
+        "exit_code": data.get("exit_code"),
+        "failure_message": str(data.get("failure") or ""),
     }
 
 
@@ -351,12 +367,15 @@ def main() -> int:
 
     if results.get("test") == "fail":
         if test_json and test_json.get("data"):
-            test_digest = build_test_digest_from_json(test_json)
+            test_digest = build_test_digest_from_json(test_json, read_log_excerpt(output_dir, "test"))
         else:
             test_digest = {
                 "failed_tests_count": 0,
                 "top_failed_tests": [],
-                "raw_excerpt": [],
+                "raw_excerpt": read_log_excerpt(output_dir, "test"),
+                "status": "",
+                "exit_code": None,
+                "failure_message": "",
             }
     else:
         test_digest = {

--- a/scripts/digest/fixtures/test-tooling-failure-input.json
+++ b/scripts/digest/fixtures/test-tooling-failure-input.json
@@ -1,0 +1,17 @@
+{
+  "success": true,
+  "data": {
+    "passed": false,
+    "status": "failed",
+    "component": "block-format-bridge",
+    "exit_code": 1,
+    "failure": "test runner exited before reporting failed test cases",
+    "test_counts": {
+      "total": 0,
+      "passed": 0,
+      "failed": 0,
+      "skipped": 0
+    },
+    "failed_tests": []
+  }
+}

--- a/scripts/digest/render-command-summary.py
+++ b/scripts/digest/render-command-summary.py
@@ -212,7 +212,21 @@ def markdown_test(data: dict[str, Any], lines: list[str]) -> None:
     if not failed_count:
         failed_count = len(failed_tests)
 
-    lines.append(f"- Failed tests: **{failed_count}**")
+    if failed_count > 0:
+        lines.append(f"- Failed tests: **{failed_count}**")
+    else:
+        lines.append("- Test command failed, but structured output reported **0 failed test cases**.")
+        status = str(data.get("status") or "").strip()
+        exit_code = data.get("exit_code")
+        if status or exit_code is not None:
+            status_label = status or "unknown"
+            exit_label = "unknown" if exit_code is None else str(exit_code)
+            lines.append(f"- Runner status: `{status_label}` (exit code `{exit_label}`)")
+        failure = str(data.get("failure") or "").strip()
+        if failure:
+            lines.append(f"- Failure: {failure}")
+        lines.append("- Interpret this as a runner/tooling failure, not failed test assertions.")
+
     details = []
     for idx, item in enumerate(failed_tests[:10], start=1):
         if isinstance(item, dict):

--- a/scripts/digest/render.py
+++ b/scripts/digest/render.py
@@ -142,7 +142,21 @@ def render_markdown(
 
     if "test" in results:
         lines.append("### Test Failure Digest")
-        lines.append(f"- Failed tests: **{test_digest.get('failed_tests_count', 0)}**")
+        failed_count = int(test_digest.get("failed_tests_count", 0) or 0)
+        if failed_count > 0:
+            lines.append(f"- Failed tests: **{failed_count}**")
+        else:
+            lines.append("- Test command failed, but structured output reported **0 failed test cases**.")
+            status = str(test_digest.get("status") or "").strip()
+            exit_code = test_digest.get("exit_code")
+            if status or exit_code is not None:
+                status_label = status or "unknown"
+                exit_label = "unknown" if exit_code is None else str(exit_code)
+                lines.append(f"- Runner status: `{status_label}` (exit code `{exit_label}`)")
+            failure_message = str(test_digest.get("failure_message") or "").strip()
+            if failure_message:
+                lines.append(f"- Failure: {failure_message}")
+            lines.append("- Interpret this as a runner/tooling failure, not failed test assertions.")
         top_tests = test_digest.get("top_failed_tests", []) or []
         if top_tests:
             _append_details_block(
@@ -150,7 +164,7 @@ def render_markdown(
                 f"Failed test details ({min(len(top_tests), 10)} shown)",
                 [_summarize_test_failure(test, idx) for idx, test in enumerate(top_tests[:10], start=1)],
             )
-        else:
+        elif failed_count > 0:
             lines.append("- No structured test failure details available.")
 
         raw_excerpt = [str(line) for line in (test_digest.get("raw_excerpt", []) or [])]

--- a/scripts/digest/test-comment-quality-render.py
+++ b/scripts/digest/test-comment-quality-render.py
@@ -51,6 +51,16 @@ def main() -> int:
     assert_not_contains(refactor, "Warnings", "no-op warnings detail")
     assert_not_contains(refactor, "Stages", "no-op stage listing")
 
+    tooling_failure = render("test", "test-tooling-failure-input.json")
+    assert_contains(
+        tooling_failure,
+        "Test command failed, but structured output reported **0 failed test cases**.",
+        "zero-failed test command explanation",
+    )
+    assert_contains(tooling_failure, "Runner status: `failed` (exit code `1`)", "test runner status")
+    assert_contains(tooling_failure, "runner/tooling failure", "test failure classification")
+    assert_not_contains(tooling_failure, "Failed tests: **0**", "misleading zero failed tests line")
+
     full_digest = render_markdown(
         lint_digest={},
         test_digest={},
@@ -80,6 +90,28 @@ def main() -> int:
     assert_contains(full_digest, "<details><summary>Audit findings (6)</summary>", "deduped details block")
     assert_not_contains(full_digest, "Top actionable findings", "failure digest duplicated top list")
     assert_not_contains(full_digest, "unknown:", "failure digest unknown severity")
+
+    test_digest = render_markdown(
+        lint_digest={},
+        test_digest={
+            "failed_tests_count": 0,
+            "top_failed_tests": [],
+            "raw_excerpt": ["composer install failed", "exit status 2"],
+            "status": "failed",
+            "exit_code": 1,
+            "failure_message": "runner setup failed",
+        },
+        audit_digest={},
+        autofixability={"overall": "human_needed", "autofix_enabled": False, "autofix_attempted": False},
+        run_url="https://github.com/Extra-Chill/homeboy/actions/runs/1",
+        tooling={},
+        job_links={},
+        results={"test": "fail"},
+    )
+    assert_contains(test_digest, "Test command failed, but structured output reported **0 failed test cases**.", "digest zero-failed test command explanation")
+    assert_contains(test_digest, "runner/tooling failure", "digest test failure classification")
+    assert_contains(test_digest, "<details><summary>Raw test failure excerpt</summary>", "digest raw log excerpt")
+    assert_not_contains(test_digest, "Failed tests: **0**", "digest misleading zero failed tests line")
 
     print("comment quality rendering checks passed")
     return 0

--- a/scripts/pr/comment/test-app-token-required.sh
+++ b/scripts/pr/comment/test-app-token-required.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    printf 'FAIL: %s\nmissing: %s\n' "${label}" "${needle}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    printf 'FAIL: %s\nunexpected: %s\n' "${label}" "${needle}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+action_yml="$(python3 - "${ROOT}/action.yml" <<'PY'
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+start = text.index("    - name: Post PR comment")
+end = text.index("    # ── Phase 8", start)
+print(text[start:end])
+PY
+)"
+post_script="$(cat "${ROOT}/scripts/pr/post-pr-comment.sh")"
+
+assert_contains "${action_yml}" 'GH_TOKEN: ${{ inputs.app-token }}' "PR comment uses app token"
+assert_not_contains "${action_yml}" 'GH_TOKEN: ${{ inputs.app-token || github.token }}' "PR comment does not fall back to github token"
+assert_contains "${post_script}" 'Refusing to post as github-actions[bot]' "missing token warning explains bot identity"
+
+printf 'PR comment app-token checks passed.\n'

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -36,6 +36,11 @@ if [ -z "${OUTPUT_DIR}" ] || [ -z "${PR_NUMBER:-}" ]; then
   exit 0
 fi
 
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "::warning::Skipping PR comment — app-token was not provided. Refusing to post as github-actions[bot]; configure the homeboy-ci GitHub App token."
+  exit 0
+fi
+
 if ! pr_is_active; then
   echo "Skipping PR comment — PR #${PR_NUMBER} is no longer open (merged or closed)"
   exit 0


### PR DESCRIPTION
## Summary
- Explain failed `test` commands that report zero failed test cases as runner/tooling failures instead of showing the misleading `Failed tests: 0` line.
- Include a compact raw test log excerpt in failure digests so reviewers have something actionable without opening Actions first.
- Require the PR comment step to use `app-token`, preventing silent fallback to `github-actions[bot]` when the `homeboy-ci[bot]` token is unavailable.

## Context
This is the short-term action-side fix. The broader migration is tracked in Extra-Chill/homeboy#1647, which moves failure digest rendering into Homeboy core.

## Tests
- `python3 scripts/digest/test-comment-quality-render.py`
- `bash scripts/pr/comment/test-app-token-required.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `bash scripts/pr/comment/test-section-key-slug.sh`
- `bash scripts/setup/test-detect-runtime-env.sh`
- `bash scripts/release/test-release-workflow.sh`
- `bash scripts/core/test-command-builders.sh`
- `python3 scripts/core/test-differential-gate.py`
- `homeboy audit homeboy-action --path /Users/chubes/Developer/homeboy-action@fix-pr-comment-status --changed-since origin/main`
- `git diff --check`

Refs Extra-Chill/homeboy#1647.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the PR comment boundary, implemented the short-term action-side rendering/token fix, and ran the verification steps. Chris remains responsible for review and merge.