### PR TITLE
fix(setup): reinstall cached extensions

### DIFF
--- a/scripts/setup/install-extension.sh
+++ b/scripts/setup/install-extension.sh
@@ -10,17 +10,33 @@ if [[ "${EXTENSION_INPUT}" == *,* ]]; then
   exit 1
 fi
 
+refresh_extension() {
+  local extension_id="$1"
+
+  if [ -z "${extension_id}" ]; then
+    return 0
+  fi
+
+  # GitHub Actions restores ~/.config/homeboy/extensions from cache. Homeboy's
+  # install command preserves an existing extension tree, so remove the cached
+  # copy first to guarantee each run consumes the current extension release.
+  homeboy extension uninstall "${extension_id}" >/dev/null 2>&1 || true
+}
+
 if [ -n "${EXTENSION_INPUT}" ]; then
   echo "Installing extension override: ${EXTENSION_INPUT} from ${EXTENSION_SOURCE}..."
+  refresh_extension "${EXTENSION_INPUT}"
   homeboy extension install "${EXTENSION_SOURCE}" --id "${EXTENSION_INPUT}"
   echo "Extension '${EXTENSION_INPUT}' installed successfully"
 else
   if homeboy extension install-for-component --help >/dev/null 2>&1; then
     echo "Installing extensions configured by ${COMPONENT_DIR}/homeboy.json from ${EXTENSION_SOURCE}..."
+    refresh_extension "${EXTENSION_ID}"
     homeboy extension install-for-component --path "${COMPONENT_DIR}" --source "${EXTENSION_SOURCE}"
     echo "Configured extensions installed successfully"
   else
     echo "::warning::Installed Homeboy does not support 'extension install-for-component'; falling back to '${EXTENSION_ID}' only"
+    refresh_extension "${EXTENSION_ID}"
     homeboy extension install "${EXTENSION_SOURCE}" --id "${EXTENSION_ID}"
     echo "Extension '${EXTENSION_ID}' installed successfully"
   fi

--- a/scripts/setup/test-install-extension.sh
+++ b/scripts/setup/test-install-extension.sh
@@ -39,23 +39,23 @@ export HOMEBOY_CALL_LOG="${TMP_DIR}/calls.log"
 
 EXTENSION_INPUT="" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null
 assert_equals \
-  "extension install-for-component --path packages/plugin --source /extensions" \
+  $'extension uninstall wordpress\nextension install-for-component --path packages/plugin --source /extensions' \
   "$(cat "${HOMEBOY_CALL_LOG}")" \
-  "configured extensions use core install-for-component"
+  "configured extensions refresh cached copy before install-for-component"
 
 : > "${HOMEBOY_CALL_LOG}"
 HOMEBOY_INSTALL_FOR_COMPONENT_HELP_STATUS="1" EXTENSION_INPUT="" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null
 assert_equals \
-  "extension install /extensions --id wordpress" \
+  $'extension uninstall wordpress\nextension install /extensions --id wordpress' \
   "$(cat "${HOMEBOY_CALL_LOG}")" \
-  "older homeboy falls back to first configured extension"
+  "older homeboy refreshes cached copy before fallback install"
 
 : > "${HOMEBOY_CALL_LOG}"
 EXTENSION_INPUT="nodejs" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null
 assert_equals \
-  "extension install /extensions --id nodejs" \
+  $'extension uninstall nodejs\nextension install /extensions --id nodejs' \
   "$(cat "${HOMEBOY_CALL_LOG}")" \
-  "explicit extension input keeps single-extension override"
+  "explicit extension input refreshes cached copy before install"
 
 : > "${HOMEBOY_CALL_LOG}"
 if EXTENSION_INPUT="wordpress,nodejs" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null 2>"${TMP_DIR}/comma.err"; then


### PR DESCRIPTION
## Summary
- Remove the configured extension from the Homeboy cache before installing it.
- Keep the install step on cache hits, but make it a real refresh instead of preserving a stale extracted extension tree.

## Why
Homeboy Action caches `~/.config/homeboy/extensions`. Running `homeboy extension install-for-component` on a cache hit can preserve an already-installed monorepo extension, so CI may keep executing old extension scripts even after a new extension release exists. Removing the cached extension first guarantees each run consumes the current extension source.

## Tests
- `bash scripts/setup/test-install-extension.sh`
- `bash scripts/setup/test-extension-cache-condition.sh`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the cache-preserved extension tree and implemented the reinstall guard/tests; Chris remains responsible for review and merge.