### PR TITLE
fix(release): self-release from checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Dry-run release check
         id: release-check
-        uses: Extra-Chill/homeboy-action@v2
+        uses: ./
         with:
           commands: release
           release-dry-run: 'true'
@@ -104,7 +104,7 @@ jobs:
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
-      - uses: Extra-Chill/homeboy-action@v2
+      - uses: ./
         id: release
         with:
           commands: release

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -40,6 +40,8 @@ assert_not_contains '^  create-release:' "${WORKFLOW}" "release workflow has no 
 assert_not_contains 'gh release create' "${WORKFLOW}" "release workflow does not shell out to gh release create"
 assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not parse changelog notes"
 
+assert_contains 'uses: ./' "${WORKFLOW}" "release workflow uses checked-out action code for self-release"
+assert_not_contains 'Extra-Chill/homeboy-action@v2' "${WORKFLOW}" "release workflow is not bootstrapped from the stale floating v2 channel"
 assert_contains 'commands: release' "${WORKFLOW}" "release workflow delegates to homeboy-action release command"
 assert_contains 'runner.temp }}/homeboy-release-last-failed' "${WORKFLOW}" "release failure cache lives outside checkout"
 assert_not_contains 'path: .release-last-failed' "${WORKFLOW}" "release failure cache is not restored into checkout"


### PR DESCRIPTION
## Summary
- Make the Homeboy Action release workflow invoke the checked-out action (`./`) for dry-run and release jobs.
- Add workflow assertions so self-release cannot depend on the floating `v2` channel.

## Why
The release workflow was trying to repair the `v2` channel while bootstrapping itself from `Extra-Chill/homeboy-action@v2`. That means fixes merged to `main` cannot affect the release job until `v2` moves, but `v2` cannot move until the release job uses the fixes. Running from checkout breaks the loop.

## Tests
- `bash scripts/release/test-release-workflow.sh`
- `bash scripts/release/test-run-release-wrapper.sh`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the self-release bootstrap loop and implemented the local-action workflow fix and tests; Chris remains responsible for review and merge.