### PR TITLE
fix(core): route release commands outside quality results

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -480,7 +480,7 @@ runs:
 
     - name: Run release
       id: release
-      if: contains(steps.resolve-commands.outputs.resolved-commands, 'release') && github.event_name != 'pull_request'
+      if: steps.resolve-commands.outputs.release-commands != '' && github.event_name != 'pull_request'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token || github.token }}

--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -15,16 +15,15 @@ if [ -z "${RESULTS:-}" ] || [ "${RESULTS}" = "{}" ]; then
     exit 0
   fi
 
-  # If the only commands are release/operations, empty quality results are expected
+  # If there are no quality commands, empty quality results are expected.
   COMMANDS="${COMMANDS:-}"
-  NON_RELEASE="$(echo "${COMMANDS}" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^release$' | grep -v '^$' || true)"
-  if [ -z "${NON_RELEASE}" ] && [ -z "${OPERATIONS_RESULTS}" ]; then
-    echo "Release-only mode — no quality gate commands to enforce"
+  if [ -z "${COMMANDS}" ] && [ -z "${OPERATIONS_RESULTS}" ]; then
+    echo "No quality gate commands to enforce"
     exit 0
   fi
 
   # If we have operations results but no quality results, that's fine
-  if [ -z "${NON_RELEASE}" ] && [ -n "${OPERATIONS_RESULTS}" ]; then
+  if [ -z "${COMMANDS}" ] && [ -n "${OPERATIONS_RESULTS}" ]; then
     HAS_QUALITY_COMMANDS=false
   elif [ -z "${OPERATIONS_RESULTS}" ]; then
     echo "::error::No command results were produced"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -267,8 +267,8 @@ resolve_push_target() {
 
 # Sort commands into canonical order: audit → lint → test → refactor.
 # Audit/lint/test are the core quality gates; real refactor commands run after
-# them when explicitly requested. Fleet/deploy are operations commands handled
-# separately by run-operations.sh and are filtered out here.
+# them when explicitly requested. Release and operations commands are handled
+# by dedicated steps and are filtered out here defensively.
 canonicalize_commands() {
   local commands="$1"
   local audit="" lint="" test="" refactor="" others=()
@@ -283,8 +283,7 @@ canonicalize_commands() {
       lint)    lint="lint" ;;
       test)    test="test" ;;
       refactor) refactor="${cmd}" ;;
-      # Fleet/deploy are operations commands — handled by run-operations.sh
-      fleet|deploy) ;;
+      release|fleet|deploy) ;;
       *)       others+=("${cmd}") ;;
     esac
   done

--- a/scripts/core/resolve-commands.sh
+++ b/scripts/core/resolve-commands.sh
@@ -5,10 +5,12 @@
 # If the COMMANDS input is explicitly set (non-empty and not the old v1 default),
 # use it as-is. Otherwise, infer from the GitHub event context.
 #
-# Commands are split into two categories:
-#   1. Quality commands: audit, lint, test, refactor, release
+# Commands are split into three categories:
+#   1. Quality commands: audit, lint, test, refactor
 #      These run in canonical order with component/workspace/scope handling.
-#   2. Operations commands: fleet, deploy
+#   2. Release command: release
+#      This is handled by the dedicated release workflow step.
+#   3. Operations commands: fleet, deploy
 #      These are passthrough commands that talk to remote servers via SSH.
 #      They're never auto-inferred — must be explicitly specified.
 #
@@ -18,6 +20,7 @@
 #
 # Outputs (GITHUB_ENV + GITHUB_OUTPUT):
 #   RESOLVED_COMMANDS     — comma-separated quality command list
+#   RELEASE_COMMANDS      — comma-separated release command list
 #   OPERATIONS_COMMANDS   — comma-separated operations command list (fleet/deploy)
 
 set -euo pipefail
@@ -50,10 +53,11 @@ else
   echo "Commands inferred from context (${SCOPE_CONTEXT}): ${ALL_COMMANDS}"
 fi
 
-# Split commands into quality vs operations categories.
-# Operations commands (fleet/deploy) are passthrough — they use their own
-# argument structure and don't take component/workspace/scope flags.
+# Split commands into quality, release, and operations categories. Release and
+# operations commands have dedicated steps; only quality commands enter the
+# structured quality-results path.
 QUALITY_COMMANDS=()
