### PR TITLE
fix(digest): render finding-level fixability

### DIFF
--- a/scripts/digest/build-failure-digest.py
+++ b/scripts/digest/build-failure-digest.py
@@ -29,6 +29,7 @@ def derive_fixable_commands(
     commands_csv: str,
     autofix_commands_csv: str,
 ) -> set[str]:
+    _ = commands_csv
     if autofix_commands_csv.strip():
         out: set[str] = set()
         for raw in autofix_commands_csv.split(","):
@@ -36,13 +37,7 @@ def derive_fixable_commands(
             if token:
                 out.add(token)
         return out
-
-    defaults: set[str] = set()
-    for raw in commands_csv.split(","):
-        cmd = raw.strip().lower()
-        if cmd in {"lint", "test", "audit"}:
-            defaults.add(cmd)
-    return defaults
+    return set()
 
 
 def classify_autofixability(
@@ -51,6 +46,7 @@ def classify_autofixability(
     autofix_enabled: bool,
     autofix_attempted: bool,
     autofix_commands_csv: str,
+    audit_digest: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     failed_commands = sorted(
         [str(cmd) for cmd, status in results.items() if isinstance(cmd, str) and status == "fail"]
@@ -74,10 +70,16 @@ def classify_autofixability(
         else:
             human_needed_failed.append(cmd)
 
-    if failed_commands and auto_fixable_failed and not human_needed_failed:
+    finding_fixability = []
+    if isinstance(audit_digest, dict):
+        raw_finding_fixability = audit_digest.get("finding_fixability", [])
+        if isinstance(raw_finding_fixability, list):
+            finding_fixability = raw_finding_fixability
+
+    if failed_commands and finding_fixability and autofix_enabled and not autofix_attempted:
         overall = "auto_fixable"
-    elif failed_commands and auto_fixable_failed and human_needed_failed:
-        overall = "mixed"
+    elif failed_commands and finding_fixability and (not autofix_enabled or autofix_attempted):
+        overall = "human_needed"
     elif failed_commands:
         overall = "human_needed"
     else:
@@ -92,6 +94,7 @@ def classify_autofixability(
         "auto_fixable_failed_commands": auto_fixable_failed,
         "potential_auto_fixable_failed_commands": potential_auto_fixable_failed,
         "human_needed_failed_commands": human_needed_failed,
+        "finding_fixability": finding_fixability,
         "overall": overall,
     }
 
@@ -241,6 +244,15 @@ def build_audit_digest_from_json(payload: dict[str, Any]) -> dict[str, Any]:
             "suggested_fix": str(item.get("suggested_fix") or item.get("suggestion") or ""),
         })
 
+    fixability = data.get("fixability") if isinstance(data, dict) else None
+    if not isinstance(fixability, dict) and isinstance(data.get("summary"), dict):
+        fixability = data["summary"].get("fixability")
+    finding_fixability = build_audit_finding_fixability(
+        fixability if isinstance(fixability, dict) else {},
+        top_findings,
+        data,
+    )
+
     return {
         "drift_increased": bool(baseline.get("drift_increased", False)),
         "new_findings_count": len(new_findings),
@@ -250,8 +262,42 @@ def build_audit_digest_from_json(payload: dict[str, Any]) -> dict[str, Any]:
         "parsed_outlier_items": len(outlier_items),
         "severity_counts": severity_counts,
         "top_findings": top_findings[:500],
+        "finding_fixability": finding_fixability,
         "raw_excerpt": [],
     }
+
+
+def build_audit_finding_fixability(
+    fixability: dict[str, Any],
+    findings: list[dict[str, str]],
+    data: dict[str, Any],
+) -> list[dict[str, Any]]:
+    by_kind = fixability.get("by_kind") if isinstance(fixability, dict) else None
+    if not isinstance(by_kind, dict):
+        return []
+
+    component_id = str(data.get("component_id") or data.get("id") or "homeboy")
+    details: list[dict[str, Any]] = []
+    for kind, raw_breakdown in sorted(by_kind.items()):
+        if not isinstance(raw_breakdown, dict):
+            continue
+        automated = int(raw_breakdown.get("automated", 0) or 0)
+        if automated <= 0:
+            continue
+        kind_key = str(kind)
+        files = sorted({
+            str(finding.get("file") or "unknown")
+            for finding in findings
+            if str(finding.get("rule") or "") == kind_key and str(finding.get("file") or "")
+        })
+        details.append({
+            "type": kind_key,
+            "automated": automated,
+            "total": int(raw_breakdown.get("total", automated) or automated),
+            "files": files,
+            "command": f"homeboy refactor {component_id} --from audit --write --changed-since=<base>",
+        })
+    return details
 
 
 def resolve_failed_job_links(run_url: str) -> dict[str, str]:
@@ -411,6 +457,7 @@ def main() -> int:
         autofix_enabled,
         autofix_attempted,
         autofix_commands_csv,
+        audit_digest,
     )
 
     md_path = os.path.join(output_dir, "homeboy-failure-digest.md")

--- a/scripts/digest/render.py
+++ b/scripts/digest/render.py
@@ -25,6 +25,37 @@ def _format_new_audit_finding(finding: dict[str, Any]) -> str:
     return line
 
 
+def _append_finding_fixability(lines: list[str], autofixability: dict[str, Any]) -> None:
+    details = autofixability.get("finding_fixability", []) or []
+    if not details:
+        failed_commands = autofixability.get("failed_commands", []) or []
+        if "audit" in [str(cmd).strip().lower() for cmd in failed_commands]:
+            lines.append("- No finding-level automated fix details available in this run.")
+            lines.append("- Automated fix: not available")
+        return
+
+    lines.append("- Finding-level automated fixes:")
+    for detail in details:
+        if not isinstance(detail, dict):
+            continue
+        fix_type = str(detail.get("type") or "unknown")
+        command = str(detail.get("command") or "").strip()
+        files = [str(file) for file in (detail.get("files", []) or []) if str(file)]
+        lines.append("  - Automated fix available:")
+        lines.append(f"    - Fix type: `{fix_type}`")
+        if files:
+            if len(files) == 1:
+                lines.append(f"    - Affected file: `{files[0]}`")
+            else:
+                lines.append("    - Affected files:")
+                for file in files[:10]:
+                    lines.append(f"      - `{file}`")
+                if len(files) > 10:
+                    lines.append(f"      - ... and {len(files) - 10} more")
+        if command:
+            lines.append(f"    - Command: `{command}`")
+
+
 def _status_summary(results: dict[str, Any], audit_digest: dict[str, Any]) -> str:
     parts: list[str] = []
     ordered_commands = [cmd for cmd in ["lint", "test", "audit", "refactor"] if cmd in results]
@@ -271,20 +302,12 @@ def render_markdown(
         f"- Autofix attempted this run: **{'yes' if autofixability.get('autofix_attempted') else 'no'}**"
     )
 
-    fixable = autofixability.get("auto_fixable_failed_commands", []) or []
-    potential_fixable_failed = (
-        autofixability.get("potential_auto_fixable_failed_commands", []) or []
-    )
     human = autofixability.get("human_needed_failed_commands", []) or []
-    if fixable:
-        lines.append("- Auto-fixable failed commands:")
-        for cmd in fixable:
-            lines.append(f"  - `{cmd}`")
     if human:
         lines.append("- Human-needed failed commands:")
         for cmd in human:
             lines.append(f"  - `{cmd}`")
-    if not fixable and not human:
+    if not human:
         failed_commands = autofixability.get("failed_commands", []) or []
         if failed_commands:
             lines.append("- Failed commands:")
@@ -293,22 +316,13 @@ def render_markdown(
         else:
             lines.append("- No failed commands to classify.")
 
-    if potential_fixable_failed:
-        lines.append("- Failed commands with available automated fixes:")
-        for cmd in potential_fixable_failed:
-            lines.append(f"  - `{cmd}`")
+    _append_finding_fixability(lines, autofixability)
 
     if not autofixability.get("autofix_enabled"):
-        potential_candidates = autofixability.get("potential_fixable_candidates", []) or []
-        if potential_candidates:
-            lines.append(
-                "- Automated fixes are **disabled for this step**. Commands with available fix support in this run: "
-                + ", ".join(f"`{cmd}`" for cmd in potential_candidates)
-            )
+        if autofixability.get("finding_fixability"):
+            lines.append("- Automated fixes are **disabled for this step**; finding-level fix details are shown for review only.")
         else:
-            lines.append(
-                "- Automated fixes are **disabled for this step** and no fix-capable commands were detected."
-            )
+            lines.append("- Automated fixes are **disabled for this step** and no finding-level automated fix details were detected.")
     lines.append("")
 
     lines.append("### Machine-readable artifacts")

--- a/scripts/digest/test-comment-quality-render.py
+++ b/scripts/digest/test-comment-quality-render.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import importlib.util
 from pathlib import Path
 
 
@@ -13,6 +14,17 @@ RENDERER = ROOT / "scripts/digest/render-command-summary.py"
 sys.path.insert(0, str(ROOT / "scripts/digest"))
 
 from render import render_markdown  # noqa: E402
+
+BUILD_DIGEST_SPEC = importlib.util.spec_from_file_location(
+    "build_failure_digest",
+    ROOT / "scripts/digest/build-failure-digest.py",
+)
+if BUILD_DIGEST_SPEC is None or BUILD_DIGEST_SPEC.loader is None:
+    raise RuntimeError("could not load build-failure-digest.py")
+build_failure_digest = importlib.util.module_from_spec(BUILD_DIGEST_SPEC)
+BUILD_DIGEST_SPEC.loader.exec_module(build_failure_digest)
+build_audit_digest_from_json = build_failure_digest.build_audit_digest_from_json
+classify_autofixability = build_failure_digest.classify_autofixability
 
 
 def assert_equal(actual: str, expected: str, label: str) -> None:
@@ -91,7 +103,12 @@ def main() -> int:
                 for idx in range(6)
             ],
         },
-        autofixability={"overall": "human_needed", "autofix_enabled": False, "autofix_attempted": False},
+        autofixability={
+            "overall": "human_needed",
+            "autofix_enabled": False,
+            "autofix_attempted": False,
+            "failed_commands": ["audit"],
+        },
         run_url="https://github.com/Extra-Chill/homeboy/actions/runs/1",
         tooling={},
         job_links={},
@@ -104,6 +121,110 @@ def main() -> int:
     assert_not_contains(full_digest, "Top actionable findings", "failure digest duplicated top list")
     assert_not_contains(full_digest, "unknown:", "failure digest unknown severity")
     assert_not_contains(full_digest, "- Alignment score:", "failure digest primary audit alignment noise")
+    assert_contains(full_digest, "No finding-level automated fix details available in this run.", "unknown audit fixability note")
+    assert_contains(full_digest, "Automated fix: not available", "unknown audit unavailable fixability")
+    assert_not_contains(full_digest, "Failed commands with available automated fixes", "generic command-level fixability")
+
+    command_only_fixability = classify_autofixability(
+        {"audit": "fail"},
+        "audit",
+        True,
+        False,
+        "audit",
+        {"finding_fixability": []},
+    )
+    command_only_digest = render_markdown(
+        lint_digest={},
+        test_digest={},
+        audit_digest={},
+        autofixability=command_only_fixability,
+        run_url="https://github.com/Extra-Chill/homeboy/actions/runs/1",
+        tooling={},
+        job_links={},
+        results={"audit": "fail"},
+    )
+    assert_contains(command_only_digest, "Overall: **human_needed**", "command-only fixability overall")
+    assert_contains(command_only_digest, "No finding-level automated fix details available in this run.", "command-only unknown fixability note")
+    assert_not_contains(command_only_digest, "Auto-fixable failed commands", "command-only auto-fixable commands")
+    assert_not_contains(command_only_digest, "Failed commands with available automated fixes", "command-only generic fixability heading")
+
+    audit_payload_with_fixability = {
+        "success": False,
+        "data": {
+            "command": "audit",
+            "component_id": "homeboy",
+            "baseline_comparison": {"drift_increased": True, "new_items": []},
+            "summary": {"alignment_score": 0.9},
+            "findings": [
+                {
+                    "file": "docs/architecture/ci-results-contract.md",
+                    "kind": "broken_doc_reference",
+                    "description": "Broken file reference `scripts/missing.sh`",
+                    "severity": "warning",
+                }
+            ],
+            "fixability": {
+                "fixable_count": 1,
+                "automated_count": 1,
+                "manual_only_count": 0,
+                "by_kind": {
+                    "broken_doc_reference": {"total": 1, "automated": 1, "manual_only": 0}
+                },
+            },
+        },
+    }
+    audit_digest = build_audit_digest_from_json(audit_payload_with_fixability)
+    autofixability = classify_autofixability(
+        {"audit": "fail"},
+        "audit",
+        True,
+        False,
+        "",
+        audit_digest,
+    )
+    finding_fix_digest = render_markdown(
+        lint_digest={},
+        test_digest={},
+        audit_digest=audit_digest,
+        autofixability=autofixability,
+        run_url="https://github.com/Extra-Chill/homeboy/actions/runs/1",
+        tooling={},
+        job_links={},
+        results={"audit": "fail"},
+    )
+    assert_contains(finding_fix_digest, "Finding-level automated fixes:", "finding-level fixability heading")
+    assert_contains(finding_fix_digest, "Fix type: `broken_doc_reference`", "finding fix type")
+    assert_contains(finding_fix_digest, "Affected file: `docs/architecture/ci-results-contract.md`", "finding fix file")
+    assert_contains(
+        finding_fix_digest,
+        "Command: `homeboy refactor homeboy --from audit --write --changed-since=<base>`",
+        "finding fix command",
+    )
+    assert_not_contains(finding_fix_digest, "Failed commands with available automated fixes", "no generic fixability heading with concrete data")
+
+    autofix_disabled_digest = render_markdown(
+        lint_digest={},
+        test_digest={},
+        audit_digest=audit_digest,
+        autofixability=classify_autofixability(
+            {"audit": "fail"},
+            "audit",
+            False,
+            False,
+            "",
+            audit_digest,
+        ),
+        run_url="https://github.com/Extra-Chill/homeboy/actions/runs/1",
+        tooling={},
+        job_links={},
+        results={"audit": "fail"},
+    )
+    assert_contains(
+        autofix_disabled_digest,
+        "Automated fixes are **disabled for this step**; finding-level fix details are shown for review only.",
+        "disabled autofix finding-level note",
+    )
+    assert_not_contains(autofix_disabled_digest, "Commands with available fix support", "disabled generic command fixability")
 
     test_digest = render_markdown(
         lint_digest={},


### PR DESCRIPTION
## Summary
- Replaces command-name autofix defaults with finding-level audit fixability when `fixability.by_kind` is available.
- Renders unknown audit fixability honestly instead of claiming generic `audit` fixes are actionable.
- Covers concrete finding-level audit fixes, command-only fixability, and autofix-disabled rendering in the digest smoke tests.

## Tests
- `python3 scripts/digest/test-comment-quality-render.py`
- `python3 scripts/digest/test-audit-comment-render.py` (skips: real audit log fixture not available)
- `python3 -m py_compile scripts/digest/build-failure-digest.py scripts/digest/render.py scripts/digest/test-comment-quality-render.py`

Closes #189

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing finding-level fixability rendering under Chris's direction.
