### PR TITLE
fix(autofix): report detailed PR fix summaries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -493,6 +493,8 @@ runs:
         AUTOFIX_FILE_COUNT: ${{ steps.autofix-prepare-nonpr.outputs.autofix-file-count }}
         AUTOFIX_FIX_TYPES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-fix-types }}
         AUTOFIX_FINDING_TYPES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-finding-types }}
+        AUTOFIX_CHANGED_FILES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-changed-files }}
+        AUTOFIX_REPORT: ${{ steps.autofix-prepare-nonpr.outputs.autofix-report }}
       run: bash ${{ github.action_path }}/scripts/autofix/open-autofix-pr.sh
 
     # ── Phase 7: Results and reporting ──

--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -161,6 +161,7 @@ commit_autofix_changes() {
   AUTOFIX_CHANGED_FILES="$(git diff --cached --name-only | sort)"
   AUTOFIX_FIX_TYPES=""
   AUTOFIX_FINDING_TYPES=""
+  AUTOFIX_REPORT=""
 
   for FIX_CMD in "${FIX_ARRAY[@]}"; do
     FIX_CMD=$(echo "${FIX_CMD}" | xargs)
@@ -184,6 +185,7 @@ commit_autofix_changes() {
       AUTOFIX_TOTAL_FIXES="$(echo "${raw_details}" | head -1)"
       AUTOFIX_DETAILS="$(echo "${raw_details}" | tail -n +2)"
     fi
+    AUTOFIX_REPORT="$(extract_fix_report_from_output "${details_dir}")"
   fi
 
   COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_DETAILS}" "${AUTOFIX_TOTAL_FIXES}")"
@@ -282,6 +284,8 @@ if push_autofix_commit; then
   echo "target-branch=${TARGET_BRANCH}" >> "${GITHUB_OUTPUT}"
   echo "autofix-file-count=${AUTOFIX_FILE_COUNT}" >> "${GITHUB_OUTPUT}"
   echo "autofix-fix-types=${AUTOFIX_FIX_TYPES}" >> "${GITHUB_OUTPUT}"
+  write_multiline_output "autofix-changed-files" "${AUTOFIX_CHANGED_FILES:-}"
+  write_multiline_output "autofix-report" "${AUTOFIX_REPORT:-}"
   exit 0
 fi
 
@@ -292,3 +296,5 @@ echo "target-repo=${TARGET_REPO}" >> "${GITHUB_OUTPUT}"
 echo "target-branch=${TARGET_BRANCH}" >> "${GITHUB_OUTPUT}"
 echo "autofix-file-count=${AUTOFIX_FILE_COUNT:-0}" >> "${GITHUB_OUTPUT}"
 echo "autofix-fix-types=${AUTOFIX_FIX_TYPES:-}" >> "${GITHUB_OUTPUT}"
+write_multiline_output "autofix-changed-files" "${AUTOFIX_CHANGED_FILES:-}"
+write_multiline_output "autofix-report" "${AUTOFIX_REPORT:-}"

--- a/scripts/autofix/open-autofix-pr.sh
+++ b/scripts/autofix/open-autofix-pr.sh
@@ -28,30 +28,7 @@ TITLE="chore(ci): autofix ${COMP_ID} from ${BASE_BRANCH}"
 BODY_FILE="$(mktemp)"
 trap 'rm -f "${BODY_FILE}"' EXIT
 
-AUTOFIX_DETAIL=""
-if [ -n "${AUTOFIX_FILE_COUNT:-}" ] && [ -n "${AUTOFIX_FIX_TYPES:-}" ]; then
-  AUTOFIX_DETAIL="- **${AUTOFIX_FILE_COUNT}** file(s) fixed via **${AUTOFIX_FIX_TYPES}**"
-elif [ -n "${AUTOFIX_FILE_COUNT:-}" ]; then
-  AUTOFIX_DETAIL="- **${AUTOFIX_FILE_COUNT}** file(s) fixed"
-fi
-
-FINDING_DETAIL=""
-if [ -n "${AUTOFIX_FINDING_TYPES:-}" ]; then
-  FINDING_DETAIL="- **Finding categories:** ${AUTOFIX_FINDING_TYPES}"
-fi
-
-cat > "${BODY_FILE}" <<EOF
-## Summary
-${AUTOFIX_DETAIL:+${AUTOFIX_DETAIL}
-}${FINDING_DETAIL:+${FINDING_DETAIL}
-}- Opened immediately after autofix without rerunning quality gates.
-- Generated automatically by Homeboy Action.
-
-## Context
-- Workflow run: ${RUN_URL}
-- Branch: ${AUTOFIX_BRANCH}
-- Base: ${BASE_BRANCH}
-EOF
+build_autofix_pr_body "${RUN_URL}" "${AUTOFIX_BRANCH}" "${BASE_BRANCH}" > "${BODY_FILE}"
 
 # Find an existing open PR for (base, head). `homeboy git pr find` emits typed
 # JSON with a stable shape regardless of `gh` version; jq extracts the first

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -126,6 +126,7 @@ fi
 
 # Capture autofix summary: file count, fix commands, and finding categories
 AUTOFIX_FILE_COUNT=$(git diff --cached --name-only | wc -l | xargs)
+AUTOFIX_CHANGED_FILES="$(git diff --cached --name-only | sort)"
 
 AUTOFIX_FIX_TYPES=""
 for FIX_CMD in "${FIX_ARRAY[@]}"; do
@@ -139,12 +140,14 @@ done
 
 AUTOFIX_DETAILS=""
 AUTOFIX_TOTAL_FIXES=""
+AUTOFIX_REPORT=""
 if [ -d "${AUTOFIX_OUTPUT_DIR}" ]; then
   raw_details="$(extract_fix_details_from_output "${AUTOFIX_OUTPUT_DIR}")"
   if [ -n "${raw_details}" ]; then
     AUTOFIX_TOTAL_FIXES="$(echo "${raw_details}" | head -1)"
     AUTOFIX_DETAILS="$(echo "${raw_details}" | tail -n +2)"
   fi
+  AUTOFIX_REPORT="$(extract_fix_report_from_output "${AUTOFIX_OUTPUT_DIR}")"
 fi
 
 COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_DETAILS}" "${AUTOFIX_TOTAL_FIXES}")"
