### PR TITLE
fix(release): verify GitHub Release after release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -140,6 +140,10 @@ inputs:
     description: 'Branch that releases are allowed from.'
     required: false
     default: 'main'
+  release-verify-github-release:
+    description: 'Verify that a successful release has a GitHub Release for the emitted tag. Set false for tag-only release consumers.'
+    required: false
+    default: 'true'
 
 outputs:
   results:
@@ -486,6 +490,7 @@ runs:
         GH_TOKEN: ${{ inputs.app-token || github.token }}
         RELEASE_DRY_RUN: ${{ inputs.release-dry-run }}
         RELEASE_BRANCH: ${{ inputs.release-branch }}
+        HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}
         COMPONENT_NAME: ${{ inputs.component }}
       run: bash ${{ github.action_path }}/scripts/release/run-release.sh
 

--- a/scripts/release/github-release.sh
+++ b/scripts/release/github-release.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+homeboy_should_verify_github_release() {
+  case "${HOMEBOY_VERIFY_GITHUB_RELEASE:-true}" in
+    true|1|yes|on)
+      return 0
+      ;;
+    false|0|no|off)
+      return 1
+      ;;
+    *)
+      echo "::error::Invalid HOMEBOY_VERIFY_GITHUB_RELEASE value '${HOMEBOY_VERIFY_GITHUB_RELEASE}'. Expected true or false."
+      return 2
+      ;;
+  esac
+}
+
+homeboy_verify_github_release_exists() {
+  local release_tag="$1"
+  local repository="$2"
+
+  if homeboy_should_verify_github_release; then
+    :
+  else
+    local decision=$?
+    if [ "${decision}" -eq 2 ]; then
+      return 1
+    fi
+
+    echo "::notice::Skipping GitHub Release verification for ${repository}@${release_tag}"
+    return 0
+  fi
+
+  if [ -z "${release_tag}" ]; then
+    echo "::error::Cannot verify GitHub Release: release tag is empty"
+    return 1
+  fi
+
+  if [ -z "${repository}" ]; then
+    echo "::error::Cannot verify GitHub Release for ${release_tag}: GITHUB_REPOSITORY is empty"
+    return 1
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "::error::Cannot verify GitHub Release ${repository}@${release_tag}: gh CLI is not available"
+    return 1
+  fi
+
+  if gh release view "${release_tag}" --repo "${repository}" >/dev/null 2>&1; then
+    echo "::notice::Verified GitHub Release ${repository}@${release_tag}"
+    return 0
+  fi
+
+  echo "::error::GitHub Release not found after successful release: repo=${repository} tag=${release_tag}"
+  echo "::error::Expected 'gh release view ${release_tag} --repo ${repository}' to succeed."
+  return 1
+}

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -20,6 +20,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/github-release.sh"
+
 RELEASE_BRANCH="${RELEASE_BRANCH:-main}"
 DRY_RUN="${RELEASE_DRY_RUN:-false}"
 
@@ -220,6 +223,8 @@ ACTUAL_BUMP="$(json_field "${RELEASE_OUTPUT_FILE}" '.data.result.bump_type // em
 ACTUAL_VERSION="${ACTUAL_VERSION:-${NEW_VERSION}}"
 ACTUAL_TAG="${ACTUAL_TAG:-v${NEW_VERSION}}"
 ACTUAL_BUMP="${ACTUAL_BUMP:-${BUMP_TYPE}}"
