### PR TITLE
fix(release): move v2 to released tag target

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -12,7 +12,7 @@
   ],
   "hooks": {
     "post:release": [
-      "current_branch=$(git rev-parse --abbrev-ref HEAD) && [ \"$current_branch\" = \"main\" ] && gh api repos/Extra-Chill/homeboy-action/git/refs/tags/v2 --method PATCH -f sha=$(git rev-parse HEAD) -F force=true || { echo \"Skipping v2 tag update (branch: $current_branch)\"; }"
+      "current_branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$current_branch\" != \"main\" ]; then echo \"Skipping v2 tag update (branch: $current_branch)\"; exit 0; fi; release_version=$(tr -d '[:space:]' < VERSION); release_sha=$(gh api repos/Extra-Chill/homeboy-action/git/ref/tags/v${release_version} --jq .object.sha); gh api repos/Extra-Chill/homeboy-action/git/refs/tags/v2 --method PATCH -f sha=\"$release_sha\" -F force=true"
     ]
   }
 }

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -8,6 +8,7 @@ RUN_RELEASE="${ROOT_DIR}/scripts/release/run-release.sh"
 README="${ROOT_DIR}/README.md"
 COMMENT_SECTIONS="${ROOT_DIR}/scripts/pr/comment/sections.sh"
 VERSION_FILE="${ROOT_DIR}/VERSION"
+HOMEBOY_CONFIG="${ROOT_DIR}/homeboy.json"
 
 assert_not_contains() {
   local needle="$1"
@@ -50,6 +51,10 @@ assert_not_contains 'remote set-url origin' "${RUN_RELEASE}" "run-release does n
 assert_contains 'homeboy_verify_github_release_exists "${TAG}" "${GITHUB_REPOSITORY:-}"' "${RUN_RELEASE}" "run-release verifies the GitHub Release after successful release"
 assert_contains 'release-verify-github-release:' "${ROOT_DIR}/action.yml" "action exposes GitHub Release verification toggle"
 assert_contains 'HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}' "${ROOT_DIR}/action.yml" "action passes verification toggle to release script"
+assert_contains 'git/ref/tags/v${release_version}' "${HOMEBOY_CONFIG}" "post-release hook reads the pushed release tag ref"
+assert_contains 'release_sha' "${HOMEBOY_CONFIG}" "post-release hook points v2 at the pushed release tag target"
+assert_not_contains 'sha=$(git rev-parse HEAD)' "${HOMEBOY_CONFIG}" "post-release hook does not point v2 at an unpushed local release commit"
+assert_not_contains 'Skipping v2 tag update.*||' "${HOMEBOY_CONFIG}" "post-release hook does not swallow failed v2 tag updates"
 assert_contains '^2\.' "${VERSION_FILE}" "VERSION is aligned with the v2 action channel"
 assert_not_contains 'Extra-Chill/homeboy-action@v1' "${README}" "README examples use the v2 action channel"
 assert_contains 'Extra-Chill/homeboy-action@v2' "${README}" "README documents the v2 action channel"


### PR DESCRIPTION
## Summary
- Update the post-release hook so the floating `v2` tag points at the pushed `v${VERSION}` release tag target.
- Stop swallowing failed `v2` tag updates; non-main branch skips remain explicit no-ops.
- Add release workflow assertions for the floating-channel contract.

## Why
The v2.1.1 release succeeded, but `v2` stayed on v2.1.0. The hook was using local `HEAD` after Homeboy's release step, and it also masked failures with a trailing `|| echo ...`, so the workflow could go green without moving the channel tag.

## Tests
- `bash scripts/release/test-release-workflow.sh`
- `bash scripts/release/test-run-release-wrapper.sh`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed why the automated v2 channel move did not take effect, implemented the fail-closed hook fix and regression assertions; Chris remains responsible for review and merge.