### PR TITLE
fix(digest): prioritize audit PR blockers

### DIFF
--- a/scripts/digest/fixtures/audit-comment-quality-expected.md
+++ b/scripts/digest/fixtures/audit-comment-quality-expected.md
@@ -1,18 +1,17 @@
-:x: **3 new finding(s) on this PR:**
+:x: **3 PR blockers**
 
 1. **docs** — Broken file reference `scripts/build/build.sh` (line 19) — target does not exist (`docs::runner::build`)
 2. **docs** — Broken file reference `scripts/lint/lint-runner.sh` (line 17) — target does not exist (`docs::runner::lint`)
 3. **docs** — Broken file reference `scripts/test/test-runner.sh` (line 18) — target does not exist (`docs::runner::test`)
 
-_Full audit state below._
-- Alignment score: **0.900**
-- Outliers in current run: **4**
-- Drift increased: **yes**
-- Severity counts: **warning: 3**
-
-<details><summary>Audit findings (6 shown)</summary>
+<details><summary>Audit context</summary>
 
 ```text
+Alignment score: 0.900
+Outliers in current run: 4
+Drift increased: yes
+Severity counts: warning: 3
+Current/contextual findings (6):
 1. **docs/architecture/runner-contract.md** — broken_doc_reference — Broken file reference `scripts/build/build.sh` (line 19) — target does not exist
 2. **docs/architecture/runner-contract.md** — broken_doc_reference — Broken file reference `scripts/lint/lint-runner.sh` (line 17) — target does not exist
 3. **docs/architecture/runner-contract.md** — broken_doc_reference — Broken file reference `scripts/test/test-runner.sh` (line 18) — target does not exist

--- a/scripts/digest/render-command-summary.py
+++ b/scripts/digest/render-command-summary.py
@@ -350,27 +350,28 @@ def markdown_audit(data: dict[str, Any], lines: list[str]) -> None:
     conventions = data.get("conventions", []) if isinstance(data, dict) else []
 
     new_items = baseline.get("new_items", []) if isinstance(baseline, dict) else []
-    if isinstance(new_items, list) and new_items:
-        lines.append(f":x: **{len(new_items)} new finding(s) on this PR:**")
+    has_new_items = isinstance(new_items, list) and bool(new_items)
+    if has_new_items:
+        plural = "s" if len(new_items) != 1 else ""
+        lines.append(f":x: **{len(new_items)} PR blocker{plural}**")
         lines.append("")
         for idx, item in enumerate(new_items[:5], start=1):
             if isinstance(item, dict):
                 lines.append(f"{idx}. {format_new_audit_item(item)}")
         if len(new_items) > 5:
             lines.append(f"... and {len(new_items) - 5} more")
-        lines.append("")
-        lines.append("_Full audit state below._")
 
+    audit_context_lines: list[str] = []
     alignment = summary.get("alignment_score") if isinstance(summary, dict) else None
     if isinstance(alignment, (int, float)):
-        lines.append(f"- Alignment score: **{alignment:.3f}**")
+        audit_context_lines.append(f"Alignment score: {alignment:.3f}")
 
     outliers = summary.get("outliers_found") if isinstance(summary, dict) else None
     if isinstance(outliers, int):
-        lines.append(f"- Outliers in current run: **{outliers}**")
+        audit_context_lines.append(f"Outliers in current run: {outliers}")
 
     drift = baseline.get("drift_increased", False) if isinstance(baseline, dict) else False
-    lines.append(f"- Drift increased: **{'yes' if drift else 'no'}**")
+    audit_context_lines.append(f"Drift increased: {'yes' if drift else 'no'}")
 
     # Collect outlier items from conventions
     outlier_items: list[dict[str, Any]] = []
@@ -404,7 +405,7 @@ def markdown_audit(data: dict[str, Any], lines: list[str]) -> None:
         known_counts = {k: v for k, v in severity_counts.items() if k != "unknown"}
         if known_counts:
             sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(known_counts.items()))
-            lines.append(f"- Severity counts: **{sev_text}**")
+            audit_context_lines.append(f"Severity counts: {sev_text}")
 
     if top_findings:
         detail_lines: list[str] = []
@@ -416,12 +417,19 @@ def markdown_audit(data: dict[str, Any], lines: list[str]) -> None:
             if message:
                 detail += f" — {message}"
             detail_lines.append(detail)
-        if len(top_findings) <= 5:
+        if has_new_items:
+            audit_context_lines.append("")
+            audit_context_lines.append(f"Current/contextual findings ({len(top_findings)}):")
+            audit_context_lines.extend(detail_lines)
+        elif len(top_findings) <= 5:
             lines.append("- Actionable findings:")
             for line in detail_lines:
                 lines.append(f"  {line}")
         else:
             append_details(lines, f"Audit findings ({min(len(top_findings), 10)} shown)", detail_lines)
+
+    if has_new_items:
+        append_details(lines, "Audit context", audit_context_lines)
 
 
 def markdown_refactor(data: dict[str, Any], lines: list[str]) -> None:

--- a/scripts/digest/render.py
+++ b/scripts/digest/render.py
@@ -185,32 +185,33 @@ def render_markdown(
         lines.append("### Audit Failure Digest")
         new_findings = audit_digest.get("new_findings", []) or []
         new_findings_count = audit_digest.get("new_findings_count", 0)
+        has_new_findings = isinstance(new_findings_count, int) and new_findings_count > 0
         if isinstance(new_findings_count, int) and new_findings_count > 0:
-            lines.append(f":x: **{new_findings_count} new finding(s) on this PR:**")
+            plural = "s" if new_findings_count != 1 else ""
+            lines.append(f":x: **{new_findings_count} PR blocker{plural}**")
             lines.append("")
             for idx, finding in enumerate(new_findings[:5], start=1):
                 lines.append(f"{idx}. {_format_new_audit_finding(finding)}")
             if new_findings_count > 5:
                 lines.append(f"... and {new_findings_count - 5} more")
-            lines.append("")
-            lines.append("_Full audit state below._")
 
+        audit_context_lines: list[str] = []
         alignment_score = audit_digest.get("alignment_score")
         if isinstance(alignment_score, (int, float)):
-            lines.append(f"- Alignment score: **{alignment_score:.3f}**")
+            audit_context_lines.append(f"Alignment score: {alignment_score:.3f}")
         severity_counts = audit_digest.get("severity_counts", {}) or {}
         if severity_counts:
             known_counts = {k: v for k, v in severity_counts.items() if str(k).lower() != "unknown"}
             if known_counts:
                 sev_text = ", ".join(f"{k}: {v}" for k, v in sorted(known_counts.items()))
-                lines.append(f"- Severity counts: **{sev_text}**")
+                audit_context_lines.append(f"Severity counts: {sev_text}")
         outliers = audit_digest.get("outliers_found")
         if isinstance(outliers, int):
-            lines.append(f"- Outliers in current run: **{outliers}**")
+            audit_context_lines.append(f"Outliers in current run: {outliers}")
         parsed_outliers = audit_digest.get("parsed_outlier_items")
         if isinstance(parsed_outliers, int) and parsed_outliers > 0:
-            lines.append(f"- Parsed outlier entries: **{parsed_outliers}**")
-        lines.append(f"- Drift increased: **{'yes' if audit_digest.get('drift_increased') else 'no'}**")
+            audit_context_lines.append(f"Parsed outlier entries: {parsed_outliers}")
+        audit_context_lines.append(f"Drift increased: {'yes' if audit_digest.get('drift_increased') else 'no'}")
 
         top_findings = audit_digest.get("top_findings", []) or []
         if top_findings:
@@ -225,14 +226,23 @@ def render_markdown(
                 detail_lines.append(
                     f"_Truncated to {max_full_findings} findings to avoid oversized PR comments ({len(top_findings)} total parsed)._"
                 )
-            if len(top_findings) <= 5:
+            if has_new_findings:
+                audit_context_lines.append("")
+                audit_context_lines.append(f"Current/contextual findings ({len(top_findings)}):")
+                audit_context_lines.extend(detail_lines)
+            elif len(top_findings) <= 5:
                 lines.append("- Actionable findings:")
                 for line in detail_lines:
                     lines.append(f"  {line}")
             else:
                 _append_details_block(lines, f"Audit findings ({len(top_findings)})", detail_lines)
+        elif has_new_findings:
+            audit_context_lines.append("No structured current/contextual audit findings available.")
         else:
             lines.append("- No structured audit findings available.")
+
+        if has_new_findings:
+            _append_details_block(lines, "Audit context", audit_context_lines)
 
         raw_excerpt = [str(line) for line in (audit_digest.get("raw_excerpt", []) or [])]
         if raw_excerpt:

--- a/scripts/digest/test-comment-quality-render.py
+++ b/scripts/digest/test-comment-quality-render.py
@@ -43,7 +43,9 @@ def main() -> int:
     assert_equal(audit, expected_audit, "audit markdown")
     assert_not_contains(audit, "Top actionable findings", "duplicated top findings heading")
     assert_not_contains(audit, "unknown:", "unknown severity count")
-    assert_contains(audit, ":x: **3 new finding(s) on this PR:**", "promoted delta block")
+    assert_contains(audit, ":x: **3 PR blockers**", "promoted delta block")
+    assert_contains(audit, "<details><summary>Audit context</summary>", "collapsed audit context")
+    assert_not_contains(audit, "- Alignment score:", "primary audit alignment noise")
 
     refactor = render("refactor --from all", "refactor-noop-input.json")
     expected_refactor = (FIXTURES / "refactor-noop-expected.md").read_text(encoding="utf-8").strip()
@@ -91,10 +93,12 @@ def main() -> int:
         results={"audit": "fail"},
     )
     assert_contains(full_digest, "**TL;DR:** :x: audit (3 new)", "failure digest TL;DR")
-    assert_contains(full_digest, ":x: **3 new finding(s) on this PR:**", "failure digest delta promotion")
-    assert_contains(full_digest, "<details><summary>Audit findings (6)</summary>", "deduped details block")
+    assert_contains(full_digest, ":x: **3 PR blockers**", "failure digest delta promotion")
+    assert_contains(full_digest, "<details><summary>Audit context</summary>", "collapsed audit context")
+    assert_contains(full_digest, "Current/contextual findings (6):", "contextual findings label")
     assert_not_contains(full_digest, "Top actionable findings", "failure digest duplicated top list")
     assert_not_contains(full_digest, "unknown:", "failure digest unknown severity")
+    assert_not_contains(full_digest, "- Alignment score:", "failure digest primary audit alignment noise")
 
     test_digest = render_markdown(
         lint_digest={},


### PR DESCRIPTION
## Summary
- Render introduced audit findings as the primary PR-blocker section when baseline comparison reports new findings.
- Move alignment score, severity counts, drift metadata, and current/contextual findings into a collapsed audit context block.
- Update digest rendering coverage to assert the delta-first audit shape while preserving lint/test failure coverage.

## Tests
- `python3 scripts/digest/test-comment-quality-render.py`
- `python3 scripts/digest/test-audit-comment-render.py` (skips locally because the optional real audit log fixture is unavailable)

Closes #188

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** implementing and testing the delta-first failure digest under Chris's direction.