### PR TITLE
fix(release): configure git push auth

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -12,7 +12,7 @@
   ],
   "hooks": {
     "post:release": [
-      "current_branch=$(git rev-parse --abbrev-ref HEAD) && [ \"$current_branch\" = \"main\" ] && gh api repos/Extra-Chill/homeboy-action/git/refs/tags/v2 --method PATCH -f sha=$(git rev-parse HEAD) -F force=true || { echo \"Skipping v2 tag update (branch: $current_branch)\"; }"
+      "current_branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$current_branch\" != \"main\" ]; then echo \"Skipping v2 tag update (branch: $current_branch)\"; exit 0; fi; release_version=$(tr -d '[:space:]' < VERSION); release_sha=$(gh api repos/Extra-Chill/homeboy-action/git/ref/tags/v${release_version} --jq .object.sha); gh api repos/Extra-Chill/homeboy-action/git/refs/tags/v2 --method PATCH -f sha=\"$release_sha\" -F force=true"
     ]
   }
 }

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -83,6 +83,16 @@ write_release_outputs() {
   return 0
 }
 
+configure_release_git_auth() {
+  if [ "${DRY_RUN}" = "true" ] || [ -z "${GH_TOKEN:-}" ]; then
+    return 0
+  fi
+
+  local encoded_token
+  encoded_token="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
+  git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${encoded_token}"
+}
+
 COMP_ID="$(resolve_component_id)"
 
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
@@ -109,6 +119,7 @@ fi
 # PRs may merge while the pipeline is in flight. Pull before invoking Homeboy so
 # core releases from the actual branch head.
 git pull --ff-only origin "${RELEASE_BRANCH}" 2>/dev/null || true
+configure_release_git_auth
 
 RELEASE_OUTPUT_FILE="$(mktemp)"
 RELEASE_ARGS=(

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -8,6 +8,7 @@ RUN_RELEASE="${ROOT_DIR}/scripts/release/run-release.sh"
 README="${ROOT_DIR}/README.md"
 COMMENT_SECTIONS="${ROOT_DIR}/scripts/pr/comment/sections.sh"
 VERSION_FILE="${ROOT_DIR}/VERSION"
+HOMEBOY_CONFIG="${ROOT_DIR}/homeboy.json"
 
 assert_not_contains() {
   local needle="$1"
@@ -50,6 +51,10 @@ assert_not_contains 'remote set-url origin' "${RUN_RELEASE}" "run-release does n
 assert_contains 'homeboy_verify_github_release_exists "${TAG}" "${GITHUB_REPOSITORY:-}"' "${RUN_RELEASE}" "run-release verifies the GitHub Release after successful release"
 assert_contains 'release-verify-github-release:' "${ROOT_DIR}/action.yml" "action exposes GitHub Release verification toggle"
 assert_contains 'HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}' "${ROOT_DIR}/action.yml" "action passes verification toggle to release script"
+assert_contains 'git/ref/tags/v${release_version}' "${HOMEBOY_CONFIG}" "post-release hook reads the pushed release tag ref"
+assert_contains 'release_sha' "${HOMEBOY_CONFIG}" "post-release hook points v2 at the pushed release tag target"
+assert_not_contains 'sha=$(git rev-parse HEAD)' "${HOMEBOY_CONFIG}" "post-release hook does not point v2 at an unpushed local release commit"
+assert_not_contains 'Skipping v2 tag update.*||' "${HOMEBOY_CONFIG}" "post-release hook does not swallow failed v2 tag updates"
 assert_contains '^2\.' "${VERSION_FILE}" "VERSION is aligned with the v2 action channel"
 assert_not_contains 'Extra-Chill/homeboy-action@v1' "${README}" "README examples use the v2 action channel"
 assert_contains 'Extra-Chill/homeboy-action@v2' "${README}" "README documents the v2 action channel"

--- a/scripts/release/test-run-release-wrapper.sh
+++ b/scripts/release/test-run-release-wrapper.sh
@@ -51,6 +51,7 @@ setup_fixture() {
   WORKSPACE="${TEST_DIR}/workspace"
   OUTPUT_FILE="${TEST_DIR}/github-output"
   HOMEBOY_ARGS_FILE="${TEST_DIR}/homeboy-args"
+  GIT_ARGS_FILE="${TEST_DIR}/git-args"
   mkdir -p "${BIN_DIR}" "${WORKSPACE}"
 
   cat > "${WORKSPACE}/homeboy.json" <<'JSON'
@@ -69,6 +70,9 @@ case "$1 $2" in
     ;;
   "pull --ff-only")
     exit 0
+    ;;
+  "config --local")
+    printf '%s\n' "$*" >> "${GIT_ARGS_FILE}"
     ;;
   *)
     echo "unexpected git args: $*" >&2