@@ -179,3 +182,5 @@ echo "autofix-branch=${AUTOFIX_BRANCH}" >> "${GITHUB_OUTPUT}"
 echo "autofix-file-count=${AUTOFIX_FILE_COUNT}" >> "${GITHUB_OUTPUT}"
 echo "autofix-fix-types=${AUTOFIX_FIX_TYPES:-}" >> "${GITHUB_OUTPUT}"
 echo "autofix-finding-types=${AUTOFIX_FINDING_TYPES:-}" >> "${GITHUB_OUTPUT}"
+write_multiline_output "autofix-changed-files" "${AUTOFIX_CHANGED_FILES:-}"
+write_multiline_output "autofix-report" "${AUTOFIX_REPORT:-}"

--- a/scripts/autofix/test-open-autofix-pr-report.sh
+++ b/scripts/autofix/test-open-autofix-pr-report.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    printf 'FAIL: %s\nmissing: %s\nbody:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    printf 'FAIL: %s\nunexpected: %s\nbody:\n%s\n' "${label}" "${needle}" "${haystack}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+FAKE_BIN="${TMP_DIR}/bin"
+mkdir -p "${FAKE_BIN}"
+
+cat > "${FAKE_BIN}/homeboy" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+body_file=""
+is_find="false"
+is_edit="false"
+is_create="false"
+for arg in "$@"; do
+  [ "${arg}" = "find" ] && is_find="true"
+  [ "${arg}" = "edit" ] && is_edit="true"
+  [ "${arg}" = "create" ] && is_create="true"
+done
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --body-file)
+      body_file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ "${is_find}" = "true" ]; then
+  printf '{"data":{"items":[]}}\n'
+elif [ "${is_create}" = "true" ] || [ "${is_edit}" = "true" ]; then
+  cp "${body_file}" "${BODY_CAPTURE}"
+  printf '{"data":{"url":"https://github.com/Extra-Chill/homeboy-action/pull/99"}}\n'
+fi
+SH
+chmod +x "${FAKE_BIN}/homeboy"
+
+cat > "${FAKE_BIN}/gh" <<'SH'
+#!/usr/bin/env bash
+printf 'main\n'
+SH
+chmod +x "${FAKE_BIN}/gh"
+
+export PATH="${FAKE_BIN}:${PATH}"
+export GITHUB_ACTION_PATH="${ROOT}"
+export GITHUB_REPOSITORY="Extra-Chill/homeboy-action"
+export GITHUB_REF="refs/heads/main"
+export GITHUB_SERVER_URL="https://github.com"
+export GITHUB_RUN_ID="12345"
+export COMPONENT_NAME="homeboy-action"
+export AUTOFIX_BRANCH="ci/autofix/homeboy-action/main"
+export GITHUB_OUTPUT="${TMP_DIR}/github-output"
+
+source "${ROOT}/scripts/core/lib.sh"
+
+OUTPUT_DIR="${TMP_DIR}/homeboy-output"
+mkdir -p "${OUTPUT_DIR}"
+cat > "${OUTPUT_DIR}/fix.json" <<'JSON'
+{
+  "data": {
+    "collected_edits": [
+      { "rule_id": "broken_doc_reference", "file": "docs/architecture/ci-results-contract.md" }
+    ]
+  }
+}
+JSON
+
+SOURCE_REPORT="$(extract_fix_report_from_output "${OUTPUT_DIR}")"
+
+BODY_CAPTURE="${TMP_DIR}/source-create.md"
+export BODY_CAPTURE
+export HOMEBOY_PR_MODE="create"
+export AUTOFIX_FILE_COUNT="2"
+export AUTOFIX_CHANGED_FILES=$'docs/architecture/ci-results-contract.md\nhomeboy.json'
+export AUTOFIX_REPORT="${SOURCE_REPORT}"
+
+bash "${ROOT}/scripts/autofix/open-autofix-pr.sh" >/tmp/homeboy-action-test-source.log
+SOURCE_BODY="$(<"${BODY_CAPTURE}")"
+
+assert_contains "${SOURCE_BODY}" 'Fixed **1** `broken_doc_reference` finding.' "source summary includes finding type"
+assert_contains "${SOURCE_BODY}" 'Changed **2** files.' "source summary includes changed file count"
+assert_contains "${SOURCE_BODY}" '| `broken_doc_reference` | 1 | `docs/architecture/ci-results-contract.md` |' "source table includes category/count/file"
+assert_contains "${SOURCE_BODY}" '- `homeboy.json` audit baseline metadata was refreshed.' "source report separates baseline churn"
+assert_contains "${SOURCE_BODY}" '- Workflow run: https://github.com/Extra-Chill/homeboy-action/actions/runs/12345' "verification includes workflow run"
+assert_not_contains "${SOURCE_BODY}" 'file(s) fixed via' "source report omits generic old summary"
+
+BODY_CAPTURE="${TMP_DIR}/baseline-create.md"
+export BODY_CAPTURE
+export AUTOFIX_FILE_COUNT="1"
+export AUTOFIX_CHANGED_FILES="homeboy.json"
+export AUTOFIX_REPORT=""
+
+bash "${ROOT}/scripts/autofix/open-autofix-pr.sh" >/tmp/homeboy-action-test-baseline.log
+BASELINE_BODY="$(<"${BODY_CAPTURE}")"
+
+assert_contains "${BASELINE_BODY}" 'No source fixes were reported by the autofix output.' "baseline-only summary is explicit"
+assert_contains "${BASELINE_BODY}" 'Changed **1** files.' "baseline-only summary includes changed count"
+assert_contains "${BASELINE_BODY}" '- `homeboy.json` audit baseline metadata was refreshed.' "baseline-only report names metadata refresh"
+assert_not_contains "${BASELINE_BODY}" '## Automated Fixes' "baseline-only report does not invent source fixes"
+
+BODY_CAPTURE="${TMP_DIR}/source-edit.md"
+export BODY_CAPTURE
+export HOMEBOY_PR_MODE="find-existing"
+export AUTOFIX_FILE_COUNT="1"
+export AUTOFIX_CHANGED_FILES="docs/architecture/ci-results-contract.md"
+export AUTOFIX_REPORT="${SOURCE_REPORT}"
+
+cat > "${FAKE_BIN}/homeboy" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+body_file=""
+is_edit="false"
+for arg in "$@"; do
+  [ "${arg}" = "edit" ] && is_edit="true"
+done
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --body-file)
+      body_file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ "${is_edit}" = "true" ]; then
+  cp "${body_file}" "${BODY_CAPTURE}"
+  printf '{"data":{"url":"https://github.com/Extra-Chill/homeboy-action/pull/42"}}\n'
+else
+  printf '{"data":{"items":[{"number":42,"url":"https://github.com/Extra-Chill/homeboy-action/pull/42"}]}}\n'
+fi
+SH
+chmod +x "${FAKE_BIN}/homeboy"
+
+EDIT_LOG="$(bash "${ROOT}/scripts/autofix/open-autofix-pr.sh")"
+EDIT_BODY="$(<"${BODY_CAPTURE}")"
+
+assert_contains "${EDIT_LOG}" 'Updated PR #42 body with latest run context' "existing PR update path edits body"
+assert_contains "${EDIT_BODY}" '| `broken_doc_reference` | 1 | `docs/architecture/ci-results-contract.md` |' "existing PR body gets rich report"
+
+printf 'All autofix PR report checks passed.\n'

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -193,6 +193,175 @@ extract_fix_details_from_output() {
   ' ${json_files} 2>/dev/null || true
 }
 
