### PR TITLE
feat(extension): install configured component extensions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
 
   # ── Extension ──
   extension:
-    description: 'Extension ID override. Auto-inferred from homeboy.json extensions if not set.'
+    description: 'Single extension ID override. If empty, installs all extensions declared in homeboy.json.'
     required: false
     default: ''
   extension-source:
@@ -289,7 +289,9 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         EXTENSION_ID: ${{ steps.read-config.outputs.portable-extension }}
+        EXTENSION_INPUT: ${{ inputs.extension }}
         EXTENSION_SOURCE: ${{ inputs.extension-source }}
+        COMPONENT_DIR: ${{ steps.read-config.outputs.component-dir }}
       run: bash ${{ github.action_path }}/scripts/setup/install-extension.sh
 
     - name: Capture tooling metadata

--- a/scripts/setup/install-extension.sh
+++ b/scripts/setup/install-extension.sh
@@ -2,6 +2,26 @@
 
 set -euo pipefail
 
-echo "Installing extension: ${EXTENSION_ID} from ${EXTENSION_SOURCE}..."
-homeboy extension install "${EXTENSION_SOURCE}" --id "${EXTENSION_ID}"
-echo "Extension '${EXTENSION_ID}' installed successfully"
+EXTENSION_INPUT="${EXTENSION_INPUT:-}"
+COMPONENT_DIR="${COMPONENT_DIR:-.}"
+
+if [[ "${EXTENSION_INPUT}" == *,* ]]; then
+  echo "::error::Comma-separated extension input is not supported. Declare multiple extensions in homeboy.json instead."
+  exit 1
+fi
+
+if [ -n "${EXTENSION_INPUT}" ]; then
+  echo "Installing extension override: ${EXTENSION_INPUT} from ${EXTENSION_SOURCE}..."
+  homeboy extension install "${EXTENSION_SOURCE}" --id "${EXTENSION_INPUT}"
+  echo "Extension '${EXTENSION_INPUT}' installed successfully"
+else
+  if homeboy extension install-for-component --help >/dev/null 2>&1; then
+    echo "Installing extensions configured by ${COMPONENT_DIR}/homeboy.json from ${EXTENSION_SOURCE}..."
+    homeboy extension install-for-component --path "${COMPONENT_DIR}" --source "${EXTENSION_SOURCE}"
+    echo "Configured extensions installed successfully"
+  else
+    echo "::warning::Installed Homeboy does not support 'extension install-for-component'; falling back to '${EXTENSION_ID}' only"
+    homeboy extension install "${EXTENSION_SOURCE}" --id "${EXTENSION_ID}"
+    echo "Extension '${EXTENSION_ID}' installed successfully"
+  fi
+fi

--- a/scripts/setup/read-portable-config.sh
+++ b/scripts/setup/read-portable-config.sh
@@ -9,7 +9,7 @@
 #
 # Outputs:
 #   PORTABLE_ID         — component id
-#   PORTABLE_EXTENSION  — extension id (first key from extensions object)
+#   PORTABLE_EXTENSION  — explicit extension input, or first key from extensions object
 #   COMPONENT_DIR       — directory containing homeboy.json
 #
 # All values are written to GITHUB_ENV and GITHUB_OUTPUT for use by subsequent steps.
@@ -44,8 +44,9 @@ if [ -z "${PORTABLE_ID}" ]; then
 fi
 
 # ── Extension ──
-# If the action input specifies an extension, use that. Otherwise infer from
-# the first (usually only) key in the extensions object.
+# If the action input specifies an extension, use that single override. Otherwise
+# infer the first key from the extensions object for downstream runtime detection.
+# Installation itself uses Homeboy core to install every configured extension.
 
 EXTENSION_INPUT="${EXTENSION_INPUT:-}"
 if [ -n "${EXTENSION_INPUT}" ]; then

--- a/scripts/setup/test-install-extension.sh
+++ b/scripts/setup/test-install-extension.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+cat > "${TMP_DIR}/bin/homeboy" <<'STUB'
+#!/usr/bin/env bash
+if [ "$*" = "extension install-for-component --help" ]; then
+  exit "${HOMEBOY_INSTALL_FOR_COMPONENT_HELP_STATUS:-0}"
+fi
+printf '%s\n' "$*" >> "${HOMEBOY_CALL_LOG}"
+STUB
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+export PATH="${TMP_DIR}/bin:${PATH}"
+export EXTENSION_SOURCE="/extensions"
+export EXTENSION_ID="wordpress"
+export COMPONENT_DIR="packages/plugin"
+export HOMEBOY_CALL_LOG="${TMP_DIR}/calls.log"
+
+EXTENSION_INPUT="" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null
+assert_equals \
+  "extension install-for-component --path packages/plugin --source /extensions" \
+  "$(cat "${HOMEBOY_CALL_LOG}")" \
+  "configured extensions use core install-for-component"
+
+: > "${HOMEBOY_CALL_LOG}"
+HOMEBOY_INSTALL_FOR_COMPONENT_HELP_STATUS="1" EXTENSION_INPUT="" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null
+assert_equals \
+  "extension install /extensions --id wordpress" \
+  "$(cat "${HOMEBOY_CALL_LOG}")" \
+  "older homeboy falls back to first configured extension"
+
+: > "${HOMEBOY_CALL_LOG}"
+EXTENSION_INPUT="nodejs" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null
+assert_equals \
+  "extension install /extensions --id nodejs" \
+  "$(cat "${HOMEBOY_CALL_LOG}")" \
+  "explicit extension input keeps single-extension override"
+
+: > "${HOMEBOY_CALL_LOG}"
+if EXTENSION_INPUT="wordpress,nodejs" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null 2>"${TMP_DIR}/comma.err"; then
+  echo "FAIL: comma-separated extension input should fail"
+  exit 1
+fi
+assert_equals "" "$(cat "${HOMEBOY_CALL_LOG}")" "comma-separated input does not invoke homeboy"
+
+echo "All install-extension checks passed."


### PR DESCRIPTION
## Summary

Support components that declare multiple Homeboy extensions without adding comma parsing to the action.

## Changes

- Uses `homeboy extension install-for-component --path <component-dir> --source <source>` when the action infers extensions from `homeboy.json`.
- Keeps `extension` input as a single-extension override for existing workflows.
- Falls back to the existing single-extension install when the installed Homeboy binary does not support `install-for-component` yet.
- Adds focused shell coverage for configured multi-extension install, explicit override, fallback, and rejected comma input.

## Tests

- `bash -n scripts/setup/install-extension.sh scripts/setup/test-install-extension.sh scripts/setup/read-portable-config.sh`
- `bash scripts/setup/test-install-extension.sh`
- `bash scripts/setup/test-detect-runtime-env.sh`
- `bash scripts/core/test-command-builders.sh`
- `git diff --check`
- `bash scripts/release/test-release-workflow.sh`
- `bash scripts/pr/comment/test-app-token-required.sh`
- `bash scripts/pr/comment/test-section-key-slug.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `python3 scripts/core/test-differential-gate.py`
- `python3 scripts/digest/test-comment-quality-render.py`

Closes #4
Refs Extra-Chill/homeboy#1773

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the action orchestration change, adding focused shell tests, running validation, and drafting this PR body. Chris remains responsible for review and merge.