+RELEASE_COMMANDS=()
 OPS_COMMANDS=()
 
 IFS=',' read -ra _ALL_ARRAY <<< "${ALL_COMMANDS}"
@@ -62,6 +66,9 @@ for _cmd in "${_ALL_ARRAY[@]}"; do
   [ -z "${_cmd}" ] && continue
   _base=$(echo "${_cmd}" | awk '{print $1}')
   case "${_base}" in
+    release)
+      RELEASE_COMMANDS+=("${_cmd}")
+      ;;
     fleet|deploy)
       OPS_COMMANDS+=("${_cmd}")
       ;;
@@ -82,11 +89,19 @@ if [ ${#OPS_COMMANDS[@]} -gt 0 ]; then
   OPERATIONS_COMMANDS="$(IFS=','; printf '%s' "${OPS_COMMANDS[*]}")"
 fi
 
+RELEASE_COMMANDS_OUTPUT=""
+if [ ${#RELEASE_COMMANDS[@]} -gt 0 ]; then
+  RELEASE_COMMANDS_OUTPUT="$(IFS=','; printf '%s' "${RELEASE_COMMANDS[*]}")"
+fi
+
 if [ -n "${RESOLVED_COMMANDS}" ]; then
   echo "Quality commands: ${RESOLVED_COMMANDS}"
 fi
 if [ -n "${OPERATIONS_COMMANDS}" ]; then
   echo "Operations commands: ${OPERATIONS_COMMANDS}"
+fi
+if [ -n "${RELEASE_COMMANDS_OUTPUT}" ]; then
+  echo "Release commands: ${RELEASE_COMMANDS_OUTPUT}"
 fi
 
 # Detect refactor-only command sets (e.g., "refactor --from all").
@@ -112,6 +127,9 @@ fi
 echo "RESOLVED_COMMANDS=${RESOLVED_COMMANDS}" >> "${GITHUB_ENV}"
 echo "resolved-commands=${RESOLVED_COMMANDS}" >> "${GITHUB_OUTPUT}"
 echo "refactor-only=${REFACTOR_ONLY}" >> "${GITHUB_OUTPUT}"
+
+echo "RELEASE_COMMANDS=${RELEASE_COMMANDS_OUTPUT}" >> "${GITHUB_ENV}"
+echo "release-commands=${RELEASE_COMMANDS_OUTPUT}" >> "${GITHUB_OUTPUT}"
 
 echo "OPERATIONS_COMMANDS=${OPERATIONS_COMMANDS}" >> "${GITHUB_ENV}"
 echo "operations-commands=${OPERATIONS_COMMANDS}" >> "${GITHUB_OUTPUT}"

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
 
-# v2: prefer RESOLVED_COMMANDS (from resolve-commands.sh), fall back to COMMANDS for compat
+# v2: prefer RESOLVED_COMMANDS (quality-only from resolve-commands.sh), fall back to COMMANDS for compat
 EFFECTIVE_COMMANDS="${RESOLVED_COMMANDS:-${COMMANDS:-audit,lint,test}}"
 
 # If no quality commands to run (e.g. operations-only mode), exit cleanly
@@ -34,11 +34,6 @@ HAS_LINT_COMMAND="$(has_lint_command "${EFFECTIVE_COMMANDS}")"
 
 for CMD in "${CMD_ARRAY[@]}"; do
   CMD=$(echo "${CMD}" | xargs)
-
-  # Release is handled by the dedicated release step, not the command loop
-  if [ "${CMD}" = "release" ]; then
-    continue
-  fi
 
   if [ "${CMD}" = "test" ] && [ "${HAS_LINT_COMMAND}" = "true" ]; then
     export HOMEBOY_SKIP_LINT=1

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -207,4 +207,14 @@ assert_equals \
   "$(canonicalize_commands "fleet exec my-fleet -- homeboy upgrade,deploy my-project --all")" \
   "canonicalize returns empty when only operations commands"
 
+assert_equals \
+  "audit,lint,test" \
+  "$(canonicalize_commands "release,audit,lint,test")" \
+  "canonicalize strips release commands"
+
+assert_equals \
+  "" \
+  "$(canonicalize_commands "release")" \
+  "canonicalize returns empty when only release commands"
+
 printf 'All command builder checks passed.\n'

--- a/scripts/core/test-command-resolution.sh
+++ b/scripts/core/test-command-resolution.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_COMMANDS="${SCRIPT_DIR}/resolve-commands.sh"
+ENFORCE_STATUS="${SCRIPT_DIR}/enforce-final-status.sh"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_contains() {
+  local needle="$1"
+  local haystack="$2"
+  local label="$3"
+
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    printf 'FAIL: %s\nmissing: %s\noutput:  %s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+make_temp_file() {
+  mktemp "${TMPDIR:-/tmp}/homeboy-action-test.XXXXXX"
+}
+
+get_output() {
+  local file="$1"
+  local key="$2"
+
+  grep -E "^${key}=" "${file}" | tail -1 | cut -d= -f2-
+}
+
+run_resolve() {
+  local commands="$1"
+  local context="${2:-manual}"
+  local output_file env_file
+
+  output_file="$(make_temp_file)"
+  env_file="$(make_temp_file)"
+
+  GITHUB_OUTPUT="${output_file}" \
+    GITHUB_ENV="${env_file}" \
+    COMMANDS_INPUT="${commands}" \
+    SCOPE_CONTEXT="${context}" \
+    bash "${RESOLVE_COMMANDS}" >/dev/null
+
+  printf '%s\n' "${output_file}"
+}
+
+release_only_output="$(run_resolve "release")"
+assert_equals "" "$(get_output "${release_only_output}" "resolved-commands")" "release-only has no quality commands"
+assert_equals "release" "$(get_output "${release_only_output}" "release-commands")" "release-only populates release bucket"
+assert_equals "" "$(get_output "${release_only_output}" "operations-commands")" "release-only has no operations commands"
+
+mixed_output="$(run_resolve "audit,release")"
+assert_equals "audit" "$(get_output "${mixed_output}" "resolved-commands")" "mixed audit/release keeps audit in quality bucket"
+assert_equals "release" "$(get_output "${mixed_output}" "release-commands")" "mixed audit/release keeps release in release bucket"
+
+quality_output="$(run_resolve "audit,lint,test")"
+assert_equals "audit,lint,test" "$(get_output "${quality_output}" "resolved-commands")" "normal quality commands stay in quality bucket"
+assert_equals "" "$(get_output "${quality_output}" "release-commands")" "normal quality commands have no release bucket"
+assert_equals "" "$(get_output "${quality_output}" "operations-commands")" "normal quality commands have no operations bucket"
+
+cron_output="$(run_resolve "" "cron")"
+assert_equals "" "$(get_output "${cron_output}" "resolved-commands")" "cron default has no quality commands"
+assert_equals "release" "$(get_output "${cron_output}" "release-commands")" "cron default populates release bucket"
+
+enforce_output="$(RESULTS='{}' COMMANDS='' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}")"
+assert_contains "No quality gate commands to enforce" "${enforce_output}" "release-only final status skips quality enforcement"
+
+printf 'All command resolution checks passed.\n'


### PR DESCRIPTION
## Summary
- Split command resolution into quality, release, and operations buckets so `release` no longer enters the quality results path.
- Point the dedicated release step at the release bucket and simplify final-status handling when there are no quality commands.
- Add shell coverage for `commands=release`, `commands=audit,release`, normal quality commands, and defensive canonicalization.

## Tests
- `bash -n scripts/core/resolve-commands.sh scripts/core/run-homeboy-commands.sh scripts/core/select-final-results.sh scripts/core/enforce-final-status.sh scripts/core/lib.sh scripts/core/test-command-resolution.sh scripts/core/test-command-builders.sh`
- `ruby -e 'require "yaml"; YAML.load_file("action.yml"); puts "action.yml parsed"'`
- `for test_script in scripts/**/test-*.sh; do echo "==> ${test_script}"; bash "${test_script}"; done`

Closes #158

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the command-bucket routing fix, added shell tests, ran verification, and prepared this PR. Chris remains responsible for review and merge.