+# Extract machine-readable autofix rows from homeboy JSON output files.
+# Format: finding_type<TAB>count<TAB>comma-separated affected files.
+extract_fix_report_from_output() {
+  local output_dir="$1"
+
+  local json_files
+  json_files=$(find "${output_dir}" -name '*.json' -type f 2>/dev/null)
+  if [ -z "${json_files}" ]; then
+    return
+  fi
+
+  # shellcheck disable=SC2086
+  jq -rsr '
+    [.[] | .data // . ] | map(select(type == "object")) |
+
+    def category:
+      if type == "string" then .
+      elif type == "object" then (keys[0] // "unknown")
+      else "unknown"
+      end;
+
+    [.[].fixes // [] | .[] | .file as $file |
+      .insertions[]? | {cat: (.kind | category), file: $file}
+    ] as $insertions |
+    [.[].new_files // [] | .[] | {cat: .finding, file}] as $new_files |
+    [.[].proposals // [] | .[] | {cat: .rule_id, file}] as $proposals |
+    [.[].collected_edits // [] | .[] | {cat: .rule_id, file}] as $collected_edits |
+    [.[].decompose_plans // [] | .[] | {cat: .source_finding, file}] as $decompose |
+
+    ($insertions + $new_files + $proposals + $collected_edits + $decompose) |
+    group_by(.cat) |
+    map({
+      cat: .[0].cat,
+      count: length,
+      files: ([.[].file] | unique | sort)
+    }) |
+    sort_by(-.count, .cat) |
+    .[] |
+    [.cat, (.count | tostring), (.files | join(", "))] | @tsv
+  ' ${json_files} 2>/dev/null || true
+}
+
+write_multiline_output() {
+  local key="$1"
+  local value="${2:-}"
+  local marker="__HOMEBOY_${key}_$(date +%s%N)__"
+
+  {
+    printf '%s<<%s\n' "${key}" "${marker}"
+    printf '%s\n' "${value}"
+    printf '%s\n' "${marker}"
+  } >> "${GITHUB_OUTPUT}"
+}
+
+autofix_changed_files_list() {
+  printf '%s\n' "${AUTOFIX_CHANGED_FILES:-}" | sed '/^[[:space:]]*$/d' | sort -u
+}
+
+autofix_source_files_from_report() {
+  printf '%s\n' "${AUTOFIX_REPORT:-}" | awk -F '\t' 'NF >= 3 { print $3 }' |
+    tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | sed '/^$/d' | sort -u
+}
+
+autofix_other_files() {
+  local changed tmp_changed tmp_source
+  tmp_changed="$(mktemp)"
+  tmp_source="$(mktemp)"
+  autofix_changed_files_list > "${tmp_changed}"
+  autofix_source_files_from_report > "${tmp_source}"
+  changed="$(comm -23 "${tmp_changed}" "${tmp_source}" || true)"
+  rm -f "${tmp_changed}" "${tmp_source}"
+  printf '%s\n' "${changed}" | sed '/^[[:space:]]*$/d'
+}
+
+autofix_count_report_rows() {
+  printf '%s\n' "${AUTOFIX_REPORT:-}" | sed '/^[[:space:]]*$/d' | wc -l | xargs
+}
+
+autofix_total_report_fixes() {
+  printf '%s\n' "${AUTOFIX_REPORT:-}" | awk -F '\t' 'NF >= 2 { total += $2 } END { print total + 0 }'
+}
+
+autofix_markdown_file_list() {
+  local files="$1"
+  local rendered=""
+  local file
+  while IFS= read -r file; do
+    [ -n "${file}" ] || continue
+    if [ -n "${rendered}" ]; then
+      rendered+=" "
+    fi
+    rendered+="\`${file}\`"
+  done <<< "$(printf '%s\n' "${files}" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | sed '/^$/d')"
+  printf '%s\n' "${rendered}"
+}
+
+autofix_render_other_change() {
+  local file="$1"
+  case "${file}" in
+    homeboy.json)
+      printf '%s\n' '- `homeboy.json` audit baseline metadata was refreshed.'
+      ;;
+    *.json|*.yml|*.yaml|*.toml|*.lock)
+      printf '%s\n' "- \`${file}\` configuration or metadata was refreshed."
+      ;;
+    *)
+      printf '%s\n' "- \`${file}\` changed outside the reported source-fix set."
+      ;;
+  esac
+}
+
+build_autofix_pr_body() {
+  local run_url="$1"
+  local branch="$2"
+  local base_branch="$3"
+
+  local changed_count="${AUTOFIX_FILE_COUNT:-0}"
+  local total_fixes row_count
+  total_fixes="$(autofix_total_report_fixes)"
+  row_count="$(autofix_count_report_rows)"
+
+  printf '## Summary\n'
+  if [ "${total_fixes}" != "0" ]; then
+    local label="finding"
+    [ "${total_fixes}" = "1" ] || label="findings"
+    if [ "${row_count}" = "1" ]; then
+      local only_type
+      only_type="$(printf '%s\n' "${AUTOFIX_REPORT}" | awk -F '\t' 'NF >= 1 { print $1; exit }')"
+      printf -- '- Fixed **%s** `%s` %s.\n' "${total_fixes}" "${only_type}" "${label}"
+    else
+      printf -- '- Fixed **%s** source %s across **%s** finding types.\n' "${total_fixes}" "${label}" "${row_count}"
+    fi
+  else
+    printf -- '- No source fixes were reported by the autofix output.\n'
+  fi
+  printf -- '- Changed **%s** files.\n\n' "${changed_count}"
+
+  if [ "${total_fixes}" != "0" ]; then
+    printf '## Automated Fixes\n'
+    printf '| Finding type | Count | Files |\n'
+    printf '|---|---:|---|\n'
+    while IFS=$'\t' read -r cat count files; do
+      [ -n "${cat}" ] || continue
+      printf '| `%s` | %s | %s |\n' "${cat}" "${count}" "$(autofix_markdown_file_list "${files}")"
+    done <<< "${AUTOFIX_REPORT}"
+    printf '\n'
+  fi
+
+  local other_files
+  other_files="$(autofix_other_files)"
+  if [ -n "${other_files}" ]; then
+    printf '## Other Changes\n'
+    while IFS= read -r file; do
+      [ -n "${file}" ] || continue
+      autofix_render_other_change "${file}"
+    done <<< "${other_files}"
+    printf '\n'
+  fi
+
+  printf '## Verification\n'
+  printf -- '- Opened immediately after autofix without rerunning quality gates.\n'
+  printf -- '- Workflow run: %s\n\n' "${run_url}"
+
+  printf '## Context\n'
+  printf -- '- Branch: %s\n' "${branch}"
+  printf -- '- Base: %s\n' "${base_branch}"
+  printf -- '- Generated automatically by Homeboy Action.\n'
+}
+
 resolve_component_id() {
   if [ -n "${COMPONENT_NAME:-}" ]; then
     printf '%s\n' "${COMPONENT_NAME}"


### PR DESCRIPTION
## Summary
- Replace generic autofix PR summaries with structured reports grouped by finding type, count, and affected files.
- Carry JSON-derived autofix details and changed files through step outputs so create and update PR paths render the same body.
- Explicitly report baseline/config-only autofix branches as metadata churn instead of pretending source fixes occurred.

## Tests
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`
- `bash -n scripts/core/lib.sh scripts/autofix/open-autofix-pr.sh scripts/autofix/apply-autofix-commit.sh scripts/autofix/prepare-autofix-branch.sh scripts/autofix/test-open-autofix-pr-report.sh`

Closes #187

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementing and testing the autofix PR body report improvement under Chris's direction.
