### PR TITLE
fix(setup): fall back when latest release asset is missing

### DIFF
--- a/scripts/setup/resolve-homeboy-version.sh
+++ b/scripts/setup/resolve-homeboy-version.sh
@@ -3,6 +3,69 @@
 set -euo pipefail
 
 REPO="Extra-Chill/homeboy"
+ASSET_RETRY_ATTEMPTS="${HOMEBOY_ASSET_RETRY_ATTEMPTS:-3}"
+ASSET_RETRY_DELAY="${HOMEBOY_ASSET_RETRY_DELAY:-5}"
+
+platform_target() {
+  local os arch
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+
+  case "${os}-${arch}" in
+    linux-x86_64) printf 'x86_64-unknown-linux-gnu' ;;
+    linux-aarch64) printf 'aarch64-unknown-linux-gnu' ;;
+    darwin-x86_64) printf 'x86_64-apple-darwin' ;;
+    darwin-arm64) printf 'aarch64-apple-darwin' ;;
+    *)
+      echo "::error::Unsupported platform: ${os}-${arch}"
+      exit 1
+      ;;
+  esac
+}
+
+release_has_asset() {
+  local tag="$1"
+  local archive="$2"
+
+  gh api "repos/${REPO}/releases/tags/${tag}" --jq '.assets[].name' 2>/dev/null | grep -Fxq "${archive}"
+}
+
+wait_for_asset() {
+  local tag="$1"
+  local archive="$2"
+  local attempt
+
+  for attempt in $(seq 1 "${ASSET_RETRY_ATTEMPTS}"); do
+    if release_has_asset "${tag}" "${archive}"; then
+      return 0
+    fi
+
+    if [ "${attempt}" -lt "${ASSET_RETRY_ATTEMPTS}" ]; then
+      echo "Homeboy ${tag#v} asset ${archive} is not available yet; retrying (${attempt}/${ASSET_RETRY_ATTEMPTS})..."
+      sleep "${ASSET_RETRY_DELAY}"
+    fi
+  done
+
+  return 1
+}
+
+previous_release_with_asset() {
+  local current_tag="$1"
+  local archive="$2"
+  local tag asset
+
+  while IFS=$'\t' read -r tag asset; do
+    if [ "${tag}" != "${current_tag}" ] && [ "${asset}" = "${archive}" ]; then
+      printf '%s' "${tag}"
+      return 0
+    fi
+  done < <(gh api "repos/${REPO}/releases?per_page=20" --jq '.[] | [.tag_name, (.assets[].name)] | @tsv' 2>/dev/null || true)
+
+  return 1
+}
+
+TARGET="$(platform_target)"
+ARCHIVE="homeboy-${TARGET}.tar.xz"
 
 if [ "${HOMEBOY_VERSION}" = "latest" ]; then
   TAG=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
@@ -10,8 +73,23 @@ if [ "${HOMEBOY_VERSION}" = "latest" ]; then
     echo "::error::Could not determine latest Homeboy release"
     exit 1
   fi
+
+  if ! wait_for_asset "${TAG}" "${ARCHIVE}"; then
+    FALLBACK_TAG=$(previous_release_with_asset "${TAG}" "${ARCHIVE}" || true)
+    if [ -z "${FALLBACK_TAG}" ]; then
+      echo "::error::Homeboy ${TAG#v} asset ${ARCHIVE} was not available and no previous release with that asset was found"
+      exit 1
+    fi
+
+    echo "::warning::Homeboy ${TAG#v} asset ${ARCHIVE} was not available; falling back to ${FALLBACK_TAG#v}"
+    TAG="${FALLBACK_TAG}"
+  fi
 else
   TAG="v${HOMEBOY_VERSION#v}"
+  if ! wait_for_asset "${TAG}" "${ARCHIVE}"; then
+    echo "::error::Homeboy ${TAG#v} asset ${ARCHIVE} was not available; explicit versions do not fall back"
+    exit 1
+  fi
 fi
 
 echo "resolved-version=${TAG#v}" >> "${GITHUB_OUTPUT}"

