### PR TITLE
fix: refresh extensions on cache hits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -308,7 +308,7 @@ runs:
       run: bash ${{ github.action_path }}/scripts/setup/resolve-binary-source.sh
 
     - name: Install extension
-      if: steps.read-config.outputs.portable-extension != '' && (inputs.binary-path != '' || steps.cache-homeboy.outputs.cache-hit != 'true' || steps.source-build.outputs.built == 'true')
+      if: steps.read-config.outputs.portable-extension != ''
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}

--- a/scripts/setup/test-extension-cache-condition.sh
+++ b/scripts/setup/test-extension-cache-condition.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ACTION_FILE="${ROOT_DIR}/action.yml"
+INSTALL_BLOCK="$(awk '
+  /^    - name: Install extension$/ { in_block = 1 }
+  in_block { print }
+  in_block && /^    - name: Capture tooling metadata$/ { exit }
+' "${ACTION_FILE}")"
+
+if ! grep -q "if: steps.read-config.outputs.portable-extension != ''" <<<"${INSTALL_BLOCK}"; then
+  echo "FAIL: Install extension step must run whenever a portable extension is configured" >&2
+  exit 1
+fi
+
+if grep -q "steps.cache-homeboy.outputs.cache-hit != 'true'" <<<"${INSTALL_BLOCK}"; then
+  echo "FAIL: Install extension step must not be gated on the Homeboy cache hit" >&2
+  exit 1
+fi
+
+echo "Extension cache condition check passed."


### PR DESCRIPTION
## Summary
- Always run the extension install step when a portable extension is configured, even when the Homeboy binary/cache restore hits.
- Add a focused regression check so the install step cannot be gated on the Homeboy cache hit again.

## Why
The cache includes `~/.config/homeboy/extensions/`, so skipping extension install on cache hits pins consumers to stale extension code. Data Machine reruns kept using an older WordPress extension even after the upstream fix merged.

## Tests
- `bash scripts/setup/test-extension-cache-condition.sh`
- `bash scripts/setup/test-install-extension.sh`
- `bash scripts/setup/test-detect-runtime-env.sh`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the stale-extension cache path, implemented the action condition fix and regression test; Chris remains responsible for review and merge.