### PR TITLE
refactor(pr-comment): delegate rendering to homeboy review

### DIFF
--- a/scripts/pr/comment/lib.sh
+++ b/scripts/pr/comment/lib.sh
@@ -2,12 +2,6 @@
 
 set -euo pipefail
 
-render_structured_summary() {
-  local command="$1"
-  local json_file="$2"
-  python3 "${GITHUB_ACTION_PATH}/scripts/digest/render-command-summary.py" "${command}" "${json_file}" markdown 2>/dev/null || true
-}
-
 derive_comment_key() {
   if [ -n "${COMMENT_KEY_INPUT:-}" ]; then
     printf '%s\n' "${COMMENT_KEY_INPUT}"
@@ -90,50 +84,6 @@ summary_json_for_command() {
 command_status() {
   local command="$1"
   echo "${RESULTS}" | jq -r --arg cmd "${command}" 'if .[$cmd] == "pass" or .[$cmd] == "fail" then .[$cmd] else "unknown" end' 2>/dev/null || echo "unknown"
-}
-
-command_icon() {
-  local status="$1"
-  case "${status}" in
-    pass)
-      printf '%s\n' "white_check_mark"
-      ;;
-    fail)
-      printf '%s\n' "x"
-      ;;
-    *)
-      printf '%s\n' "warning"
-      ;;
-  esac
-}
-
-command_status_note() {
-  local command="$1"
-  local status="$2"
-
-  if [ "${status}" = "unknown" ]; then
-    printf '%s\n' "- Could not parse a pass/fail result for ${command}; check the action logs or result artifact."
-  fi
-}
-
-digest_covers_command() {
-  local command="$1"
-
-  if [ "${HAS_DIGEST:-false}" != "true" ]; then
-    return 1
-  fi
-
-  case "${command}" in
-    audit|lint|test)
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-
-  local status
-  status="$(command_status "${command}")"
-  [ "${status}" = "fail" ]
 }
 
 is_refactor_owning_section() {

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -5,58 +5,6 @@ set -euo pipefail
 source "${GITHUB_ACTION_PATH}/scripts/scope/context.sh"
 source "${GITHUB_ACTION_PATH}/scripts/pr/comment/lib.sh"
 
-append_autofix_section() {
-  if ! is_refactor_owning_section; then
-    return 0
-  fi
-
-  if [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_COMMITTED:-}" = "true" ]; then
-    local autofix_summary=":wrench: **Autofix applied**"
-    if [ -n "${AUTOFIX_FILE_COUNT:-}" ] && [ -n "${AUTOFIX_FIX_TYPES:-}" ]; then
-      autofix_summary+=" — ${AUTOFIX_FILE_COUNT} file(s) fixed via ${AUTOFIX_FIX_TYPES}"
-    elif [ -n "${AUTOFIX_FILE_COUNT:-}" ]; then
-      autofix_summary+=" — ${AUTOFIX_FILE_COUNT} file(s) fixed"
-    fi
-    SECTION_BODY+="> ${autofix_summary}"$'\n\n'
-  elif [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_ATTEMPTED:-false}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "push-failed" ]; then
-    SECTION_BODY+="> :warning: Autofix generated changes but could not push them back to **${AUTOFIX_TARGET_REPO:-${REPO}}:${AUTOFIX_TARGET_BRANCH:-unknown}**"$'\n\n'
-  elif [ "${AUTOFIX_ENABLED}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "skipped-head-bot-author" ]; then
-    SECTION_BODY+="> :information_source: Autofix skipped — PR head is already a **homeboy-ci[bot]** commit, so PR autofix only runs after human commits"$'\n\n'
-  fi
-}
-
-append_binary_source_section() {
-  if [ "${BINARY_SOURCE}" = "fallback" ]; then
-    SECTION_BODY+="> :warning: **Source build failed** — results from fallback release binary"$'\n\n'
-  fi
-}
-
-append_digest_section() {
-  HAS_DIGEST="false"
-  if [ -n "${DIGEST_FILE}" ] && [ -f "${DIGEST_FILE}" ]; then
-    HAS_DIGEST="true"
-    SECTION_BODY+="$(cat "${DIGEST_FILE}")"$'\n\n'
-  fi
-}
-
-append_scope_section() {
-  if is_scoped; then
-    SECTION_BODY+="> :zap: Scope: **changed files only**"$'\n\n'
-  elif [ "$(scope_context)" = "pr" ] && [ "${SCOPE_MODE:-full}" = "full" ]; then
-    SECTION_BODY+="> :information_source: Scope resolved to **full**"$'\n\n'
-  fi
-}
-
-append_test_scope_section() {
-  if [[ ",${COMMANDS}," == *",test,"* ]] || [[ "${COMMANDS}" == "test" ]]; then
-    if [ "$(scope_context)" = "pr" ] && [ "${SCOPE_MODE:-full}" = "full" ]; then
-      SECTION_BODY+="> :information_source: PR test scope: **full**"$'\n\n'
-    elif [ "${TEST_SCOPE_EFFECTIVE:-}" = "changed" ]; then
-      SECTION_BODY+="> :zap: PR test scope: **changed** (files affected by this PR)"$'\n\n'
-    fi
-  fi
-}
-
 commands_use_review_report() {
   local normalized
   normalized="$(canonicalize_commands "${COMMANDS}")"
@@ -64,27 +12,65 @@ commands_use_review_report() {
   [ "${normalized}" = "audit,lint,test" ] && [ -z "${EXTRA_ARGS:-}" ]
 }
 
-append_review_report_section() {
-  if ! commands_use_review_report; then
-    return 1
+add_review_banner() {
+  local key="$1"
+  local value="$2"
+
+  [ -n "${value}" ] || return 0
+  REVIEW_CMD+=(--banner "${key}=${value}")
+}
+
+append_review_banner_args() {
+  if [ "${AUTOFIX_ENABLED:-false}" = "true" ] && [ "${AUTOFIX_COMMITTED:-}" = "true" ]; then
+    local autofix_summary="applied"
+    if [ -n "${AUTOFIX_FILE_COUNT:-}" ] && [ -n "${AUTOFIX_FIX_TYPES:-}" ]; then
+      autofix_summary+=" — ${AUTOFIX_FILE_COUNT} file(s) fixed via ${AUTOFIX_FIX_TYPES}"
+    elif [ -n "${AUTOFIX_FILE_COUNT:-}" ]; then
+      autofix_summary+=" — ${AUTOFIX_FILE_COUNT} file(s) fixed"
+    fi
+    add_review_banner "autofix" "${autofix_summary}"
+  elif [ "${AUTOFIX_ENABLED:-false}" = "true" ] && [ "${AUTOFIX_ATTEMPTED:-false}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "push-failed" ]; then
+    add_review_banner "autofix" "generated changes but could not push them back to ${AUTOFIX_TARGET_REPO:-${REPO}}:${AUTOFIX_TARGET_BRANCH:-unknown}"
+  elif [ "${AUTOFIX_ENABLED:-false}" = "true" ] && [ "${AUTOFIX_STATUS:-}" = "skipped-head-bot-author" ]; then
+    add_review_banner "autofix" "skipped — PR head is already a homeboy-ci[bot] commit, so PR autofix only runs after human commits"
   fi
 
-  local review_cmd review_md review_exit
-  review_cmd="$(build_review_report_command "${COMP_ID}" "${WORKSPACE}")"
+  if [ "${BINARY_SOURCE:-source}" = "fallback" ]; then
+    add_review_banner "binary-source" "fallback release binary (source build failed)"
+  fi
+}
+
+append_review_report_section() {
+  if ! commands_use_review_report; then
+    SECTION_BODY+="> :warning: Homeboy core PR-comment rendering currently supports the default \`audit,lint,test\` review report only. Check the action logs for \`${COMMANDS}\`."$'\n\n'
+    return 0
+  fi
+
+  local review_md review_exit scope_flags
+  local -a REVIEW_CMD
+  REVIEW_CMD=(homeboy review "${COMP_ID}" --path "${WORKSPACE}" --report=pr-comment)
+
+  scope_flags="$(scope_flags_for "review")"
+  if [ -n "${scope_flags}" ]; then
+    # shellcheck disable=SC2206
+    REVIEW_CMD+=(${scope_flags})
+  fi
+
+  append_review_banner_args
 
   set +e
-  review_md="$(eval "${review_cmd}" 2>/dev/null)"
+  review_md="$("${REVIEW_CMD[@]}" 2>/dev/null)"
   review_exit=$?
   set -e
 
   if [ -z "${review_md}" ]; then
-    echo "::warning::homeboy review did not render a PR-comment report; falling back to command summaries."
-    return 1
+    SECTION_BODY+="> :warning: \`homeboy review --report=pr-comment\` produced no output. Check the action logs for details."$'\n\n'
+    return 0
   fi
 
   if [[ "${review_md}" != *"finding(s) across"* ]]; then
-    echo "::warning::homeboy review output was not a PR-comment report; falling back to command summaries."
-    return 1
+    SECTION_BODY+="> :warning: \`homeboy review --report=pr-comment\` returned an unexpected report shape. Check the action logs for details."$'\n\n'
+    return 0
   fi
 
   SECTION_BODY+="${review_md}"$'\n\n'
@@ -99,49 +85,9 @@ append_review_report_section() {
   return 0
 }
 
-append_command_sections() {
-  IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS}"
-
-  for CMD in "${CMD_ARRAY[@]}"; do
-    CMD=$(echo "${CMD}" | xargs)
-    SUMMARY_JSON="$(summary_json_for_command "${CMD}")"
-    STATUS="$(command_status "${CMD}")"
-    ICON="$(command_icon "${STATUS}")"
-    SCOPE_NOTE="$(scope_note_for "${CMD}")"
-
-    SECTION_BODY+=":${ICON}: **${CMD}**${SCOPE_NOTE}"$'\n'
-
-    if digest_covers_command "${CMD}"; then
-      :
-    elif [ -n "${SUMMARY_JSON}" ] && [ -f "${SUMMARY_JSON}" ]; then
-      SUMMARY_MD="$(render_structured_summary "${CMD}" "${SUMMARY_JSON}")"
-      if [ -n "${SUMMARY_MD}" ]; then
-        SECTION_BODY+="${SUMMARY_MD}"$'\n'
-      fi
-    elif [ "${STATUS}" = "fail" ] && [ "${HAS_DIGEST}" != "true" ]; then
-      SECTION_BODY+="- No structured ${CMD} summary artifact was generated."$'\n'
-    fi
-
-    STATUS_NOTE="$(command_status_note "${CMD}" "${STATUS}")"
-    if [ -n "${STATUS_NOTE}" ]; then
-      SECTION_BODY+="${STATUS_NOTE}"$'\n'
-    fi
-
-    SECTION_BODY+=$'\n'
-  done
-}
-
 build_section_body() {
   SECTION_BODY="### ${SECTION_TITLE}"$'\n\n'
-  append_autofix_section
-  append_binary_source_section
-  if append_review_report_section; then
-    return 0
-  fi
-  append_digest_section
-  append_scope_section
-  append_test_scope_section
-  append_command_sections
+  append_review_report_section
 }
 
 # Build the shared `tooling` section body written at the bottom of every

--- a/scripts/pr/comment/test-review-report-section.sh
+++ b/scripts/pr/comment/test-review-report-section.sh
@@ -35,7 +35,10 @@ trap 'rm -rf "${fake_bin}"' EXIT
 
 cat > "${fake_bin}/homeboy" <<'SH'
 #!/usr/bin/env bash
+printf '%s\n' "$*" >> "${HOMEBOY_REVIEW_CALL_LOG}"
 printf ':zap: Scope: **changed files only** (since `origin/main`)\n\n'
+printf '> :wrench: **autofix:** applied — 2 file(s) fixed via lint\n'
+printf '> :warning: **binary-source:** fallback release binary (source build failed)\n\n'
 printf '**2** finding(s) across 2 stage(s)\n\n'
 printf ':x: **audit** — failed (2 finding(s))\n'
 exit 1
@@ -43,14 +46,18 @@ SH
 chmod +x "${fake_bin}/homeboy"
 
 export PATH="${fake_bin}:${PATH}"
+export HOMEBOY_REVIEW_CALL_LOG="${fake_bin}/review.log"
 export GITHUB_ACTION_PATH="${ROOT}"
 export COMMANDS="audit,lint,test"
 export RESULTS='{"audit":"fail","lint":"pass","test":"pass"}'
 export COMP_ID="data-machine"
 export WORKSPACE="/tmp/workspace"
 export SECTION_TITLE="Audit"
-export AUTOFIX_ENABLED="false"
-export BINARY_SOURCE="source"
+export AUTOFIX_ENABLED="true"
+export AUTOFIX_COMMITTED="true"
+export AUTOFIX_FILE_COUNT="2"
+export AUTOFIX_FIX_TYPES="lint"
+export BINARY_SOURCE="fallback"
 export SCOPE_MODE="changed"
 export SCOPE_BASE_REF="origin/main"
 export DIGEST_FILE=""
@@ -64,10 +71,13 @@ assert_contains "${SECTION_BODY}" "### Audit" "section title preserved"
 assert_contains "${SECTION_BODY}" "**2** finding(s) across 2 stage(s)" "review markdown appended"
 assert_contains "${SECTION_BODY}" ":x: **audit** — failed" "review stage markdown appended"
 assert_not_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "legacy per-command audit block skipped"
+assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner autofix=applied — 2 file(s) fixed via lint" "autofix banner passed to core"
+assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner binary-source=fallback release binary (source build failed)" "binary-source banner passed to core"
 
 export EXTRA_ARGS="--format json"
 build_section_body
 
-assert_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "custom args fall back to legacy command blocks"
+assert_contains "${SECTION_BODY}" "core PR-comment rendering currently supports the default" "custom args render unsupported warning"
+assert_not_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "custom args do not fall back to legacy command blocks"
 
 printf 'All review report section checks passed.\n'

--- a/scripts/pr/comment/test-unknown-status-rendering.sh
+++ b/scripts/pr/comment/test-unknown-status-rendering.sh
@@ -30,12 +30,6 @@ assert_not_contains() {
   printf 'PASS: %s\n' "${label}"
 }
 
-render_for_results() {
-  export RESULTS="$1"
-  build_section_body
-  printf '%s\n' "${SECTION_BODY}"
-}
-
 export GITHUB_ACTION_PATH="${ROOT}"
 export COMMANDS="audit"
 export COMP_ID="data-machine"
@@ -49,18 +43,17 @@ export DIGEST_FILE=""
 source "${ROOT}/scripts/core/lib.sh"
 source "${ROOT}/scripts/pr/comment/sections.sh"
 
-body="$(render_for_results '{not-json')"
-assert_contains "${body}" ":warning: **audit**" "malformed results render as warning"
-assert_contains "${body}" "Could not parse a pass/fail result for audit" "malformed results explain parse problem"
-assert_not_contains "${body}" ":x: **audit**" "malformed results do not render as command failure"
+body="$(RESULTS='{not-json' build_section_body; printf '%s\n' "${SECTION_BODY}")"
+assert_contains "${body}" "core PR-comment rendering currently supports the default" "single-command runs use unsupported review warning"
+assert_not_contains "${body}" ":warning: **audit**" "single-command runs do not render legacy warning block"
+assert_not_contains "${body}" "Could not parse a pass/fail result for audit" "single-command runs do not render legacy parse warning"
 
-body="$(render_for_results '{"audit":"mystery"}')"
-assert_contains "${body}" ":warning: **audit**" "unknown status renders as warning"
-assert_contains "${body}" "Could not parse a pass/fail result for audit" "unknown status explains parse problem"
-assert_not_contains "${body}" ":x: **audit**" "unknown status does not render as command failure"
+body="$(RESULTS='{"audit":"mystery"}' build_section_body; printf '%s\n' "${SECTION_BODY}")"
+assert_contains "${body}" "core PR-comment rendering currently supports the default" "unknown single-command status uses unsupported review warning"
+assert_not_contains "${body}" ":warning: **audit**" "unknown status does not render legacy warning block"
 
-body="$(render_for_results '{"audit":"fail"}')"
-assert_contains "${body}" ":x: **audit**" "explicit failure remains failure"
-assert_not_contains "${body}" "Could not parse a pass/fail result for audit" "explicit failure has no parse warning"
+body="$(RESULTS='{"audit":"fail"}' build_section_body; printf '%s\n' "${SECTION_BODY}")"
+assert_contains "${body}" "core PR-comment rendering currently supports the default" "explicit single-command failure uses unsupported review warning"
+assert_not_contains "${body}" ":x: **audit**" "explicit failure does not render legacy command failure"
 
-printf 'All unknown status rendering checks passed.\n'
+printf 'All unsupported single-command rendering checks passed.\n'

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -14,11 +14,12 @@
 #   - idempotency (identical body → noop, no PATCH)
 #   - header preservation across merges
 #
-# This script only handles presentation (body rendering via sections.sh) and
-# two primitive calls: one for this job's section, one for the shared
-# "tooling" section (re-rendered every run so versions stay fresh).
+# This script delegates this job's section body to
+# `homeboy review --report=pr-comment`, then makes two primitive calls: one for
+# this job's section, one for the shared "tooling" section (re-rendered every
+# run so versions stay fresh).
 #
-# Migration tracked in: Extra-Chill/homeboy-action#141.
+# Renderer migration tracked in: Extra-Chill/homeboy-action#144.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Delegate the default `audit,lint,test` PR-comment body to `homeboy review --report=pr-comment` instead of the action-owned per-command shell/Python renderer.
- Pass autofix and binary-source notices through core `--banner` arguments, and remove the PR-comment fallback calls into `render-command-summary.py`.
- Keep non-default/custom command sections explicit as unsupported by the core review renderer rather than recreating the legacy renderer path.

## Tests
- `for test_script in scripts/pr/comment/test-*.sh scripts/core/test-command-builders.sh; do bash "${test_script}"; done`
- `for test_script in scripts/**/*.sh; do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`
- `for test_script in scripts/**/*.py; do case "${test_script}" in */test-*.py) python3 "${test_script}" ;; esac; done`
- `git diff --check`
- `homeboy lint homeboy-action --path /Users/chubes/Developer/homeboy-action` and `homeboy test homeboy-action --path /Users/chubes/Developer/homeboy-action` remain blocked by existing component config: `Component 'homeboy-action' has no extensions configured`.

Closes #144

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the PR-comment renderer migration, updated focused shell tests, and ran verification. Chris remains responsible for review and merge.