### PR TITLE
fix(setup): refresh configured extensions

### DIFF
--- a/scripts/setup/capture-tooling-metadata.sh
+++ b/scripts/setup/capture-tooling-metadata.sh
@@ -30,6 +30,11 @@ if [ -n "${EXTENSION_ID_EFFECTIVE}" ] && [ "${EXTENSION_ID_EFFECTIVE}" != "auto"
   EXT_DIR="${HOME}/.config/homeboy/extensions/${EXTENSION_ID_EFFECTIVE}"
   if [ -d "${EXT_DIR}/.git" ]; then
     EXTENSION_REVISION="$(git -C "${EXT_DIR}" rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+  elif [ -f "${EXT_DIR}/.source-revision" ]; then
+    EXTENSION_REVISION="$(tr -d '[:space:]' < "${EXT_DIR}/.source-revision")"
+    if [ -z "${EXTENSION_REVISION}" ]; then
+      EXTENSION_REVISION="unknown"
+    fi
   fi
 fi
 

--- a/scripts/setup/install-extension.sh
+++ b/scripts/setup/install-extension.sh
@@ -23,6 +23,19 @@ refresh_extension() {
   homeboy extension uninstall "${extension_id}" >/dev/null 2>&1 || true
 }
 
+refresh_configured_extensions() {
+  local config_file="${COMPONENT_DIR}/homeboy.json"
+
+  if [ ! -f "${config_file}" ]; then
+    refresh_extension "${EXTENSION_ID}"
+    return 0
+  fi
+
+  while IFS= read -r configured_extension_id; do
+    refresh_extension "${configured_extension_id}"
+  done < <(jq -r '.extensions // {} | keys[]' "${config_file}" 2>/dev/null || true)
+}
+
 if [ -n "${EXTENSION_INPUT}" ]; then
   echo "Installing extension override: ${EXTENSION_INPUT} from ${EXTENSION_SOURCE}..."
   refresh_extension "${EXTENSION_INPUT}"
@@ -31,7 +44,7 @@ if [ -n "${EXTENSION_INPUT}" ]; then
 else
   if homeboy extension install-for-component --help >/dev/null 2>&1; then
     echo "Installing extensions configured by ${COMPONENT_DIR}/homeboy.json from ${EXTENSION_SOURCE}..."
-    refresh_extension "${EXTENSION_ID}"
+    refresh_configured_extensions
     homeboy extension install-for-component --path "${COMPONENT_DIR}" --source "${EXTENSION_SOURCE}"
     echo "Configured extensions installed successfully"
   else

--- a/scripts/setup/test-capture-tooling-metadata.sh
+++ b/scripts/setup/test-capture-tooling-metadata.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+assert_contains() {
+  local needle="$1"
+  local haystack="$2"
+  local label="$3"
+
+  if ! grep -Fq -- "${needle}" "${haystack}"; then
+    printf 'FAIL: %s\nmissing: %s\n' "${label}" "${needle}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin" "${TMP_DIR}/home/.config/homeboy/extensions/wordpress"
+cat > "${TMP_DIR}/bin/homeboy" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then
+  printf 'homeboy 9.9.9\n'
+fi
+STUB
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+printf 'abc1234\n' > "${TMP_DIR}/home/.config/homeboy/extensions/wordpress/.source-revision"
+
+export PATH="${TMP_DIR}/bin:${PATH}"
+export HOME="${TMP_DIR}/home"
+export PORTABLE_EXTENSION="wordpress"
+export EXTENSION_SOURCE="https://github.com/Extra-Chill/homeboy-extensions"
+export ACTION_REF="v2"
+export ACTION_REPOSITORY="Extra-Chill/homeboy-action"
+export GITHUB_ENV="${TMP_DIR}/github-env"
+
+bash "${ROOT_DIR}/scripts/setup/capture-tooling-metadata.sh" > "${TMP_DIR}/metadata.log"
+
+assert_contains "HOMEBOY_EXTENSION_REVISION=abc1234" "${GITHUB_ENV}" "source revision file is exported"
+assert_contains "- Extension revision: abc1234" "${TMP_DIR}/metadata.log" "source revision file is logged"
+
+echo "All tooling metadata checks passed."

--- a/scripts/setup/test-install-extension.sh
+++ b/scripts/setup/test-install-extension.sh
@@ -34,14 +34,25 @@ chmod +x "${TMP_DIR}/bin/homeboy"
 export PATH="${TMP_DIR}/bin:${PATH}"
 export EXTENSION_SOURCE="/extensions"
 export EXTENSION_ID="wordpress"
-export COMPONENT_DIR="packages/plugin"
+export COMPONENT_DIR="${TMP_DIR}/component"
 export HOMEBOY_CALL_LOG="${TMP_DIR}/calls.log"
+
+mkdir -p "${COMPONENT_DIR}"
+cat > "${COMPONENT_DIR}/homeboy.json" <<'JSON'
+{
+  "id": "demo",
+  "extensions": {
+    "wordpress": {},
+    "nodejs": {}
+  }
+}
+JSON
 
 EXTENSION_INPUT="" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null
 assert_equals \
-  $'extension uninstall wordpress\nextension install-for-component --path packages/plugin --source /extensions' \
+  $'extension uninstall nodejs\nextension uninstall wordpress\nextension install-for-component --path '"${COMPONENT_DIR}"$' --source /extensions' \
   "$(cat "${HOMEBOY_CALL_LOG}")" \
-  "configured extensions refresh cached copy before install-for-component"
+  "all configured extensions refresh cached copy before install-for-component"
 
 : > "${HOMEBOY_CALL_LOG}"
 HOMEBOY_INSTALL_FOR_COMPONENT_HELP_STATUS="1" EXTENSION_INPUT="" bash "${ROOT_DIR}/scripts/setup/install-extension.sh" >/dev/null


### PR DESCRIPTION
## Summary
- Refresh every extension declared in `homeboy.json` before running `install-for-component`, so cached configured extensions cannot survive upstream fixes.
- Report monorepo-extracted extension revisions from `.source-revision`, not only `.git`, so CI comments expose the actual installed extension SHA.
- Add shell coverage for configured-extension refresh and revision metadata reporting.

Closes #184.

## Tests
- `bash scripts/setup/test-install-extension.sh`
- `bash scripts/setup/test-capture-tooling-metadata.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed stale configured-extension refresh behavior from Data Machine CI logs, implemented the setup-script fix, and added regression coverage. Chris reviewed and directed immediate merge.