@@ -139,13 +143,16 @@ run_wrapper() {
   GITHUB_WORKSPACE="${WORKSPACE}" \
   GITHUB_REPOSITORY="Extra-Chill/homeboy-action" \
   HOMEBOY_ARGS_FILE="${HOMEBOY_ARGS_FILE}" \
+  GIT_ARGS_FILE="${GIT_ARGS_FILE}" \
   HOMEBOY_MOCK_SCENARIO="${HOMEBOY_MOCK_SCENARIO}" \
   RELEASE_DRY_RUN="${RELEASE_DRY_RUN:-false}" \
+  GH_TOKEN="${GH_TOKEN:-}" \
   bash "${RUN_RELEASE}"
 }
 
 setup_fixture
 HOMEBOY_MOCK_SCENARIO="released"
+GH_TOKEN="secret123"
 run_wrapper
 ARGS="$(cat "${HOMEBOY_ARGS_FILE}")"
 assert_contains 'mock-component' "${ARGS}" "release passes component id"
@@ -158,9 +165,11 @@ assert_output_line 'released=true' "${OUTPUT_FILE}" "released output is true"
 assert_output_line 'release-version=2.1.0' "${OUTPUT_FILE}" "release version output is translated"
 assert_output_line 'release-tag=v2.1.0' "${OUTPUT_FILE}" "release tag output is translated"
 assert_output_line 'bump-type=minor' "${OUTPUT_FILE}" "bump type output is translated"
+assert_contains 'http.https://github.com/.extraheader' "$(cat "${GIT_ARGS_FILE}")" "release configures token-backed git push auth"
 
 setup_fixture
 HOMEBOY_MOCK_SCENARIO="skipped"
+GH_TOKEN="secret123"
 run_wrapper
 assert_output_line 'released=false' "${OUTPUT_FILE}" "skipped release output is false"
 assert_output_line 'skipped-reason=no-releasable-commits' "${OUTPUT_FILE}" "skipped reason comes from homeboy"
@@ -169,9 +178,16 @@ assert_output_line 'bump-type=patch' "${OUTPUT_FILE}" "skipped release preserves
 setup_fixture
 HOMEBOY_MOCK_SCENARIO="released"
 RELEASE_DRY_RUN="true"
+GH_TOKEN="secret123"
 run_wrapper
 ARGS="$(cat "${HOMEBOY_ARGS_FILE}")"
 assert_contains '--dry-run' "${ARGS}" "dry-run mode passes through to homeboy"
+if [ -s "${GIT_ARGS_FILE}" ]; then
+  printf 'FAIL: dry-run should not configure git push auth\nactual:\n'
+  cat "${GIT_ARGS_FILE}"
+  exit 1
+fi
+printf 'PASS: dry-run does not configure git push auth\n'
 assert_output_line 'released=false' "${OUTPUT_FILE}" "dry-run output is not released"
 assert_output_line 'release-version=2.1.0' "${OUTPUT_FILE}" "dry-run preserves planned version"
 assert_output_line 'release-tag=v2.1.0' "${OUTPUT_FILE}" "dry-run preserves planned tag"


### PR DESCRIPTION
## Summary
- Configure a local GitHub auth extraheader from `GH_TOKEN` before non-dry release runs.
- Keep `origin` unchanged while giving Homeboy's internal `git push` credentials.
- Cover normal and dry-run release paths in the wrapper test.

## Why
The release job supplied an app token to the action, but `actions/checkout` removed the auth extraheader and Homeboy's `git push` had no credentials. The v2.1.1 release was created, but the version/changelog commit was not pushed to `main`, leaving future releases stuck on a conflicting tag.

## Tests
- `bash scripts/release/test-run-release-wrapper.sh`
- `bash scripts/release/test-release-workflow.sh`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the failed release push path and implemented the token-backed Git auth fix and tests; Chris remains responsible for review and merge.