### PR TITLE
fix(setup): scan all release assets

### DIFF
--- a/scripts/setup/resolve-homeboy-version.sh
+++ b/scripts/setup/resolve-homeboy-version.sh
@@ -52,13 +52,19 @@ wait_for_asset() {
 previous_release_with_asset() {
   local current_tag="$1"
   local archive="$2"
-  local tag asset
+  local tag assets asset
 
-  while IFS=$'\t' read -r tag asset; do
-    if [ "${tag}" != "${current_tag}" ] && [ "${asset}" = "${archive}" ]; then
-      printf '%s' "${tag}"
-      return 0
+  while IFS=$'\t' read -r tag assets; do
+    if [ "${tag}" = "${current_tag}" ]; then
+      continue
     fi
+
+    for asset in ${assets//$'\t'/ }; do
+      if [ "${asset}" = "${archive}" ]; then
+        printf '%s' "${tag}"
+        return 0
+      fi
+    done
   done < <(gh api "repos/${REPO}/releases?per_page=20" --jq '.[] | [.tag_name, (.assets[].name)] | @tsv' 2>/dev/null || true)
 
   return 1

--- a/scripts/setup/test-resolve-homeboy-version.sh
+++ b/scripts/setup/test-resolve-homeboy-version.sh
@@ -127,7 +127,7 @@ mkdir -p "${TMPDIR}/state-fallback"
 FAKE_STATE_DIR="${TMPDIR}/state-fallback" \
 FAKE_LATEST_TAG="v0.122.0" \
 FAKE_ASSETS_v0_122_0="" \
-FAKE_RELEASE_ROWS="v0.122.0${TAB}other-platform.tar.xz"$'\n'"v0.121.0${TAB}${ARCHIVE}"$'\n' \
+FAKE_RELEASE_ROWS="v0.122.0${TAB}other-platform.tar.xz"$'\n'"v0.121.0${TAB}other-platform.tar.xz${TAB}${ARCHIVE}"$'\n' \
 run_resolver "latest" "${GITHUB_OUTPUT_FILE}" "${LOG_FILE}"
 assert_equals "resolved-version=0.121.0" "$(cat "${GITHUB_OUTPUT_FILE}")" "latest falls back to previous release with asset"
 assert_contains "falling back to 0.121.0" "${LOG_FILE}" "fallback is visible in logs"


### PR DESCRIPTION
## Summary
- Fix latest-version fallback scanning so it checks every asset on each release row, not just the first asset.
- Cover the regression with a multi-asset release row where the required platform archive is not first.

## Tests
- `bash scripts/setup/test-resolve-homeboy-version.sh`
- `for test_script in scripts/setup/test-*.sh; do bash "$test_script"; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Homeboy Action release failure after PR #185, implemented the resolver fallback fix, and added regression coverage. Chris directed immediate merge to unblock Data Machine CI.
