### PR TITLE
fix(pr-comment): suppress failed-test text for passing runs

### DIFF
--- a/scripts/digest/fixtures/test-passing-zero-failures-input.json
+++ b/scripts/digest/fixtures/test-passing-zero-failures-input.json
@@ -1,0 +1,16 @@
+{
+  "success": true,
+  "data": {
+    "passed": true,
+    "status": "passed",
+    "component": "block-format-bridge",
+    "exit_code": 0,
+    "test_counts": {
+      "total": 12,
+      "passed": 12,
+      "failed": 0,
+      "skipped": 0
+    },
+    "failed_tests": []
+  }
+}

--- a/scripts/digest/render-command-summary.py
+++ b/scripts/digest/render-command-summary.py
@@ -293,6 +293,18 @@ def summarize_test_failure(item: dict[str, Any], idx: int) -> str:
     return " — ".join(parts)
 
 
+def is_successful_test_run(data: dict[str, Any]) -> bool:
+    status = str(data.get("status") or "").strip().lower()
+    exit_code = data.get("exit_code")
+    passed = data.get("passed")
+
+    if passed is True:
+        return exit_code in {0, "0", None}
+    if status in {"pass", "passed", "success", "succeeded"}:
+        return exit_code in {0, "0", None}
+    return False
+
+
 def markdown_lint(data: dict[str, Any], lines: list[str]) -> None:
     if data.get("summary"):
         lines.append(f"- Lint summary: **{data['summary']}**")
@@ -315,6 +327,8 @@ def markdown_test(data: dict[str, Any], lines: list[str]) -> None:
 
     if failed_count > 0:
         lines.append(f"- Failed tests: **{failed_count}**")
+    elif is_successful_test_run(data):
+        return
     else:
         lines.append("- Test command failed, but structured output reported **0 failed test cases**.")
         status = str(data.get("status") or "").strip()

--- a/scripts/digest/render.py
+++ b/scripts/digest/render.py
@@ -67,6 +67,14 @@ def _summarize_test_failure(test: dict[str, Any], idx: int) -> str:
     return " — ".join(parts)
 
 
+def _is_successful_test_run(test_digest: dict[str, Any]) -> bool:
+    status = str(test_digest.get("status") or "").strip().lower()
+    exit_code = test_digest.get("exit_code")
+    if status in {"pass", "passed", "success", "succeeded"}:
+        return exit_code in {0, "0", None}
+    return False
+
+
 def _resolve_job_link(job_links: dict[str, str], run_url: str, *candidates: str) -> str:
     for candidate in candidates:
         if candidate in job_links:
@@ -145,6 +153,8 @@ def render_markdown(
         failed_count = int(test_digest.get("failed_tests_count", 0) or 0)
         if failed_count > 0:
             lines.append(f"- Failed tests: **{failed_count}**")
+        elif str(results.get("test", "")).strip().lower() == "pass" and _is_successful_test_run(test_digest):
+            pass
         else:
             lines.append("- Test command failed, but structured output reported **0 failed test cases**.")
             status = str(test_digest.get("status") or "").strip()

--- a/scripts/digest/test-comment-quality-render.py
+++ b/scripts/digest/test-comment-quality-render.py
@@ -61,6 +61,11 @@ def main() -> int:
     assert_contains(tooling_failure, "runner/tooling failure", "test failure classification")
     assert_not_contains(tooling_failure, "Failed tests: **0**", "misleading zero failed tests line")
 
+    passing_tests = render("test", "test-passing-zero-failures-input.json")
+    assert_equal(passing_tests, "", "passing zero-failure test markdown")
+    assert_not_contains(passing_tests, "Test command failed", "passing test command failure explanation")
+    assert_not_contains(passing_tests, "runner/tooling failure", "passing test failure classification")
+
     bench = render("bench", "bench-summary-input.json")
     assert_contains(bench, "Benchmark scenarios: **1**", "bench scenario count")
     assert_contains(bench, "pipeline-scale: p50 120.50, p95 141.25", "bench primary metrics")
@@ -117,6 +122,25 @@ def main() -> int:
     assert_contains(test_digest, "runner/tooling failure", "digest test failure classification")
     assert_contains(test_digest, "<details><summary>Raw test failure excerpt</summary>", "digest raw log excerpt")
     assert_not_contains(test_digest, "Failed tests: **0**", "digest misleading zero failed tests line")
+
+    passing_digest = render_markdown(
+        lint_digest={},
+        test_digest={
+            "failed_tests_count": 0,
+            "top_failed_tests": [],
+            "raw_excerpt": [],
+            "status": "passed",
+            "exit_code": 0,
+        },
+        audit_digest={},
+        autofixability={"overall": "none", "autofix_enabled": False, "autofix_attempted": False},
+        run_url="https://github.com/Extra-Chill/homeboy/actions/runs/1",
+        tooling={},
+        job_links={},
+        results={"test": "pass"},
+    )
+    assert_not_contains(passing_digest, "Test command failed", "passing digest command failure explanation")
+    assert_not_contains(passing_digest, "runner/tooling failure", "passing digest failure classification")
 
     print("comment quality rendering checks passed")
     return 0


### PR DESCRIPTION
## Summary
- Suppress the zero-failed-tests runner/tooling failure copy when structured test output reports a successful run.
- Preserve the existing runner/tooling failure diagnostics for failed, unknown, or malformed zero-failure test results.
- Add a passing zero-failure fixture and assertions for both command-summary and digest rendering paths.

## Tests
- `python3 scripts/digest/test-comment-quality-render.py`
- `bash scripts/pr/comment/test-unknown-status-rendering.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`

Closes #190

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing the passing-test PR comment fix under Chris's direction.