### PR TITLE
Upload Homeboy observation bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Run `homeboy bench` in CI and preserve the raw structured output for downstream 
 
 Bench runs write the exact `homeboy bench --output` payload to `homeboy-ci-results/bench.json`, upload it as the `homeboy-ci-results` artifact, and render a compact PR-summary section when PR comments are enabled.
 
+Homeboy Action also runs `homeboy runs export --since 24h --output homeboy-observations` after command execution and uploads the result as a separate `homeboy-observations` artifact. This export is best-effort: if the current Homeboy version does not support observation export or no observations exist, the CI result is unchanged.
+
+Artifact boundaries:
+
+- `homeboy-ci-results`: immediate structured command outputs used for pass/fail decisions and PR rendering, such as `bench.json`.
+- `homeboy-observations`: persisted Homeboy run history exported for later import/query by agents and other tooling.
+
 #### Continuous release outputs
 
 | Output | Description |
@@ -150,6 +157,7 @@ Use these outputs to gate downstream jobs:
 | `iterations` | No | | Bench iteration count passed to `homeboy bench --iterations` |
 | `regression-threshold` | No | | Bench regression threshold passed to `homeboy bench --regression-threshold` |
 | `differential-gating` | No | `false` | On PRs, compare `audit`/`test` counts against the base SHA and fail only when the PR is worse. Opt-in; `lint` still gates on exit code. PR autofix is skipped while enabled. |
+| `observation-window` | No | `24h` | Duration window passed to best-effort `homeboy runs export --since` for the separate `homeboy-observations` artifact. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |
 | `node-version` | No | | Node.js version (sets up via `actions/setup-node`) |
 | `autofix` | No | `false` | On PR failures, run safe autofixes, commit, push, and re-run checks |

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,10 @@ inputs:
     description: 'On PRs, compare audit/test failure counts against the base SHA and fail only when the PR is worse. Opt-in; lint remains normal exit-code gating. PR autofix is skipped while enabled.'
     required: false
     default: 'false'
+  observation-window:
+    description: 'Duration window to export Homeboy observations after command execution (e.g. "24h", "7d", "30m"). Export is best-effort and non-fatal.'
+    required: false
+    default: '24h'
 
   # ── Environment setup ──
   auto-setup:
@@ -419,6 +423,21 @@ runs:
       with:
         name: homeboy-ci-results
         path: homeboy-ci-results/*.json
+        if-no-files-found: ignore
+
+    - name: Export Homeboy observations
+      if: always() && steps.check-pr-state.outputs.active != 'false' && steps.resolve-commands.outputs.resolved-commands != ''
+      shell: bash
+      env:
+        HOMEBOY_OBSERVATION_WINDOW: ${{ inputs.observation-window }}
+      run: bash ${{ github.action_path }}/scripts/core/export-observations.sh
+
+    - name: Upload Homeboy observations
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: homeboy-observations
+        path: homeboy-observations/**
         if-no-files-found: ignore
 
     - name: Run baseline Homeboy commands

--- a/scripts/core/export-observations.sh
+++ b/scripts/core/export-observations.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
+
+OBSERVATION_WINDOW="${HOMEBOY_OBSERVATION_WINDOW:-24h}"
+OBSERVATION_DIR="${GITHUB_WORKSPACE:-$(pwd)}/homeboy-observations"
+EXPORT_CMD="$(build_observation_export_command "${OBSERVATION_WINDOW}" "${OBSERVATION_DIR}")"
+
+echo "HOMEBOY_OBSERVATIONS_DIR=${OBSERVATION_DIR}" >> "${GITHUB_ENV}"
+
+echo ""
+echo "--------------------------------------------------"
+echo "  Exporting Homeboy observations: ${EXPORT_CMD}"
+echo "--------------------------------------------------"
+echo ""
+
+EXPORT_EXIT=0
+set +e
+eval "${EXPORT_CMD}"
+EXPORT_EXIT=$?
+set -e
+
+if [ "${EXPORT_EXIT}" -ne 0 ]; then
+  echo "::warning::homeboy runs export failed with exit code ${EXPORT_EXIT}; continuing without observation artifact"
+  exit 0
+fi
+
+if [ -d "${OBSERVATION_DIR}" ] && [ -n "$(find "${OBSERVATION_DIR}" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+  echo "::notice::Homeboy observations exported to ${OBSERVATION_DIR}"
+else
+  echo "::notice::No Homeboy observations found for the ${OBSERVATION_WINDOW} export window"
+fi

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -554,6 +554,13 @@ build_review_report_command() {
   printf '%s\n' "${full_cmd}"
 }
 
+build_observation_export_command() {
+  local since_window="$1"
+  local output_dir="$2"
+
+  printf 'homeboy runs export --since %s --output %s\n' "${since_window}" "${output_dir}"
+}
+
 command_output_stem() {
   local cmd="$1"
   local stem

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -159,6 +159,11 @@ assert_equals \
   "$(build_review_report_command "${COMPONENT}" "${WORKSPACE}")" \
   "review report keeps workspace path"
 
+assert_equals \
+  "homeboy runs export --since 24h --output /tmp/workspace/homeboy-observations" \
+  "$(build_observation_export_command "24h" "/tmp/workspace/homeboy-observations")" \
+  "observation export uses separate output directory"
+
 PR_HEAD_REPO="some-contributor/homeboy-action"
 GITHUB_REPOSITORY="Extra-Chill/homeboy-action"
 GITHUB_HEAD_REF="feat/fork-pr"


### PR DESCRIPTION
## Summary
- Exports `homeboy runs export --since <window> --output homeboy-observations` after Homeboy command execution.
- Uploads `homeboy-observations` as a separate best-effort artifact from `homeboy-ci-results`.
- Documents the artifact boundary and adds command-builder coverage for the export command.

Closes #200.

## Tests
- `bash scripts/core/test-command-builders.sh`
- `bash -n scripts/core/export-observations.sh scripts/core/lib.sh`
- Stubbed success/failure smoke tests for `scripts/core/export-observations.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the action/script/docs/test changes; Chris remains responsible for review and merge.