### PR TITLE
fix(pr-comment): render split quality sections

### DIFF
--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -42,7 +42,7 @@ append_review_banner_args() {
 
 append_review_report_section() {
   if ! commands_use_review_report; then
-    SECTION_BODY+="> :warning: Homeboy core PR-comment rendering currently supports the default \`audit,lint,test\` review report only. Check the action logs for \`${COMMANDS}\`."$'\n\n'
+    append_split_command_sections
     return 0
   fi
 
@@ -83,6 +83,166 @@ append_review_report_section() {
   fi
 
   return 0
+}
+
+status_icon() {
+  case "$1" in
+    pass|passed) printf '%s\n' ':white_check_mark:' ;;
+    fail|failed) printf '%s\n' ':x:' ;;
+    skipped) printf '%s\n' ':fast_forward:' ;;
+    *) printf '%s\n' ':warning:' ;;
+  esac
+}
+
+status_label() {
+  case "$1" in
+    pass|passed) printf '%s\n' 'passed' ;;
+    fail|failed) printf '%s\n' 'failed' ;;
+    skipped) printf '%s\n' 'skipped' ;;
+    *) printf '%s\n' 'unknown' ;;
+  esac
+}
+
+scope_suffix_for_command() {
+  local command="$1"
+  local scope_flags
+  scope_flags="$(scope_flags_for "${command}")"
+
+  if [ -n "${scope_flags}" ]; then
+    printf ' %s\n' "${scope_flags}"
+  else
+    printf '\n'
+  fi
+}
+
+append_json_hints() {
+  local json_file="$1"
+  local hints
+
+  hints="$(jq -r '(.data.hints // .hints // [])[]?' "${json_file}" 2>/dev/null || true)"
+  [ -n "${hints}" ] || return 0
+
+  while IFS= read -r hint; do
+    [ -n "${hint}" ] || continue
+    SECTION_BODY+="> :information_source: ${hint}"$'\n'
+  done <<< "${hints}"
+}
+
+append_lint_details() {
+  local json_file="$1"
+  local details total
+
+  details="$(jq -r '
+    (.data.lint_findings // .lint_findings // [])
+    | group_by(.category // "lint")
+    | sort_by(-length)
+    | .[:10][]?
+    | "- `" + (.[0].category // "lint") + "` — " + (length|tostring) + " finding(s)"
+  ' "${json_file}" 2>/dev/null || true)"
+  total="$(jq -r '(.data.lint_findings // .lint_findings // []) | length' "${json_file}" 2>/dev/null || printf '0')"
+
+  if [ -n "${details}" ]; then
+    SECTION_BODY+="${details}"$'\n'
+  fi
+  if [ "${total}" != "0" ] && [ "${total}" != "null" ]; then
+    SECTION_BODY+="- _Total: ${total} finding(s)_"$'\n'
+  fi
+}
+
+append_audit_details() {
+  local json_file="$1"
+  local details total
+
+  details="$(jq -r '
+    (.data.baseline_comparison.new_items // .data.findings // .findings // [])
+    | group_by(.context_label // .convention // .kind // "audit")
+    | sort_by(-length)
+    | .[:10][]?
+    | "- **" + (.[0].context_label // .[0].convention // .[0].kind // "audit") + "** — " + (length|tostring) + " finding(s)"
+  ' "${json_file}" 2>/dev/null || true)"
+  total="$(jq -r '
+    if (.data.baseline_comparison.new_items? // null) != null then .data.baseline_comparison.new_items | length
+    elif (.data.findings? // null) != null then .data.findings | length
+    elif (.findings? // null) != null then .findings | length
+    else 0 end
+  ' "${json_file}" 2>/dev/null || printf '0')"
+
+  if [ -n "${details}" ]; then
+    SECTION_BODY+="${details}"$'\n'
+  fi
+  if [ "${total}" != "0" ] && [ "${total}" != "null" ]; then
+    SECTION_BODY+="- _Total: ${total} finding(s)_"$'\n'
+  fi
+}
+
+append_test_details() {
+  local json_file="$1"
+  local details counts failed passed skipped total
+
+  failed="$(jq -r '(.data.test_counts.failed // .test_counts.failed // 0)' "${json_file}" 2>/dev/null || printf '0')"
+  passed="$(jq -r '(.data.test_counts.passed // .test_counts.passed // 0)' "${json_file}" 2>/dev/null || printf '0')"
+  skipped="$(jq -r '(.data.test_counts.skipped // .test_counts.skipped // 0)' "${json_file}" 2>/dev/null || printf '0')"
+  total="$(jq -r '(.data.test_counts.total // .test_counts.total // 0)' "${json_file}" 2>/dev/null || printf '0')"
+
+  if [ "${total}" != "0" ] && [ "${total}" != "null" ]; then
+    if [ "${failed}" != "0" ] && [ "${failed}" != "null" ]; then
+      SECTION_BODY+="- **${failed} failed** out of ${total} total"$'\n'
+    elif [ "${passed}" != "0" ] && [ "${passed}" != "null" ]; then
+      SECTION_BODY+="- ${passed} passed"$'\n'
+    fi
+    if [ "${skipped}" != "0" ] && [ "${skipped}" != "null" ]; then
+      SECTION_BODY+="- ${skipped} skipped"$'\n'
+    fi
+  fi
+
+  details="$(jq -r '(.data.failed_tests // .failed_tests // [])[:10][]? | "- `" + (.name // .test // .case // "test") + "`"' "${json_file}" 2>/dev/null || true)"
+  if [ -n "${details}" ]; then
+    SECTION_BODY+="${details}"$'\n'
+  fi
+}
+
+append_command_details() {
+  local command="$1"
+  local json_file="$2"
+
+  case "${command}" in
+    audit) append_audit_details "${json_file}" ;;
+    lint) append_lint_details "${json_file}" ;;
+    test) append_test_details "${json_file}" ;;
+  esac
+}
+
+append_split_command_section() {
+  local command="$1"
+  local status json_file scope_suffix icon label
+
+  status="$(command_status "${command}")"
+  icon="$(status_icon "${status}")"
+  label="$(status_label "${status}")"
+  json_file="$(summary_json_for_command "${command}")"
+  scope_suffix="$(scope_suffix_for_command "${command}")"
+
+  SECTION_BODY+="${icon} **${command}** — ${label}"$'\n'
+
+  if [ -n "${json_file}" ] && [ -f "${json_file}" ]; then
+    append_command_details "${command}" "${json_file}"
+    append_json_hints "${json_file}"
+  else
+    SECTION_BODY+="> :warning: Structured output for \`${command}\` was not found. Check the action logs for details."$'\n'
+  fi
+
+  SECTION_BODY+="> Deep dive: homeboy ${command} ${COMP_ID}${scope_suffix}"$'\n\n'
+}
+
+append_split_command_sections() {
+  local selected command
+
+  IFS=',' read -ra selected <<< "${COMMANDS:-}"
+  for command in "${selected[@]}"; do
+    command="$(echo "${command}" | xargs)"
+    [ -n "${command}" ] || continue
+    append_split_command_section "${command}"
+  done
 }
 
 build_section_body() {

--- a/scripts/pr/comment/test-review-report-section.sh
+++ b/scripts/pr/comment/test-review-report-section.sh
@@ -77,7 +77,41 @@ assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner binary-source=fa
 export EXTRA_ARGS="--format json"
 build_section_body
 
-assert_contains "${SECTION_BODY}" "core PR-comment rendering currently supports the default" "custom args render unsupported warning"
+assert_contains "${SECTION_BODY}" ":x: **audit** — failed" "custom args render split audit status"
+assert_contains "${SECTION_BODY}" ":white_check_mark: **lint** — passed" "custom args render split lint status"
+assert_contains "${SECTION_BODY}" ":white_check_mark: **test** — passed" "custom args render split test status"
 assert_not_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "custom args do not fall back to legacy command blocks"
+assert_not_contains "${SECTION_BODY}" "core PR-comment rendering currently supports the default" "custom args do not use unsupported warning"
+
+split_output_dir="$(mktemp -d)"
+cat > "${split_output_dir}/lint.json" <<'JSON'
+{
+  "success": false,
+  "data": {
+    "hints": ["Some issues may require manual fixes"],
+    "lint_findings": [
+      {"category":"phpstan","message":"A"},
+      {"category":"phpstan","message":"B"},
+      {"category":"phpcs","message":"C"}
+    ]
+  }
+}
+JSON
+
+export COMMANDS="lint"
+export RESULTS='{"lint":"fail"}'
+export SECTION_TITLE="Lint"
+export OUTPUT_DIR="${split_output_dir}"
+unset EXTRA_ARGS
+build_section_body
+
+assert_contains "${SECTION_BODY}" "### Lint" "split command section title preserved"
+assert_contains "${SECTION_BODY}" ":x: **lint** — failed" "split command failure rendered"
+assert_contains "${SECTION_BODY}" '`phpstan` — 2 finding(s)' "split command phpstan bucket rendered"
+assert_contains "${SECTION_BODY}" '`phpcs` — 1 finding(s)' "split command phpcs bucket rendered"
+assert_contains "${SECTION_BODY}" "_Total: 3 finding(s)_" "split command total rendered"
+assert_contains "${SECTION_BODY}" "Some issues may require manual fixes" "split command hints rendered"
+assert_contains "${SECTION_BODY}" "Deep dive: homeboy lint data-machine --changed-since origin/main" "split command deep dive rendered"
+assert_not_contains "${SECTION_BODY}" "core PR-comment rendering currently supports the default" "split command does not use unsupported warning"
 
 printf 'All review report section checks passed.\n'

--- a/scripts/pr/comment/test-unknown-status-rendering.sh
+++ b/scripts/pr/comment/test-unknown-status-rendering.sh
@@ -39,21 +39,22 @@ export AUTOFIX_ENABLED="false"
 export BINARY_SOURCE="source"
 export SCOPE_MODE="full"
 export DIGEST_FILE=""
+export OUTPUT_DIR=""
 
 source "${ROOT}/scripts/core/lib.sh"
 source "${ROOT}/scripts/pr/comment/sections.sh"
 
 body="$(RESULTS='{not-json' build_section_body; printf '%s\n' "${SECTION_BODY}")"
-assert_contains "${body}" "core PR-comment rendering currently supports the default" "single-command runs use unsupported review warning"
-assert_not_contains "${body}" ":warning: **audit**" "single-command runs do not render legacy warning block"
+assert_contains "${body}" ":warning: **audit** — unknown" "invalid results render unknown status"
+assert_contains "${body}" "Structured output for \`audit\` was not found" "missing audit json warning rendered"
 assert_not_contains "${body}" "Could not parse a pass/fail result for audit" "single-command runs do not render legacy parse warning"
 
 body="$(RESULTS='{"audit":"mystery"}' build_section_body; printf '%s\n' "${SECTION_BODY}")"
-assert_contains "${body}" "core PR-comment rendering currently supports the default" "unknown single-command status uses unsupported review warning"
-assert_not_contains "${body}" ":warning: **audit**" "unknown status does not render legacy warning block"
+assert_contains "${body}" ":warning: **audit** — unknown" "unknown single-command status renders unknown"
+assert_contains "${body}" "Structured output for \`audit\` was not found" "unknown status missing json warning rendered"
 
 body="$(RESULTS='{"audit":"fail"}' build_section_body; printf '%s\n' "${SECTION_BODY}")"
-assert_contains "${body}" "core PR-comment rendering currently supports the default" "explicit single-command failure uses unsupported review warning"
-assert_not_contains "${body}" ":x: **audit**" "explicit failure does not render legacy command failure"
+assert_contains "${body}" ":x: **audit** — failed" "explicit single-command failure renders failure"
+assert_contains "${body}" "Structured output for \`audit\` was not found" "failed status missing json warning rendered"
 
 printf 'All unsupported single-command rendering checks passed.\n'


### PR DESCRIPTION
## Summary
- Render split `audit`, `lint`, and `test` PR-comment sections from each command's structured JSON output.
- Keep the existing `homeboy review --report=pr-comment` path for single-invocation `audit,lint,test` runs.
- Update shell coverage so split command runs no longer regress to the generic unsupported-renderer warning.

## Tests
- `for test_script in scripts/**/*.sh(N); do case "${test_script}" in */test-*.sh) bash "${test_script}" ;; esac; done`
- `homeboy lint homeboy-action --path /Users/chubes/Developer/homeboy-action@fix-split-pr-comment-rendering --changed-since origin/main` attempted, but local Homeboy reports `Component 'homeboy-action' has no extensions configured`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the split-job PR comment renderer gap, drafting the shell changes/tests, and running local verification. Chris reviewed the direction and requested the PR.
