### PR TITLE
fix(issues): keep reconcile policy in homeboy core

### DIFF
--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -10,7 +10,7 @@
 #      findings shape (groups by category + count).
 #   2. Render markdown bodies for each group using the action's templates
 #      (autofix status, finding tables, footers).
-#   3. Pipe the canonical JSON to `homeboy issues reconcile --apply --json`
+#   3. Pipe the canonical JSON to `homeboy issues reconcile --apply`
 #      and surface its plan in the run log.
 #
 # See homeboy issue #1551 for the architectural framing. This replaces
@@ -27,12 +27,6 @@
 #   HOMEBOY_OUTPUT_DIR    — directory with command log files
 #   COMPONENT_NAME        — component ID
 #   COMMANDS              — comma-separated list of commands that were run
-#   EXPECTED_COMMANDS     — optional; comma-separated list of command types
-#                           expected to run across the full workflow. Used to
-#                           scope the orphan-reconciliation step so workflows
-#                           which split audit/lint/test across separate
-#                           invocations do not close each other's issues.
-#                           Defaults to COMMANDS when empty.
 #   RESULTS               — JSON object with pass/fail per command
 #   AUTOFIX_ATTEMPTED     — whether autofix was tried before filing
 #   AUTOFIX_PR_CREATED    — whether an autofix PR was opened
@@ -410,9 +404,8 @@ FOOTEREOF
 #
 # Per-group `body` is rendered from the action's templates, so the reconciler
 # stays format-agnostic. Categories with `count: 0` (which would never come
-# from a real findings stream — that's reconcile's "no findings remaining"
-# row) are not emitted here; close-on-resolved is driven by the absence of
-# a category from `groups` versus its presence in the existing tracker.
+# from a real findings stream) are not emitted here; category lifecycle is
+# reconciled by core from this run's group set.
 # ─────────────────────────────────────────────────────────────────────────────
 
 build_reconcile_input() {
@@ -578,69 +571,6 @@ for CMD in "${CMD_ARRAY[@]}"; do
   if reconcile_command "${CMD}" "${FINDINGS_JSON}" "${local_comp_id}"; then
     COMMANDS_PROCESSED=$((COMMANDS_PROCESSED + 1))
   fi
-done
-
-# ── Reconciliation: close orphaned issues for command types not in this run ──
-# If a command was removed from the workflow, its issues are never updated or
-# closed because the main loop only processes commands that ran this time.
-# Close any open issues for command types that were NOT in this CI run.
-#
-# Scope: workflows that split audit/lint/test across separate invocations
-# (e.g. one step per command + a final autofix step) must pass the full set
-# as `expected-commands` so each invocation only reconciles command types
-# that no invocation in the workflow will handle. Without it, an invocation
-# running only `audit` would treat every open lint/test issue as orphaned
-# and close it — even though a sibling invocation will file lint/test
-# issues seconds later.
-#
-# Default (EXPECTED_COMMANDS empty): fall back to COMMANDS so single-command
-# invocations still reconcile siblings the bot once owned but no longer runs.
-#
-# Implementation: for each orphan command type, invoke `homeboy issues
-# reconcile` with an empty groups object. Since no findings exist, every
-# open issue for that command type drops to row 3 of the contract (close
-# with reason=completed). closed-not_planned issues are left alone.
-
-if [ -n "${EXPECTED_COMMANDS:-}" ]; then
-  IFS=',' read -ra EXPECTED_CMD_ARRAY <<< "${EXPECTED_COMMANDS}"
-  for i in "${!EXPECTED_CMD_ARRAY[@]}"; do
-    EXPECTED_CMD_ARRAY[$i]=$(echo "${EXPECTED_CMD_ARRAY[$i]}" | xargs)
-  done
-else
-  EXPECTED_CMD_ARRAY=("${CMD_ARRAY[@]}")
-fi
-
-ALL_CMD_TYPES=('audit' 'lint' 'test')
-for CMD_TYPE in "${ALL_CMD_TYPES[@]}"; do
-  EXPECTED_JOINED=$(IFS=','; echo "${EXPECTED_CMD_ARRAY[*]}")
-  if echo ",${EXPECTED_JOINED}," | grep -q ",${CMD_TYPE},"; then
-    continue
-  fi
-  echo ""
-  echo "Reconciling orphaned ${CMD_TYPE} issues for ${COMP_ID}..."
-
-  # Empty groups payload triggers row-3 close-on-zero-findings for every
-  # open issue for this command type. The reconciler is a single source of
-  # truth for "what does close-on-resolved mean" — we just hand it nothing.
-  orphan_input=$(mktemp)
-  jq -n --arg cmd "${CMD_TYPE}" '{command: $cmd, groups: {}}' > "${orphan_input}"
-
-  orphan_result=$(mktemp)
-  if homeboy issues reconcile "${COMP_ID}" \
-    --findings "${orphan_input}" \
-    --path "${RECONCILE_PATH}" \
-    --apply \
-    --suppress-from-config \
-    > "${orphan_result}" 2>&1; then
-    jq -r '.data.plan_lines[]' "${orphan_result}" 2>/dev/null | sed 's/^/  /' || true
-    closed_count=$(jq -r '[.data.result.executions[]? | select(.outcome.outcome == "closed" or .outcome.outcome == "closed_duplicate")] | length' "${orphan_result}" 2>/dev/null || echo 0)
-    TOTAL_ISSUES_CLOSED=$((TOTAL_ISSUES_CLOSED + closed_count))
-  else
-    echo "::warning::Failed to reconcile orphaned ${CMD_TYPE} issues"
-    cat "${orphan_result}"
-  fi
-
-  rm -f "${orphan_input}" "${orphan_result}"
 done
 
 echo ""


### PR DESCRIPTION
## Summary

Keep Homeboy Action's categorized issue script as orchestration glue now that Homeboy core owns issue reconciliation policy.

## Changes

- Removes the action-side orphan command reconciliation loop and its closed/not-planned policy comments.
- Keeps the action focused on normalizing audit/lint/test JSON, rendering issue body markdown, invoking `homeboy issues reconcile --apply`, and logging the core reconcile plan/result.
- Corrects the script header to match the actual core command surface.

## Tests

- `git diff --check origin/main...HEAD`
- `bash -n scripts/issues/auto-file-categorized-issues.sh scripts/issues/auto-file-issue.sh scripts/core/test-command-builders.sh`
- `bash scripts/core/test-command-builders.sh`
- `bash scripts/setup/test-detect-runtime-env.sh`
- `bash scripts/release/test-release-workflow.sh`
- `bash scripts/pr/comment/test-app-token-required.sh`
- `bash scripts/pr/comment/test-section-key-slug.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `python3 scripts/core/test-differential-gate.py`
- `python3 scripts/digest/test-comment-quality-render.py`
- `python3 scripts/digest/test-audit-comment-render.py` (skips when the real audit log fixture is absent)

Refs Extra-Chill/homeboy#1551

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the follow-up bridge cleanup, running local checks, and drafting this PR body. Chris remains responsible for review and merge.