### PR TITLE
fix(pr-comment): render unknown command status as warning

### DIFF
--- a/scripts/pr/comment/lib.sh
+++ b/scripts/pr/comment/lib.sh
@@ -89,15 +89,30 @@ summary_json_for_command() {
 
 command_status() {
   local command="$1"
-  echo "${RESULTS}" | jq -r --arg cmd "${command}" '.[$cmd] // "unknown"' 2>/dev/null || echo "unknown"
+  echo "${RESULTS}" | jq -r --arg cmd "${command}" 'if .[$cmd] == "pass" or .[$cmd] == "fail" then .[$cmd] else "unknown" end' 2>/dev/null || echo "unknown"
 }
 
 command_icon() {
   local status="$1"
-  if [ "${status}" = "pass" ]; then
-    printf '%s\n' "white_check_mark"
-  else
-    printf '%s\n' "x"
+  case "${status}" in
+    pass)
+      printf '%s\n' "white_check_mark"
+      ;;
+    fail)
+      printf '%s\n' "x"
+      ;;
+    *)
+      printf '%s\n' "warning"
+      ;;
+  esac
+}
+
+command_status_note() {
+  local command="$1"
+  local status="$2"
+
+  if [ "${status}" = "unknown" ]; then
+    printf '%s\n' "- Could not parse a pass/fail result for ${command}; check the action logs or result artifact."
   fi
 }
 

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -122,6 +122,11 @@ append_command_sections() {
       SECTION_BODY+="- No structured ${CMD} summary artifact was generated."$'\n'
     fi
 
+    STATUS_NOTE="$(command_status_note "${CMD}" "${STATUS}")"
+    if [ -n "${STATUS_NOTE}" ]; then
+      SECTION_BODY+="${STATUS_NOTE}"$'\n'
+    fi
+
     SECTION_BODY+=$'\n'
   done
 }

--- a/scripts/pr/comment/test-unknown-status-rendering.sh
+++ b/scripts/pr/comment/test-unknown-status-rendering.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    printf 'FAIL: %s\nmissing: %s\nbody:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    printf 'FAIL: %s\nunexpected: %s\nbody:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+render_for_results() {
+  export RESULTS="$1"
+  build_section_body
+  printf '%s\n' "${SECTION_BODY}"
+}
+
+export GITHUB_ACTION_PATH="${ROOT}"
+export COMMANDS="audit"
+export COMP_ID="data-machine"
+export WORKSPACE="/tmp/workspace"
+export SECTION_TITLE="Audit"
+export AUTOFIX_ENABLED="false"
+export BINARY_SOURCE="source"
+export SCOPE_MODE="full"
+export DIGEST_FILE=""
+
+source "${ROOT}/scripts/core/lib.sh"
+source "${ROOT}/scripts/pr/comment/sections.sh"
+
+body="$(render_for_results '{not-json')"
+assert_contains "${body}" ":warning: **audit**" "malformed results render as warning"
+assert_contains "${body}" "Could not parse a pass/fail result for audit" "malformed results explain parse problem"
+assert_not_contains "${body}" ":x: **audit**" "malformed results do not render as command failure"
+
+body="$(render_for_results '{"audit":"mystery"}')"
+assert_contains "${body}" ":warning: **audit**" "unknown status renders as warning"
+assert_contains "${body}" "Could not parse a pass/fail result for audit" "unknown status explains parse problem"
+assert_not_contains "${body}" ":x: **audit**" "unknown status does not render as command failure"
+
+body="$(render_for_results '{"audit":"fail"}')"
+assert_contains "${body}" ":x: **audit**" "explicit failure remains failure"
+assert_not_contains "${body}" "Could not parse a pass/fail result for audit" "explicit failure has no parse warning"
+
+printf 'All unknown status rendering checks passed.\n'


### PR DESCRIPTION
## Summary
- Render unparseable or unknown command results as a warning in PR comments instead of a normal command failure.
- Preserve existing pass/fail icons and add focused shell coverage for malformed `RESULTS` JSON and unknown statuses.

## Tests
- `bash scripts/pr/comment/test-unknown-status-rendering.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `bash scripts/pr/comment/test-section-key-slug.sh`
- `python3 scripts/digest/test-comment-quality-render.py`
- `python3 scripts/digest/test-audit-comment-render.py` (skipped real audit fixture, as expected)
- `bash scripts/core/test-command-builders.sh`
- `bash scripts/core/test-command-resolution.sh`
- `bash -n scripts/pr/comment/lib.sh scripts/pr/comment/sections.sh scripts/pr/comment/test-unknown-status-rendering.sh`

Closes #164.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the focused renderer fix, added shell coverage, and ran the relevant local checks. Chris remains responsible for review and merge.

Note: the task prompt referenced #165, but the matching unknown-status issue in GitHub is #164. Issue #165 is about the hardcoded PR-comment footer version and is intentionally not closed by this PR.
