### PR TITLE
fix(release): keep failure cache outside checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         id: failure-cache
         uses: actions/cache/restore@v4
         with:
-          path: .release-last-failed
+          path: ${{ runner.temp }}/homeboy-release-last-failed
           key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             release-last-failed-${{ github.ref_name }}-
@@ -62,8 +62,9 @@ jobs:
         id: check
         run: |
           HEAD_SHA="$(git rev-parse HEAD)"
-          if [ -f .release-last-failed ]; then
-            LAST_FAILED="$(tr -d '[:space:]' < .release-last-failed)"
+          FAILURE_MARKER="${RUNNER_TEMP}/homeboy-release-last-failed"
+          if [ -f "${FAILURE_MARKER}" ]; then
+            LAST_FAILED="$(tr -d '[:space:]' < "${FAILURE_MARKER}")"
             if [ "${HEAD_SHA}" = "${LAST_FAILED}" ]; then
               echo "::notice::HEAD ${HEAD_SHA:0:8} matches last failed release attempt — skipping until new commits"
               echo "should-release=false" >> "$GITHUB_OUTPUT"
@@ -122,12 +123,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Save failed SHA
-        run: git rev-parse HEAD > .release-last-failed
+        run: git rev-parse HEAD > "${RUNNER_TEMP}/homeboy-release-last-failed"
 
       - name: Cache failed SHA
         uses: actions/cache/save@v4
         with:
-          path: .release-last-failed
+          path: ${{ runner.temp }}/homeboy-release-last-failed
           key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
 
   # ── Clear failure cache on success ──

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -40,6 +40,9 @@ assert_not_contains 'gh release create' "${WORKFLOW}" "release workflow does not
 assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not parse changelog notes"
 
 assert_contains 'commands: release' "${WORKFLOW}" "release workflow delegates to homeboy-action release command"
+assert_contains 'runner.temp }}/homeboy-release-last-failed' "${WORKFLOW}" "release failure cache lives outside checkout"
+assert_not_contains 'path: .release-last-failed' "${WORKFLOW}" "release failure cache is not restored into checkout"
+assert_not_contains '< .release-last-failed' "${WORKFLOW}" "release failure marker is not read from checkout"
 assert_not_contains '--no-github-release' "${RUN_RELEASE}" "run-release lets Homeboy core create GitHub Releases"
 assert_contains '--git-identity bot' "${RUN_RELEASE}" "run-release delegates bot identity to Homeboy core"
 assert_not_contains 'git config user.name' "${RUN_RELEASE}" "run-release does not configure git identity directly"


### PR DESCRIPTION
## Summary
- Store the release retry-loop failure marker under `runner.temp` instead of the repository checkout.
- Read the restored marker from `RUNNER_TEMP` before deciding whether to skip a repeated failed release attempt.
- Add release workflow assertions so the cache marker cannot make the checkout dirty again.

## Why
The release workflow restores `.release-last-failed` before running the Homeboy release dry-run. When that cache exists, it creates an untracked file in the checkout, and `homeboy release --dry-run` refuses to run with `Uncommitted changes detected`. That prevents the automatic release/channel update from advancing `v2`.

## Tests
- `bash scripts/release/test-release-workflow.sh`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed release workflow from GitHub logs, implemented the workflow fix and focused assertions, and ran local shell verification. Chris remains responsible for review and merge.