+
+homeboy_verify_github_release_exists "${ACTUAL_TAG}" "${GITHUB_REPOSITORY:-}"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/release/test-github-release-verification.sh
+++ b/scripts/release/test-github-release-verification.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="${ROOT_DIR}/scripts/release/github-release.sh"
+
+source "${HELPER}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+assert_success() {
+  local label="$1"
+  shift
+
+  if "$@" >"${TMP_DIR}/stdout" 2>"${TMP_DIR}/stderr"; then
+    printf 'PASS: %s\n' "${label}"
+    return 0
+  fi
+
+  printf 'FAIL: %s\n' "${label}"
+  printf 'stdout:\n%s\n' "$(cat "${TMP_DIR}/stdout")"
+  printf 'stderr:\n%s\n' "$(cat "${TMP_DIR}/stderr")"
+  exit 1
+}
+
+assert_failure_contains() {
+  local expected="$1"
+  local label="$2"
+  shift 2
+
+  if "$@" >"${TMP_DIR}/stdout" 2>"${TMP_DIR}/stderr"; then
+    printf 'FAIL: %s\nexpected failure containing: %s\n' "${label}" "${expected}"
+    exit 1
+  fi
+
+  if ! grep -q -- "${expected}" "${TMP_DIR}/stdout" "${TMP_DIR}/stderr"; then
+    printf 'FAIL: %s\nmissing expected output: %s\n' "${label}" "${expected}"
+    printf 'stdout:\n%s\n' "$(cat "${TMP_DIR}/stdout")"
+    printf 'stderr:\n%s\n' "$(cat "${TMP_DIR}/stderr")"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+write_fake_gh() {
+  local exit_code="$1"
+  cat >"${TMP_DIR}/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" > "${TMP_DIR}/gh-args"
+exit ${exit_code}
+EOF
+  chmod +x "${TMP_DIR}/gh"
+}
+
+write_fake_gh 0
+PATH="${TMP_DIR}:${PATH}" assert_success \
+  "verifies existing GitHub Release" \
+  homeboy_verify_github_release_exists "v1.2.3" "Extra-Chill/homeboy-action"
+
+if [ "$(cat "${TMP_DIR}/gh-args")" != "release view v1.2.3 --repo Extra-Chill/homeboy-action" ]; then
+  printf 'FAIL: gh release view arguments were not passed through correctly\n'
+  printf 'args: %s\n' "$(cat "${TMP_DIR}/gh-args")"
+  exit 1
+fi
+printf 'PASS: gh release view receives tag and repo\n'
+
+write_fake_gh 1
+PATH="${TMP_DIR}:${PATH}" assert_failure_contains \
+  "GitHub Release not found after successful release: repo=Extra-Chill/homeboy-action tag=v9.9.9" \
+  "fails clearly when GitHub Release is missing" \
+  homeboy_verify_github_release_exists "v9.9.9" "Extra-Chill/homeboy-action"
+
+HOMEBOY_VERIFY_GITHUB_RELEASE=false assert_success \
+  "can skip verification for tag-only release consumers" \
+  homeboy_verify_github_release_exists "v1.2.3" "Extra-Chill/homeboy-action"
+
+HOMEBOY_VERIFY_GITHUB_RELEASE=maybe assert_failure_contains \
+  "Invalid HOMEBOY_VERIFY_GITHUB_RELEASE value" \
+  "rejects invalid verification configuration" \
+  homeboy_verify_github_release_exists "v1.2.3" "Extra-Chill/homeboy-action"
+
+assert_failure_contains \
+  "release tag is empty" \
+  "fails clearly when tag is empty" \
+  homeboy_verify_github_release_exists "" "Extra-Chill/homeboy-action"
+
+assert_failure_contains \
+  "GITHUB_REPOSITORY is empty" \
+  "fails clearly when repository is empty" \
+  homeboy_verify_github_release_exists "v1.2.3" ""
+
+printf 'All GitHub Release verification checks passed.\n'

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -38,5 +38,8 @@ assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not
 
 assert_contains 'commands: release' "${WORKFLOW}" "release workflow delegates to homeboy-action release command"
 assert_not_contains '--no-github-release' "${RUN_RELEASE}" "run-release lets Homeboy core create GitHub Releases"
+assert_contains 'homeboy_verify_github_release_exists "${ACTUAL_TAG}" "${GITHUB_REPOSITORY:-}"' "${RUN_RELEASE}" "run-release verifies the GitHub Release after successful release"
+assert_contains 'release-verify-github-release:' "${ROOT_DIR}/action.yml" "action exposes GitHub Release verification toggle"
+assert_contains 'HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}' "${ROOT_DIR}/action.yml" "action passes verification toggle to release script"
 
 printf 'All release workflow checks passed.\n'


### PR DESCRIPTION
## Summary

- Add a post-release guard that verifies the emitted tag exists as a GitHub Release with `gh release view` before the release step is considered successful.
- Expose `release-verify-github-release` for tag-only consumers while keeping verification enabled by default.
- Add shell coverage for success, missing release, opt-out, invalid config, and missing tag/repo cases.

## Tests

- `bash -n scripts/release/run-release.sh scripts/release/github-release.sh scripts/release/test-github-release-verification.sh scripts/release/test-release-workflow.sh`
- `bash scripts/release/test-release-workflow.sh`
- `bash scripts/release/test-github-release-verification.sh`
- `for f in scripts/*/test*.sh scripts/*/*/test*.sh; do [ -f "$f" ] || continue; bash "$f"; done`
- `python3 -c 'import glob, subprocess, sys; files=glob.glob("scripts/*/test*.py")+glob.glob("scripts/*/*/test*.py"); [print(f) or subprocess.check_call([sys.executable, f]) for f in files]'`

Closes #157

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the release verification guard, shell helper tests, and PR preparation. Chris remains responsible for review and merge.