--- a/scripts/setup/test-resolve-homeboy-version.sh
+++ b/scripts/setup/test-resolve-homeboy-version.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_contains() {
+  local needle="$1"
+  local file="$2"
+  local label="$3"
+
+  if ! grep -qF "${needle}" "${file}"; then
+    printf 'FAIL: %s\nmissing: %s\n' "${label}" "${needle}"
+    printf 'log:\n'
+    cat "${file}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+FAKE_BIN="${TMPDIR}/bin"
+mkdir -p "${FAKE_BIN}"
+
+cat > "${FAKE_BIN}/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+endpoint=""
+for arg in "$@"; do
+  case "${arg}" in
+    repos/*) endpoint="${arg}" ;;
+  esac
+done
+
+case "${endpoint}" in
+  repos/Extra-Chill/homeboy/releases/latest)
+    printf '%s\n' "${FAKE_LATEST_TAG}"
+    ;;
+  repos/Extra-Chill/homeboy/releases/tags/*)
+    tag="${endpoint##*/}"
+    attempts_file="${FAKE_STATE_DIR}/${tag}.attempts"
+    count=0
+    if [ -f "${attempts_file}" ]; then
+      count="$(cat "${attempts_file}")"
+    fi
+    count=$((count + 1))
+    printf '%s' "${count}" > "${attempts_file}"
+
+    assets_var="FAKE_ASSETS_${tag//[^A-Za-z0-9_]/_}"
+    assets="${!assets_var:-}"
+    for asset in ${assets}; do
+      printf '%s\n' "${asset}"
+    done
+    ;;
+  repos/Extra-Chill/homeboy/releases?per_page=20)
+    printf '%b' "${FAKE_RELEASE_ROWS}"
+    ;;
+  *)
+    printf 'unexpected gh endpoint: %s\n' "${endpoint}" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "${FAKE_BIN}/gh"
+
+run_resolver() {
+  local version="$1"
+  local output_file="$2"
+  local log_file="$3"
+
+  PATH="${FAKE_BIN}:${PATH}" \
+  GITHUB_OUTPUT="${output_file}" \
+  HOMEBOY_VERSION="${version}" \
+  HOMEBOY_ASSET_RETRY_ATTEMPTS="2" \
+  HOMEBOY_ASSET_RETRY_DELAY="0" \
+  bash "${SCRIPT_DIR}/resolve-homeboy-version.sh" > "${log_file}" 2>&1
+}
+
+case "$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)" in
+  linux-x86_64) TARGET="x86_64-unknown-linux-gnu" ;;
+  linux-aarch64) TARGET="aarch64-unknown-linux-gnu" ;;
+  darwin-x86_64) TARGET="x86_64-apple-darwin" ;;
+  darwin-arm64) TARGET="aarch64-apple-darwin" ;;
+  *)
+    printf 'Unsupported test platform: %s-%s\n' "$(uname -s)" "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+ARCHIVE="homeboy-${TARGET}.tar.xz"
+TAB=$'\t'
+
+GITHUB_OUTPUT_FILE="${TMPDIR}/output-complete"
+LOG_FILE="${TMPDIR}/log-complete"
+FAKE_STATE_DIR="${TMPDIR}/state-complete" \
+FAKE_LATEST_TAG="v0.122.0" \
+FAKE_ASSETS_v0_122_0="${ARCHIVE}" \
+FAKE_RELEASE_ROWS="v0.122.0${TAB}${ARCHIVE}"$'\n' \
+mkdir -p "${TMPDIR}/state-complete"
+
+FAKE_STATE_DIR="${TMPDIR}/state-complete" \
+FAKE_LATEST_TAG="v0.122.0" \
+FAKE_ASSETS_v0_122_0="${ARCHIVE}" \
+FAKE_RELEASE_ROWS="v0.122.0${TAB}${ARCHIVE}"$'\n' \
+run_resolver "latest" "${GITHUB_OUTPUT_FILE}" "${LOG_FILE}"
+assert_equals "resolved-version=0.122.0" "$(cat "${GITHUB_OUTPUT_FILE}")" "latest keeps newest when asset exists"
+
+GITHUB_OUTPUT_FILE="${TMPDIR}/output-fallback"
+LOG_FILE="${TMPDIR}/log-fallback"
+mkdir -p "${TMPDIR}/state-fallback"
+FAKE_STATE_DIR="${TMPDIR}/state-fallback" \
+FAKE_LATEST_TAG="v0.122.0" \
+FAKE_ASSETS_v0_122_0="" \
+FAKE_RELEASE_ROWS="v0.122.0${TAB}other-platform.tar.xz"$'\n'"v0.121.0${TAB}${ARCHIVE}"$'\n' \
+run_resolver "latest" "${GITHUB_OUTPUT_FILE}" "${LOG_FILE}"
+assert_equals "resolved-version=0.121.0" "$(cat "${GITHUB_OUTPUT_FILE}")" "latest falls back to previous release with asset"
+assert_contains "falling back to 0.121.0" "${LOG_FILE}" "fallback is visible in logs"
+assert_equals "2" "$(cat "${TMPDIR}/state-fallback/v0.122.0.attempts")" "latest retries before fallback"
+
+GITHUB_OUTPUT_FILE="${TMPDIR}/output-pinned"
+LOG_FILE="${TMPDIR}/log-pinned"
+mkdir -p "${TMPDIR}/state-pinned"
+if FAKE_STATE_DIR="${TMPDIR}/state-pinned" \
+  FAKE_LATEST_TAG="v0.122.0" \
+  FAKE_ASSETS_v0_122_0="" \
+  FAKE_RELEASE_ROWS="v0.121.0${TAB}${ARCHIVE}"$'\n' \
+  run_resolver "0.122.0" "${GITHUB_OUTPUT_FILE}" "${LOG_FILE}"; then
+  printf 'FAIL: pinned missing asset should fail\n'
+  exit 1
+fi
+assert_contains "explicit versions do not fall back" "${LOG_FILE}" "pinned missing asset fails clearly"
+
+printf 'All Homeboy version resolver checks passed.\n'


### PR DESCRIPTION
## Summary
- Validate the platform-specific Homeboy release asset during version resolution, before the cache key is computed.
- Retry briefly for release-asset propagation races, then fall back from `latest` to the newest previous release that has the needed asset.
- Keep explicitly pinned versions strict: missing pinned assets fail clearly and do not fall back.

## Behavior
- `version: latest` keeps using the newest release when its platform asset exists.
- `version: latest` warns and falls back when the newest release is missing the current platform archive after retries.
- Explicit `version: 0.x.y` retries and then fails with a clear error if that exact asset is missing.

## Tests
- `bash scripts/setup/test-resolve-homeboy-version.sh`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`
- Attempted `homeboy lint homeboy-action --path /Users/chubes/Developer/homeboy-action@fix-latest-asset-fallback` and `homeboy test ...`; both are blocked locally because this component has no Homeboy extension configured.

Closes #170

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the resolver fallback behavior, added focused shell coverage, and ran local verification; Chris remains responsible for review and merge.