### PR TITLE
fix(pr-comment): skip green no-op comments

### DIFF
--- a/scripts/pr/comment/lib.sh
+++ b/scripts/pr/comment/lib.sh
@@ -161,3 +161,118 @@ is_refactor_owning_section() {
 
   return 1
 }
+
+command_is_selected() {
+  local command="$1"
+  local selected
+
+  IFS=',' read -ra selected <<< "${COMMANDS:-}"
+  for item in "${selected[@]}"; do
+    item="$(echo "${item}" | xargs)"
+    if [ "${item}" = "${command}" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+autofix_has_actionable_content() {
+  if ! is_refactor_owning_section; then
+    return 1
+  fi
+
+  [ "${AUTOFIX_ENABLED:-false}" = "true" ] || return 1
+
+  if [ "${AUTOFIX_COMMITTED:-}" = "true" ]; then
+    return 0
+  fi
+
+  case "${AUTOFIX_STATUS:-}" in
+    push-failed|skipped-head-bot-author)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+commands_have_actionable_status() {
+  local selected command status
+
+  IFS=',' read -ra selected <<< "${COMMANDS:-}"
+  for command in "${selected[@]}"; do
+    command="$(echo "${command}" | xargs)"
+    [ -n "${command}" ] || continue
+
+    status="$(command_status "${command}")"
+    if [ "${status}" != "pass" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+scope_has_actionable_content() {
+  if is_scoped; then
+    return 0
+  fi
+
+  if command_is_selected "test" && [ "${TEST_SCOPE_EFFECTIVE:-}" = "changed" ]; then
+    return 0
+  fi
+
+  return 1
+}
+
+outputs_have_actionable_content() {
+  local selected command json_file
+
+  IFS=',' read -ra selected <<< "${COMMANDS:-}"
+  for command in "${selected[@]}"; do
+    command="$(echo "${command}" | xargs)"
+    [ -n "${command}" ] || continue
+
+    case "${command}" in
+      bench|release|coverage)
+        return 0
+        ;;
+    esac
+
+    json_file="$(summary_json_for_command "${command}")"
+    if [ "${command}" = "bench" ] && [ -n "${json_file}" ] && [ -f "${json_file}" ]; then
+      return 0
+    fi
+  done
+
+  if [ -n "${DIGEST_FILE:-}" ] && [ -f "${DIGEST_FILE}" ]; then
+    return 0
+  fi
+
+  return 1
+}
+
+comment_has_actionable_content() {
+  if commands_have_actionable_status; then
+    return 0
+  fi
+
+  if autofix_has_actionable_content; then
+    return 0
+  fi
+
+  if [ "${BINARY_SOURCE:-source}" = "fallback" ]; then
+    return 0
+  fi
+
+  if scope_has_actionable_content; then
+    return 0
+  fi
+
+  if outputs_have_actionable_content; then
+    return 0
+  fi
+
+  return 1
+}

--- a/scripts/pr/comment/test-skip-green-noop-comment.sh
+++ b/scripts/pr/comment/test-skip-green-noop-comment.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    printf 'FAIL: %s\nmissing: %s\noutput:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual: %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+FAKE_BIN="${TMP_DIR}/bin"
+mkdir -p "${FAKE_BIN}" "${TMP_DIR}/output"
+
+cat > "${FAKE_BIN}/gh" <<'SH'
+#!/usr/bin/env bash
+printf 'OPEN\n'
+SH
+chmod +x "${FAKE_BIN}/gh"
+
+cat > "${FAKE_BIN}/homeboy" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${HOMEBOY_CALL_LOG}"
+printf '{"action":"created","data":{"comment_id":123}}\n'
+SH
+chmod +x "${FAKE_BIN}/homeboy"
+
+export PATH="${FAKE_BIN}:${PATH}"
+export GITHUB_ACTION_PATH="${ROOT}"
+export HOMEBOY_OUTPUT_DIR="${TMP_DIR}/output"
+export HOMEBOY_CALL_LOG="${TMP_DIR}/homeboy.log"
+export GITHUB_ENV="${TMP_DIR}/github.env"
+export GITHUB_REPOSITORY="Extra-Chill/homeboy-action"
+export GITHUB_WORKFLOW="Homeboy"
+export GITHUB_JOB="homeboy"
+export GH_TOKEN="app-token"
+export PR_NUMBER="191"
+export COMPONENT_NAME="homeboy-action"
+export COMMANDS="audit"
+export AUTOFIX_ENABLED="false"
+export AUTOFIX_COMMITTED="false"
+export AUTOFIX_ATTEMPTED="false"
+export AUTOFIX_STATUS=""
+export BINARY_SOURCE="source"
+export SCOPE_MODE="full"
+export TEST_SCOPE_EFFECTIVE="full"
+export HOMEBOY_CLI_VERSION="homeboy 1.2.3"
+export HOMEBOY_EXTENSION_ID="auto"
+export HOMEBOY_EXTENSION_SOURCE="auto"
+export HOMEBOY_EXTENSION_REVISION="abc1234"
+export HOMEBOY_ACTION_REPOSITORY="Extra-Chill/homeboy-action"
+export HOMEBOY_ACTION_REF="fix-skip-green-noop-comments"
+
+run_post_comment() {
+  : > "${HOMEBOY_CALL_LOG}"
+  : > "${GITHUB_ENV}"
+  bash "${ROOT}/scripts/pr/post-pr-comment.sh"
+}
+
+output="$(RESULTS='{"audit":"pass"}' run_post_comment)"
+assert_contains "${output}" "Skipping PR comment — run passed with no actionable content" "clean run is skipped"
+assert_equals "" "$(cat "${HOMEBOY_CALL_LOG}")" "clean run does not call homeboy comment primitive"
+
+output="$(RESULTS='{"audit":"fail"}' run_post_comment)"
+assert_contains "${output}" "PR comment posted successfully" "failed run comments"
+assert_equals "2" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "failed run posts section and tooling"
+
+export COMMANDS="refactor"
+export AUTOFIX_ENABLED="true"
+export AUTOFIX_COMMITTED="true"
+output="$(RESULTS='{"refactor":"pass"}' run_post_comment)"
+assert_contains "${output}" "PR comment posted successfully" "autofix-applied run comments"
+assert_equals "2" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "autofix-applied run posts section and tooling"
+
+export COMMANDS="audit"
+export AUTOFIX_ENABLED="false"
+export AUTOFIX_COMMITTED="false"
+output="$(RESULTS='{"audit":"mystery"}' run_post_comment)"
+assert_contains "${output}" "PR comment posted successfully" "unknown-status run comments"
+assert_equals "2" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "unknown-status run posts section and tooling"
+
+printf 'All green no-op PR comment checks passed.\n'

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -56,6 +56,11 @@ HEADER="## Homeboy Results — \`${COMP_ID}\`"
 # stays at the bottom of the comment.
 SECTION_ORDER="lint,build,test,audit,bench,tooling"
 
+if ! comment_has_actionable_content; then
+  echo "Skipping PR comment — run passed with no actionable content"
+  exit 0
+fi
+
 build_section_body
 
 SECTION_FILE="$(mktemp)"


### PR DESCRIPTION
## Summary
- Skip posting or refreshing the shared Homeboy PR comment when all selected commands passed and no actionable note needs surfacing.
- Keep comments for failures, warning/unknown statuses, autofix outcomes, scoped-run caveats, and benchmark/release/coverage-style actionable output.
- Add shell coverage proving clean runs do not call the PR comment primitive while failure, autofix-applied, and unknown-status runs still comment.

## Tests
- `for test_script in scripts/pr/comment/test-*.sh; do bash "${test_script}"; done`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`
- `bash -n scripts/pr/comment/lib.sh scripts/pr/comment/sections.sh scripts/pr/post-pr-comment.sh scripts/pr/comment/test-skip-green-noop-comment.sh`

Could not run `homeboy lint homeboy-action --path /Users/chubes/Developer/homeboy-action@fix-skip-green-noop-comments --changed-since origin/main` because this component currently has no lint extension configured.

Closes #191

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5 / openai/gpt-5.5)
- **Used for:** implementing and testing green no-op comment suppression under Chris's direction.
