### PR TITLE
feat: expose bench as a CI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homeboy Action
 
-GitHub Action for running [Homeboy](https://github.com/Extra-Chill/homeboy) lint, test, audit, and release commands in CI.
+GitHub Action for running [Homeboy](https://github.com/Extra-Chill/homeboy) lint, test, audit, bench, and release commands in CI.
 
 Works with **any Homeboy extension** — WordPress, Rust, Node, or your own custom extension.
 
@@ -83,6 +83,24 @@ The release command:
 
 After the tag push, downstream build/publish jobs can pick it up (e.g. cargo-dist, npm publish).
 
+### Benchmarks
+
+Run `homeboy bench` in CI and preserve the raw structured output for downstream review agents:
+
+```yaml
+- uses: Extra-Chill/homeboy-action@v2
+  with:
+    extension: rust
+    component: homeboy
+    commands: bench
+    rig: main,pr
+    scenario: audit-self
+    runs: 3
+    iterations: 10
+```
+
+Bench runs write the exact `homeboy bench --output` payload to `homeboy-ci-results/bench.json`, upload it as the `homeboy-ci-results` artifact, and render a compact PR-summary section when PR comments are enabled.
+
 #### Continuous release outputs
 
 | Output | Description |
@@ -126,6 +144,11 @@ Use these outputs to gate downstream jobs:
 | `expected-commands` | No | *(falls back to `commands`)* | Full set of command types expected to run across the workflow (e.g. `audit,lint,test`). Set this on every invocation when a workflow splits audit/lint/test across separate steps, otherwise each invocation will close sibling invocations' issues during reconciliation. |
 | `component` | No | *(repo name)* | Component name (auto-detected from repo) |
 | `args` | No | | Extra arguments passed to each command |
+| `rig` | No | | Bench rig pair/list passed to `homeboy bench --rig` |
+| `scenario` | No | | Bench scenario ID passed to `homeboy bench --scenario` |
+| `runs` | No | | Bench run count passed to `homeboy bench --runs` |
+| `iterations` | No | | Bench iteration count passed to `homeboy bench --iterations` |
+| `regression-threshold` | No | | Bench regression threshold passed to `homeboy bench --regression-threshold` |
 | `differential-gating` | No | `false` | On PRs, compare `audit`/`test` counts against the base SHA and fail only when the PR is worse. Opt-in; `lint` still gates on exit code. PR autofix is skipped while enabled. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |
 | `node-version` | No | | Node.js version (sets up via `actions/setup-node`) |

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,26 @@ inputs:
     description: 'Additional arguments to pass to each command.'
     required: false
     default: ''
+  rig:
+    description: 'Bench rig pair/list to pass to `homeboy bench --rig` when command includes bench.'
+    required: false
+    default: ''
+  scenario:
+    description: 'Bench scenario ID to pass to `homeboy bench --scenario` when command includes bench.'
+    required: false
+    default: ''
+  runs:
+    description: 'Bench run count to pass to `homeboy bench --runs` when command includes bench.'
+    required: false
+    default: ''
+  iterations:
+    description: 'Bench iteration count to pass to `homeboy bench --iterations` when command includes bench.'
+    required: false
+    default: ''
+  regression-threshold:
+    description: 'Bench regression threshold to pass to `homeboy bench --regression-threshold` when command includes bench.'
+    required: false
+    default: ''
   differential-gating:
     description: 'On PRs, compare audit/test failure counts against the base SHA and fail only when the PR is worse. Opt-in; lint remains normal exit-code gating. PR autofix is skipped while enabled.'
     required: false
@@ -381,9 +401,22 @@ runs:
       env:
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
+        BENCH_RIG: ${{ inputs.rig }}
+        BENCH_SCENARIO: ${{ inputs.scenario }}
+        BENCH_RUNS: ${{ inputs.runs }}
+        BENCH_ITERATIONS: ${{ inputs.iterations }}
+        BENCH_REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
         RUN_GROUP_PREFIX: homeboy
       run: bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
+
+    - name: Upload Homeboy CI results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: homeboy-ci-results
+        path: homeboy-ci-results/*.json
+        if-no-files-found: ignore
 
     - name: Run baseline Homeboy commands
       id: run-baseline-commands

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -265,13 +265,13 @@ resolve_push_target() {
   fi
 }
 
-# Sort commands into canonical order: audit → lint → test → refactor.
-# Audit/lint/test are the core quality gates; real refactor commands run after
-# them when explicitly requested. Release and operations commands are handled
-# by dedicated steps and are filtered out here defensively.
+# Sort commands into canonical order: audit → lint → test → refactor → bench.
+# Audit/lint/test are the core quality gates; real refactor and bench commands
+# run after them when explicitly requested. Release and operations commands are
+# handled by dedicated steps and are filtered out here defensively.
 canonicalize_commands() {
   local commands="$1"
-  local audit="" lint="" test="" refactor="" others=()
+  local audit="" lint="" test="" refactor="" bench="" others=()
   local cmd base_cmd
 
   IFS=',' read -ra CMD_ARRAY <<< "${commands}"
@@ -283,6 +283,7 @@ canonicalize_commands() {
       lint)    lint="lint" ;;
       test)    test="test" ;;
       refactor) refactor="${cmd}" ;;
+      bench) bench="${cmd}" ;;
       release|fleet|deploy) ;;
       *)       others+=("${cmd}") ;;
     esac
@@ -293,6 +294,7 @@ canonicalize_commands() {
   [ -n "${lint}" ]  && result+=("${lint}")
   [ -n "${test}" ]  && result+=("${test}")
   [ -n "${refactor}" ] && result+=("${refactor}")
+  [ -n "${bench}" ] && result+=("${bench}")
   result+=("${others[@]+"${others[@]}"}")
 
   local IFS=','
@@ -330,6 +332,12 @@ build_run_command() {
 
   if [[ "${cmd}" == refactor* ]]; then
     full_cmd="homeboy ${global_flags}refactor ${component_id} ${cmd#refactor } --path ${workspace}"
+  elif [[ "${cmd}" == bench* ]]; then
+    local bench_args
+    bench_args="$(printf '%s' "${cmd#bench}" | xargs)"
+    full_cmd="homeboy ${global_flags}bench ${component_id}"
+    [ -n "${bench_args}" ] && full_cmd="${full_cmd} ${bench_args}"
+    full_cmd="${full_cmd} --path ${workspace}"
   else
     full_cmd="homeboy ${global_flags}${cmd} ${component_id} --path ${workspace}"
   fi
@@ -340,6 +348,24 @@ build_run_command() {
 
   if [ -n "${EXTRA_ARGS:-}" ]; then
     full_cmd="${full_cmd} ${EXTRA_ARGS}"
+  fi
+
+  if [[ "${cmd}" == bench* ]]; then
+    if [ -n "${BENCH_RIG:-}" ]; then
+      full_cmd="${full_cmd} --rig ${BENCH_RIG}"
+    fi
+    if [ -n "${BENCH_SCENARIO:-}" ]; then
+      full_cmd="${full_cmd} --scenario ${BENCH_SCENARIO}"
+    fi
+    if [ -n "${BENCH_RUNS:-}" ]; then
+      full_cmd="${full_cmd} --runs ${BENCH_RUNS}"
+    fi
+    if [ -n "${BENCH_ITERATIONS:-}" ]; then
+      full_cmd="${full_cmd} --iterations ${BENCH_ITERATIONS}"
+    fi
+    if [ -n "${BENCH_REGRESSION_THRESHOLD:-}" ]; then
+      full_cmd="${full_cmd} --regression-threshold ${BENCH_REGRESSION_THRESHOLD}"
+    fi
   fi
 
   printf '%s\n' "${full_cmd}"

--- a/scripts/core/resolve-commands.sh
+++ b/scripts/core/resolve-commands.sh
@@ -6,7 +6,7 @@
 # use it as-is. Otherwise, infer from the GitHub event context.
 #
 # Commands are split into three categories:
-#   1. Quality commands: audit, lint, test, refactor
+#   1. Quality-style commands: audit, lint, test, refactor, bench
 #      These run in canonical order with component/workspace/scope handling.
 #   2. Release command: release
 #      This is handled by the dedicated release workflow step.

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -23,6 +23,10 @@ GROUP_PREFIX="${RUN_GROUP_PREFIX:-homeboy}"
 HOMEBOY_OUTPUT_DIR=$(mktemp -d)
 echo "HOMEBOY_OUTPUT_DIR=${HOMEBOY_OUTPUT_DIR}" >> "${GITHUB_ENV}"
 
+HOMEBOY_CI_RESULTS_DIR="${GITHUB_WORKSPACE:-$(pwd)}/homeboy-ci-results"
+mkdir -p "${HOMEBOY_CI_RESULTS_DIR}"
+echo "HOMEBOY_CI_RESULTS_DIR=${HOMEBOY_CI_RESULTS_DIR}" >> "${GITHUB_ENV}"
+
 HOMEBOY_ANNOTATIONS_DIR=$(mktemp -d)
 echo "HOMEBOY_ANNOTATIONS_DIR=${HOMEBOY_ANNOTATIONS_DIR}" >> "${GITHUB_ENV}"
 export HOMEBOY_ANNOTATIONS_DIR
@@ -42,7 +46,11 @@ for CMD in "${CMD_ARRAY[@]}"; do
   fi
 
   OUTPUT_STEM="$(command_output_stem "${CMD}")"
-  OUTPUT_JSON="${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.json"
+  if [ "$(printf '%s' "${CMD}" | awk '{print $1}')" = "bench" ]; then
+    OUTPUT_JSON="${HOMEBOY_CI_RESULTS_DIR}/bench.json"
+  else
+    OUTPUT_JSON="${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.json"
+  fi
   FULL_CMD="$(build_run_command "${CMD}" "${COMP_ID}" "${WORKSPACE}" "${OUTPUT_JSON}")"
 
   echo ""
@@ -61,6 +69,8 @@ for CMD in "${CMD_ARRAY[@]}"; do
 
   if [ ! -s "${OUTPUT_JSON}" ]; then
     echo "::warning::homeboy ${CMD} did not write structured output to ${OUTPUT_JSON}"
+  elif [ "$(printf '%s' "${CMD}" | awk '{print $1}')" = "bench" ]; then
+    cp "${OUTPUT_JSON}" "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.json"
   fi
 
   if [ "${CMD_EXIT}" -eq 0 ]; then

--- a/scripts/core/test-bench-command.sh
+++ b/scripts/core/test-bench-command.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+assert_file() {
+  local path="$1"
+  local label="$2"
+  if [ ! -s "${path}" ]; then
+    printf 'FAIL: %s missing at %s\n' "${label}" "${path}"
+    exit 1
+  fi
+  printf 'PASS: %s\n' "${label}"
+}
+
+mkdir -p "${TMP_DIR}/bin" "${TMP_DIR}/workspace"
+cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ -z "${output}" ]; then
+  echo "missing --output" >&2
+  exit 2
+fi
+mkdir -p "$(dirname "${output}")"
+printf '%s\n' '{"success":true,"data":{"scenarios":[{"scenario":"noop","metrics":{"elapsed_ms":{"p50":1,"p95":2}}}]}}' > "${output}"
+SH
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+export PATH="${TMP_DIR}/bin:${PATH}"
+export GITHUB_ACTION_PATH="${ROOT_DIR}"
+export GITHUB_WORKSPACE="${TMP_DIR}/workspace"
+export GITHUB_OUTPUT="${TMP_DIR}/github-output"
+export GITHUB_ENV="${TMP_DIR}/github-env"
+export GITHUB_REPOSITORY="Extra-Chill/homeboy-action"
+export RESOLVED_COMMANDS="bench"
+export COMPONENT_NAME="homeboy-action"
+export BENCH_RIG="main,pr"
+export BENCH_SCENARIO="noop"
+export BENCH_RUNS="1"
+export BENCH_ITERATIONS="2"
+
+(cd "${TMP_DIR}/workspace" && bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh")
+
+assert_file "${TMP_DIR}/workspace/homeboy-ci-results/bench.json" "stable bench artifact"
+
+output_dir="$(grep '^HOMEBOY_OUTPUT_DIR=' "${TMP_DIR}/github-env" | cut -d= -f2-)"
+assert_file "${output_dir}/bench.json" "comment-summary bench artifact copy"
+
+if ! grep -q '^results={"bench":"pass"}$' "${TMP_DIR}/github-output"; then
+  printf 'FAIL: bench result was not recorded as pass\n'
+  cat "${TMP_DIR}/github-output"
+  exit 1
+fi
+printf 'PASS: bench result recorded\n'
+
+printf 'Bench command runner checks passed.\n'

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -93,6 +93,19 @@ assert_equals \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "run command keeps output path before extra args"
 
+unset EXTRA_ARGS
+BENCH_RIG="main,pr"
+BENCH_SCENARIO="pipeline-scale"
+BENCH_RUNS="3"
+BENCH_ITERATIONS="10"
+BENCH_REGRESSION_THRESHOLD="5"
+assert_equals \
+  "homeboy --output /tmp/workspace/out.json bench data-machine --path /tmp/workspace --rig main,pr --scenario pipeline-scale --runs 3 --iterations 10 --regression-threshold 5" \
+  "$(build_run_command "bench" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "bench includes first-class benchmark flags"
+unset BENCH_RIG BENCH_SCENARIO BENCH_RUNS BENCH_ITERATIONS BENCH_REGRESSION_THRESHOLD
+EXTRA_ARGS="--format json"
+
 assert_equals \
   "homeboy refactor data-machine --from lint --write --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_autofix_command "refactor --from lint --write" "${COMPONENT}" "${WORKSPACE}")" \
@@ -201,6 +214,11 @@ assert_equals \
   "audit,lint,test,refactor --all" \
   "$(canonicalize_commands "deploy --fleet prod data-machine,audit,lint,test,fleet status my-fleet,refactor --all")" \
   "canonicalize strips all operations and preserves order"
+
+assert_equals \
+  "audit,lint,test,refactor --all,bench" \
+  "$(canonicalize_commands "bench,audit,lint,test,refactor --all")" \
+  "canonicalize places bench after quality commands"
 
 assert_equals \
   "" \

--- a/scripts/core/test-command-resolution.sh
+++ b/scripts/core/test-command-resolution.sh
@@ -74,6 +74,11 @@ assert_equals "audit,lint,test" "$(get_output "${quality_output}" "resolved-comm
 assert_equals "" "$(get_output "${quality_output}" "release-commands")" "normal quality commands have no release bucket"
 assert_equals "" "$(get_output "${quality_output}" "operations-commands")" "normal quality commands have no operations bucket"
 
+bench_output="$(run_resolve "bench")"
+assert_equals "bench" "$(get_output "${bench_output}" "resolved-commands")" "bench enters structured command bucket"
+assert_equals "" "$(get_output "${bench_output}" "release-commands")" "bench has no release bucket"
+assert_equals "" "$(get_output "${bench_output}" "operations-commands")" "bench has no operations bucket"
+
 cron_output="$(run_resolve "" "cron")"
 assert_equals "" "$(get_output "${cron_output}" "resolved-commands")" "cron default has no quality commands"
 assert_equals "release" "$(get_output "${cron_output}" "release-commands")" "cron default populates release bucket"

--- a/scripts/digest/fixtures/bench-summary-input.json
+++ b/scripts/digest/fixtures/bench-summary-input.json
@@ -1,0 +1,19 @@
+{
+  "success": true,
+  "data": {
+    "component": "data-machine",
+    "rigs": ["main", "pr"],
+    "scenarios": [
+      {
+        "scenario": "pipeline-scale",
+        "metrics": {
+          "elapsed_ms": {
+            "p50": 120.5,
+            "p95": 141.25,
+            "delta_percent": 4.2
+          }
+        }
+      }
+    ]
+  }
+}

--- a/scripts/digest/render-command-summary.py
+++ b/scripts/digest/render-command-summary.py
@@ -75,6 +75,8 @@ def compact_summary(command: str, raw: dict[str, Any]) -> str:
         return compact_audit(data)
     if command == "refactor":
         return compact_refactor(data)
+    if command == "bench":
+        return compact_bench(data)
     return "structured command details available"
 
 
@@ -154,6 +156,19 @@ def compact_refactor(data: dict[str, Any]) -> str:
     return "no automated fixes found"
 
 
+def compact_bench(data: dict[str, Any]) -> str:
+    regressions = count_matching_keys(data, {"regression", "regressions"})
+    scenarios = collect_scenario_names(data)
+    primary = collect_bench_metric_rows(data)
+    if primary:
+        return "; ".join(primary[:2])
+    if regressions:
+        return f"{regressions} regression(s) reported"
+    if scenarios:
+        return f"{len(scenarios)} benchmark scenario(s) reported"
+    return "structured benchmark details available"
+
+
 # ── Markdown summaries (multi-line for PR comments) ───────────────────
 
 def markdown_summary(command: str, raw: dict[str, Any]) -> str:
@@ -176,8 +191,94 @@ def markdown_summary(command: str, raw: dict[str, Any]) -> str:
         markdown_audit(data, lines)
     elif command == "refactor":
         markdown_refactor(data, lines)
+    elif command == "bench":
+        markdown_bench(data, lines)
 
     return "\n".join(lines)
+
+
+def walk_dicts(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from walk_dicts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from walk_dicts(child)
+
+
+def count_matching_keys(value: Any, needles: set[str]) -> int:
+    count = 0
+    for item in walk_dicts(value):
+        for key, child in item.items():
+            if str(key).lower() in needles:
+                if isinstance(child, list):
+                    count += len(child)
+                elif isinstance(child, dict):
+                    count += len(child) or 1
+                elif child:
+                    count += 1
+    return count
+
+
+def collect_scenario_names(data: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for item in walk_dicts(data):
+        for key in ("scenario", "scenario_id", "name", "id"):
+            raw = item.get(key)
+            if isinstance(raw, str) and raw and any(token in item for token in ("p50", "p95", "elapsed_ms", "metrics", "timings_ns")):
+                if raw not in names:
+                    names.append(raw)
+                break
+    return names
+
+
+def collect_bench_metric_rows(data: dict[str, Any]) -> list[str]:
+    rows: list[str] = []
+    seen: set[str] = set()
+    for item in walk_dicts(data):
+        label = str(item.get("scenario") or item.get("scenario_id") or item.get("name") or item.get("id") or "benchmark")
+        p50 = metric_value(item, "p50")
+        p95 = metric_value(item, "p95")
+        delta = metric_value(item, "delta_percent") or metric_value(item, "change_percent") or metric_value(item, "regression_percent")
+        elapsed = metric_value(item, "elapsed_ms")
+        parts: list[str] = []
+        if p50 is not None:
+            parts.append(f"p50 {format_metric(p50)}")
+        if p95 is not None:
+            parts.append(f"p95 {format_metric(p95)}")
+        if delta is not None:
+            parts.append(f"delta {format_metric(delta)}%")
+        elif elapsed is not None and not parts:
+            parts.append(f"elapsed {format_metric(elapsed)}ms")
+        if not parts:
+            continue
+        row = f"{label}: " + ", ".join(parts)
+        if row not in seen:
+            seen.add(row)
+            rows.append(row)
+    return rows
+
+
+def metric_value(item: dict[str, Any], key: str) -> float | int | None:
+    value = item.get(key)
+    if isinstance(value, (int, float)):
+        return value
+    metrics = item.get("metrics")
+    if isinstance(metrics, dict):
+        nested = metrics.get(key)
+        if isinstance(nested, (int, float)):
+            return nested
+        elapsed = metrics.get("elapsed_ms")
+        if isinstance(elapsed, dict):
+            nested = elapsed.get(key)
+            if isinstance(nested, (int, float)):
+                return nested
+    return None
+
+
+def format_metric(value: float | int) -> str:
+    return f"{value:.2f}" if isinstance(value, float) and not value.is_integer() else str(int(value))
 
 
 def summarize_test_failure(item: dict[str, Any], idx: int) -> str:
@@ -360,6 +461,25 @@ def markdown_refactor(data: dict[str, Any], lines: list[str]) -> None:
         notable = [str(w) for w in warnings if isinstance(w, str) and "merge order" not in w.lower()]
         if notable:
             append_details(lines, f"Warnings ({len(notable)})", notable[:10])
+
+
+def markdown_bench(data: dict[str, Any], lines: list[str]) -> None:
+    rows = collect_bench_metric_rows(data)
+    scenarios = collect_scenario_names(data)
+    regressions = count_matching_keys(data, {"regression", "regressions"})
+
+    if scenarios:
+        lines.append(f"- Benchmark scenarios: **{len(scenarios)}**")
+    if regressions:
+        lines.append(f"- Regression signals: **{regressions}**")
+    if rows:
+        lines.append("- Primary metrics:")
+        for row in rows[:6]:
+            lines.append(f"  - {row}")
+        if len(rows) > 6:
+            lines.append(f"  - ... and {len(rows) - 6} more")
+    if not lines:
+        lines.append("- Benchmark structured output is available in `homeboy-ci-results/bench.json`.")
 
 
 # ── CLI entry point ───────────────────────────────────────────────────

--- a/scripts/digest/test-comment-quality-render.py
+++ b/scripts/digest/test-comment-quality-render.py
@@ -61,6 +61,11 @@ def main() -> int:
     assert_contains(tooling_failure, "runner/tooling failure", "test failure classification")
     assert_not_contains(tooling_failure, "Failed tests: **0**", "misleading zero failed tests line")
 
+    bench = render("bench", "bench-summary-input.json")
+    assert_contains(bench, "Benchmark scenarios: **1**", "bench scenario count")
+    assert_contains(bench, "pipeline-scale: p50 120.50, p95 141.25", "bench primary metrics")
+    assert_contains(bench, "delta 4.20%", "bench delta metric")
+
     full_digest = render_markdown(
         lint_digest={},
         test_digest={},

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -51,10 +51,10 @@ COMMENT_KEY="$(derive_comment_key)"
 SECTION_KEY="$(derive_section_key)"
 SECTION_TITLE="$(derive_section_title)"
 HEADER="## Homeboy Results — \`${COMP_ID}\`"
-# Preserve the current rendered order (lint, build, test, audit). Core's
+# Preserve the current rendered order (lint, build, test, audit, bench). Core's
 # default is alphabetical; `tooling` is pinned last so the versions block
 # stays at the bottom of the comment.
-SECTION_ORDER="lint,build,test,audit,tooling"
+SECTION_ORDER="lint,build,test,audit,bench,tooling"
 
 build_section_body
 


### PR DESCRIPTION
## Summary
- Adds `bench` to the action command path with first-class benchmark inputs for rig, scenario, runs, iterations, and regression threshold.
- Writes the raw `homeboy bench --output` payload to `homeboy-ci-results/bench.json` and uploads it as the `homeboy-ci-results` artifact.
- Adds compact benchmark rendering for PR comments while preserving the full JSON artifact for downstream consumers.

## Behaviour
- `commands: bench` runs through the normal structured command runner and records `{"bench":"pass|fail"}` in action results.
- Bench output is written directly to `homeboy-ci-results/bench.json`, then copied into the existing temp output directory so existing PR summary rendering can consume it.
- Existing lint/test/audit/refactor command ordering and behaviour are preserved; `bench` runs after quality/refactor commands when mixed.

## Tests
- `bash scripts/core/test-command-builders.sh`
- `bash scripts/core/test-command-resolution.sh`
- `bash scripts/core/test-bench-command.sh`
- `python3 scripts/digest/test-comment-quality-render.py`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`
- `python3 scripts/digest/test-audit-comment-render.py && python3 scripts/digest/test-comment-quality-render.py && python3 scripts/core/test-differential-gate.py`
- `python3 -m py_compile scripts/digest/render-command-summary.py scripts/digest/test-comment-quality-render.py scripts/core/test-differential-gate.py`
- `bash -n scripts/core/lib.sh scripts/core/run-homeboy-commands.sh scripts/core/test-bench-command.sh scripts/core/test-command-builders.sh scripts/pr/post-pr-comment.sh`

`homeboy lint homeboy-action --path .` is blocked locally because the component has no Homeboy extension configured.

Closes #172

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the action wiring, benchmark summary renderer, tests, and PR description. Chris remains responsible for review and merge.
