### PR TITLE
fix(core): fail closed on malformed results

### DIFF
--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -6,6 +6,23 @@ OPERATIONS_RESULTS="${OPERATIONS_RESULTS:-}"
 HAS_QUALITY_COMMANDS=true
 HAS_OPERATIONS_COMMANDS=true
 
+validate_results_json() {
+  local label="$1"
+  local json="$2"
+
+  if [ -z "${json}" ]; then
+    return 0
+  fi
+
+  if ! printf '%s\n' "${json}" | jq -e 'type == "object"' > /dev/null 2>&1; then
+    echo "::error::${label} results are not valid JSON object data"
+    return 1
+  fi
+}
+
+validate_results_json "Quality command" "${RESULTS:-}"
+validate_results_json "Operations command" "${OPERATIONS_RESULTS}"
+
 if [ -z "${RESULTS:-}" ] || [ "${RESULTS}" = "{}" ]; then
   HAS_QUALITY_COMMANDS=false
 
@@ -35,7 +52,7 @@ FAILED=false
 
 # Check quality command results
 if [ "${HAS_QUALITY_COMMANDS}" = true ]; then
-  if echo "${RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
+  if printf '%s\n' "${RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
     echo "::error::One or more quality commands failed"
     FAILED=true
   fi
@@ -43,7 +60,7 @@ fi
 
 # Check operations command results
 if [ -n "${OPERATIONS_RESULTS}" ] && [ "${OPERATIONS_RESULTS}" != "{}" ]; then
-  if echo "${OPERATIONS_RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
+  if printf '%s\n' "${OPERATIONS_RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
     echo "::error::One or more operations commands (fleet/deploy) failed"
     FAILED=true
   fi

--- a/scripts/core/test-enforce-final-status.sh
+++ b/scripts/core/test-enforce-final-status.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENFORCE_STATUS="${SCRIPT_DIR}/enforce-final-status.sh"
+
+assert_exit() {
+  local expected="$1"
+  local label="$2"
+  shift 2
+
+  local output status
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "${status}" -ne "${expected}" ]; then
+    printf 'FAIL: %s\nexpected exit: %s\nactual exit:   %s\noutput:        %s\n' "${label}" "${expected}" "${status}" "${output}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_exit 1 "malformed quality results fail closed" \
+  env RESULTS='{"test":"fail"}}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+
+assert_exit 1 "failing quality results fail" \
+  env RESULTS='{"test":"fail"}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+
+assert_exit 0 "passing quality results pass" \
+  env RESULTS='{"test":"pass"}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+
+printf 'All final status enforcement checks passed.\n'


### PR DESCRIPTION
## Summary
- Validate quality and operations result payloads as JSON objects before enforcing final status.
- Fail closed with a GitHub Actions error when malformed result JSON reaches the final-status step.
- Add a focused smoke test covering malformed fail JSON, valid failing JSON, and valid passing JSON.

## Tests
- `for test_script in scripts/core/test-*.sh scripts/pr/comment/test-*.sh scripts/release/test-*.sh scripts/setup/test-*.sh; do bash "${test_script}"; done; for test_script in scripts/core/test-*.py scripts/digest/test-*.py; do python3 "${test_script}"; done`
- `homeboy lint homeboy-action --path /Users/chubes/Developer/homeboy-action@fix-results-json-fail-closed` could not run because this component has no Homeboy extension configured.
- `homeboy test homeboy-action --path /Users/chubes/Developer/homeboy-action@fix-results-json-fail-closed` could not run because this component has no Homeboy extension configured.

Closes #164

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the shell fix, added smoke coverage, and ran local verification; Chris remains responsible for review and merge.
