### PR TITLE
fix(pr): remove duplicated action footer

### DIFF
--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -159,6 +159,4 @@ build_tooling_section() {
   printf '%s\n' "- Extension revision: \`${extension_revision}\`"
   printf '%s\n' "- Action: \`${action_repository}@${action_ref}\`"
   printf '\n</details>\n\n'
-  printf '%s\n' '---'
-  printf '%s\n' "*[Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v2*"
 }

--- a/scripts/pr/comment/test-tooling-section.sh
+++ b/scripts/pr/comment/test-tooling-section.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+export GITHUB_ACTION_PATH="${ROOT}"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    printf 'FAIL: %s\nmissing: %s\nbody:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    printf 'FAIL: %s\nunexpected: %s\nbody:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+export HOMEBOY_CLI_VERSION="homeboy 1.2.3"
+export HOMEBOY_EXTENSION_ID="wordpress"
+export HOMEBOY_EXTENSION_SOURCE="github"
+export HOMEBOY_EXTENSION_REVISION="abc1234"
+export HOMEBOY_ACTION_REPOSITORY="Extra-Chill/homeboy-action"
+export HOMEBOY_ACTION_REF="feature/footer-test"
+
+source "${ROOT}/scripts/pr/comment/sections.sh"
+
+tooling_section="$(build_tooling_section)"
+
+assert_contains "${tooling_section}" '- Homeboy CLI: `homeboy 1.2.3`' "tooling section includes CLI version"
+assert_contains "${tooling_section}" '- Action: `Extra-Chill/homeboy-action@feature/footer-test`' "tooling section renders actual action ref"
+assert_not_contains "${tooling_section}" 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v1' "tooling section does not hardcode v1 footer"
+assert_not_contains "${tooling_section}" 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v2' "tooling section does not hardcode v2 footer"
+assert_not_contains "${tooling_section}" '---' "tooling section has no redundant footer separator"
+
+printf 'All tooling section checks passed.\n'

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -48,6 +48,6 @@ assert_contains '^2\.' "${VERSION_FILE}" "VERSION is aligned with the v2 action 
 assert_not_contains 'Extra-Chill/homeboy-action@v1' "${README}" "README examples use the v2 action channel"
 assert_contains 'Extra-Chill/homeboy-action@v2' "${README}" "README documents the v2 action channel"
 assert_not_contains 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v1' "${COMMENT_SECTIONS}" "PR comment footer does not advertise v1"
-assert_contains 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v2' "${COMMENT_SECTIONS}" "PR comment footer advertises v2"
+assert_not_contains 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v2' "${COMMENT_SECTIONS}" "PR comment footer does not duplicate action metadata"
 
 printf 'All release workflow checks passed.\n'


### PR DESCRIPTION
## Summary
- Remove the redundant hardcoded Homeboy Action footer from sectioned PR comments.
- Keep the tooling block as the single source of truth for the actual action repository/ref.
- Add a focused tooling-section smoke test so hardcoded v1/v2 footer text cannot disagree with the rendered action metadata.

## Tests
- `bash scripts/pr/comment/test-section-key-slug.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `bash scripts/pr/comment/test-app-token-required.sh`
- `bash scripts/pr/comment/test-tooling-section.sh`
- `bash scripts/release/test-release-workflow.sh`

Closes #166

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** Drafted the code/test change and ran focused validation; Chris remains responsible for review and merge.