### PR TITLE
fix(release): authenticate Homeboy git pushes

### DIFF
--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -46,6 +46,27 @@ write_output() {
   echo "${key}=${value}" >> "${GITHUB_OUTPUT}"
 }
 
+configure_git_push_auth() {
+  if [ -z "${GH_TOKEN:-}" ]; then
+    return 0
+  fi
+
+  GIT_ASKPASS_SCRIPT="$(mktemp)"
+  chmod 700 "${GIT_ASKPASS_SCRIPT}"
+  cat > "${GIT_ASKPASS_SCRIPT}" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  *Username*) printf '%s\n' 'x-access-token' ;;
+  *Password*) printf '%s\n' "${GH_TOKEN}" ;;
+  *) printf '\n' ;;
+esac
+SH
+
+  export GIT_ASKPASS="${GIT_ASKPASS_SCRIPT}"
+  export GIT_TERMINAL_PROMPT=0
+  trap 'rm -f "${GIT_ASKPASS_SCRIPT:-}"' EXIT
+}
+
 resolve_component_id() {
   if [ -n "${COMPONENT_NAME:-}" ]; then
     echo "${COMPONENT_NAME}"
@@ -87,6 +108,8 @@ write_release_outputs() {
 }
 
 COMP_ID="$(resolve_component_id)"
+
+configure_git_push_auth
 
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 if [ "${CURRENT_BRANCH}" != "${RELEASE_BRANCH}" ]; then

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -48,6 +48,7 @@ assert_not_contains 'path: .release-last-failed' "${WORKFLOW}" "release failure 
 assert_not_contains '< .release-last-failed' "${WORKFLOW}" "release failure marker is not read from checkout"
 assert_not_contains '--no-github-release' "${RUN_RELEASE}" "run-release lets Homeboy core create GitHub Releases"
 assert_contains '--git-identity bot' "${RUN_RELEASE}" "run-release delegates bot identity to Homeboy core"
+assert_contains 'GIT_ASKPASS' "${RUN_RELEASE}" "run-release provides token auth to Homeboy git pushes"
 assert_not_contains 'git config user.name' "${RUN_RELEASE}" "run-release does not configure git identity directly"
 assert_not_contains 'git config --local' "${RUN_RELEASE}" "run-release does not configure git auth directly"
 assert_not_contains 'remote set-url origin' "${RUN_RELEASE}" "run-release does not rewrite origin to an authenticated URL"

--- a/scripts/release/test-run-release-wrapper.sh
+++ b/scripts/release/test-run-release-wrapper.sh
@@ -51,6 +51,7 @@ setup_fixture() {
   WORKSPACE="${TEST_DIR}/workspace"
   OUTPUT_FILE="${TEST_DIR}/github-output"
   HOMEBOY_ARGS_FILE="${TEST_DIR}/homeboy-args"
+  HOMEBOY_AUTH_FILE="${TEST_DIR}/homeboy-auth"
   mkdir -p "${BIN_DIR}" "${WORKSPACE}"
 
   cat > "${WORKSPACE}/homeboy.json" <<'JSON'
@@ -96,6 +97,18 @@ shift
 
 printf '%s\n' "$*" > "${HOMEBOY_ARGS_FILE}"
 
+if [ -n "${GH_TOKEN:-}" ]; then
+  if [ -z "${GIT_ASKPASS:-}" ] || [ ! -x "${GIT_ASKPASS}" ]; then
+    echo "missing executable GIT_ASKPASS" >&2
+    exit 2
+  fi
+  {
+    "${GIT_ASKPASS}" 'Username for https://github.com'
+    "${GIT_ASKPASS}" 'Password for https://x-access-token@github.com'
+    printf '%s\n' "${GIT_TERMINAL_PROMPT:-}"
+  } > "${HOMEBOY_AUTH_FILE}"
+fi
+
 case "${HOMEBOY_MOCK_SCENARIO}" in
   released)
     cat > "${output_file}" <<'JSON'
@@ -139,6 +152,7 @@ run_wrapper() {
   GITHUB_WORKSPACE="${WORKSPACE}" \
   GITHUB_REPOSITORY="Extra-Chill/homeboy-action" \
   HOMEBOY_ARGS_FILE="${HOMEBOY_ARGS_FILE}" \
+  HOMEBOY_AUTH_FILE="${HOMEBOY_AUTH_FILE}" \
   HOMEBOY_MOCK_SCENARIO="${HOMEBOY_MOCK_SCENARIO}" \
   RELEASE_DRY_RUN="${RELEASE_DRY_RUN:-false}" \
   GH_TOKEN="${GH_TOKEN:-}" \
@@ -156,6 +170,9 @@ assert_contains '--skip-checks' "${ARGS}" "release skips duplicate checks"
 assert_contains '--skip-publish' "${ARGS}" "release leaves publishing to tag workflow"
 assert_contains '--git-identity bot' "${ARGS}" "release delegates bot identity to homeboy"
 assert_not_contains '--dry-run' "${ARGS}" "normal release uses one non-dry-run homeboy invocation"
+assert_output_line 'x-access-token' "${HOMEBOY_AUTH_FILE}" "release exposes GitHub token username through askpass"
+assert_output_line 'secret123' "${HOMEBOY_AUTH_FILE}" "release exposes GitHub token password through askpass"
+assert_output_line '0' "${HOMEBOY_AUTH_FILE}" "release disables interactive git prompts"
 assert_output_line 'released=true' "${OUTPUT_FILE}" "released output is true"
 assert_output_line 'release-version=2.1.0' "${OUTPUT_FILE}" "release version output is translated"
 assert_output_line 'release-tag=v2.1.0' "${OUTPUT_FILE}" "release tag output is translated"


### PR DESCRIPTION
## Summary
- Provides `GIT_ASKPASS` from `GH_TOKEN` before invoking `homeboy release`, so Homeboy's internal `git push` can authenticate even when checkout credentials are not persisted.
- Covers the release wrapper behavior in shell tests while preserving the no-remote-rewrite contract.

## Tests
- `bash scripts/release/test-run-release-wrapper.sh`
- `bash scripts/release/test-release-workflow.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the failed self-release workflow, drafted the release auth fix, and ran local shell tests.