### PR TITLE
fix(autofix): commit baseline-only drift directly

### DIFF
--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -25,6 +25,60 @@ fi
 COMP_ID="$(resolve_component_id)"
 WORKSPACE="$(resolve_workspace)"
 
+configure_autofix_bot_identity() {
+  git config user.name "${AUTOFIX_BOT_NAME}"
+  git config user.email "${AUTOFIX_BOT_EMAIL}"
+}
+
+commit_with_autofix_bot() {
+  local message="$1"
+
+  GIT_AUTHOR_NAME="${AUTOFIX_BOT_NAME}" \
+  GIT_AUTHOR_EMAIL="${AUTOFIX_BOT_EMAIL}" \
+  GIT_COMMITTER_NAME="${AUTOFIX_BOT_NAME}" \
+  GIT_COMMITTER_EMAIL="${AUTOFIX_BOT_EMAIL}" \
+    git commit -m "${message}"
+}
+
+push_refspec() {
+  local refspec="$1"
+
+  if [ -n "${APP_TOKEN:-}" ]; then
+    git -c "http.https://github.com/.extraheader=" \
+      push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+      "${refspec}"
+  else
+    git push origin "${refspec}"
+  fi
+}
+
+push_direct_baseline_update() {
+  local base_branch="$1"
+
+  if ! changes_are_only_audit_baseline "${WORKSPACE}"; then
+    return 1
+  fi
+
+  git add "$(baseline_file_path "${WORKSPACE}")"
+  if git diff --cached --quiet; then
+    return 1
+  fi
+
+  configure_autofix_bot_identity
+  commit_with_autofix_bot "chore(ci): update audit baseline"
+
+  echo "Pushing audit baseline update directly to ${base_branch}"
+  if push_refspec "HEAD:refs/heads/${base_branch}"; then
+    echo "baseline-committed=true" >> "${GITHUB_OUTPUT}"
+    echo "committed=false" >> "${GITHUB_OUTPUT}"
+    return 0
+  fi
+
+  echo "::warning::Direct audit baseline push to ${base_branch} failed; falling back to autofix PR"
+  git reset --soft HEAD~1
+  return 1
+}
+
 if [ -n "${AUTOFIX_COMMANDS:-}" ]; then
   IFS=',' read -ra FIX_ARRAY <<< "${AUTOFIX_COMMANDS}"
 else
@@ -95,16 +149,27 @@ if [ -n "${json_files}" ]; then
   fi
 fi
 
-# Update baseline so it stays current when this commit merges to main.
-# Full (unscoped) audit ensures the baseline reflects the entire codebase,
-# not just changed files. Tolerate failure — baseline update is best-effort.
-echo "Updating audit baseline..."
-set +e
-homeboy audit "${COMP_ID}" --baseline --path "${WORKSPACE}"
-BASELINE_EXIT=$?
-set -e
-if [ "${BASELINE_EXIT}" -ne 0 ]; then
-  echo "Baseline update exited non-zero (${BASELINE_EXIT}), continuing"
+# If autofix made no source changes, ratchet baseline drift directly on the
+# base branch. Source autofixes stay on the autofix PR path; their baseline
+# effects are handled by the next main run after the PR merges.
+if git diff --quiet && git diff --cached --quiet; then
+  echo "Updating audit baseline..."
+  set +e
+  homeboy audit "${COMP_ID}" --baseline --path "${WORKSPACE}"
+  BASELINE_EXIT=$?
+  set -e
+  if [ "${BASELINE_EXIT}" -ne 0 ]; then
+    echo "Baseline update exited non-zero (${BASELINE_EXIT}), continuing"
+  fi
+
+  if push_direct_baseline_update "${BASE_BRANCH}"; then
+    rm -rf "${AUTOFIX_OUTPUT_DIR}"
+    git checkout -
+    git branch -D "${AUTOFIX_BRANCH}"
+    exit 0
+  fi
+else
+  echo "Skipping direct audit baseline update because autofix changed source files"
 fi
 
 if git diff --quiet && git diff --cached --quiet; then
@@ -153,15 +218,8 @@ fi
 COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_DETAILS}" "${AUTOFIX_TOTAL_FIXES}")"
 rm -rf "${AUTOFIX_OUTPUT_DIR}"
 
-BOT_NAME="homeboy-ci[bot]"
-BOT_EMAIL="266378653+homeboy-ci[bot]@users.noreply.github.com"
-git config user.name "${BOT_NAME}"
-git config user.email "${BOT_EMAIL}"
-GIT_AUTHOR_NAME="${BOT_NAME}" \
-GIT_AUTHOR_EMAIL="${BOT_EMAIL}" \
-GIT_COMMITTER_NAME="${BOT_NAME}" \
-GIT_COMMITTER_EMAIL="${BOT_EMAIL}" \
-  git commit -m "${COMMIT_MSG}"
+configure_autofix_bot_identity
+commit_with_autofix_bot "${COMMIT_MSG}"
 
 # Use GitHub App token for push if available — pushes from a GitHub App
 # trigger workflow re-runs, while GITHUB_TOKEN pushes do not.

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -304,6 +304,28 @@ autofix_render_other_change() {
   esac
 }
 
+baseline_file_path() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local prefix
+
+  prefix="$(git -C "${workspace}" rev-parse --show-prefix 2>/dev/null || true)"
+  printf '%shomeboy.json\n' "${prefix}"
+}
+
+git_changed_files() {
+  git diff --name-only HEAD -- | sed '/^[[:space:]]*$/d' | sort -u
+}
+
+changes_are_only_audit_baseline() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local baseline_file changed
+
+  baseline_file="$(baseline_file_path "${workspace}")"
+  changed="$(git_changed_files)"
+
+  [ -n "${changed}" ] && [ "${changed}" = "${baseline_file}" ]
+}
+
 build_autofix_pr_body() {
   local run_url="$1"
   local branch="$2"

--- a/scripts/core/test-baseline-change-detection.sh
+++ b/scripts/core/test-baseline-change-detection.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+assert_true() {
+  local label="$1"
+  shift
+
+  if ! "$@" >/dev/null 2>&1; then
+    printf 'FAIL: %s\n' "${label}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_false() {
+  local label="$1"
+  shift
+
+  if "$@" >/dev/null 2>&1; then
+    printf 'FAIL: %s\n' "${label}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+REPO="$(mktemp -d)"
+trap 'rm -rf "${REPO}"' EXIT
+
+git -C "${REPO}" init -q
+git -C "${REPO}" config user.name test
+git -C "${REPO}" config user.email test@example.com
+printf '{"id":"root"}\n' > "${REPO}/homeboy.json"
+mkdir -p "${REPO}/packages/plugin"
+printf '{"id":"plugin"}\n' > "${REPO}/packages/plugin/homeboy.json"
+printf 'initial\n' > "${REPO}/README.md"
+git -C "${REPO}" add .
+git -C "${REPO}" commit -q -m initial
+
+cd "${REPO}"
+
+printf '{"id":"root","audit":{"baseline":[]}}\n' > homeboy.json
+assert_equals "homeboy.json" "$(baseline_file_path "${REPO}")" "root baseline path"
+assert_true "root homeboy.json-only diff is baseline-only" changes_are_only_audit_baseline "${REPO}"
+
+printf 'changed\n' > README.md
+assert_false "source plus baseline diff is not baseline-only" changes_are_only_audit_baseline "${REPO}"
+
+git checkout -q -- README.md homeboy.json
+printf '{"id":"plugin","audit":{"baseline":[]}}\n' > packages/plugin/homeboy.json
+assert_equals "packages/plugin/homeboy.json" "$(baseline_file_path "${REPO}/packages/plugin")" "component baseline path"
+assert_true "component homeboy.json-only diff is baseline-only" changes_are_only_audit_baseline "${REPO}/packages/plugin"
+
+printf 'All baseline change detection checks passed.\n'


### PR DESCRIPTION
## Summary
- Split baseline-only non-PR autofix drift from source autofix PRs.
- Commit direct-to-base only when the diff is exactly the component `homeboy.json` audit baseline.
- Keep source/code/doc autofix changes on the existing `ci/autofix/<component>/<branch>` PR path, with direct baseline push falling back to that path if push fails.

## Testing
- `bash scripts/core/test-baseline-change-detection.sh`
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `bash scripts/core/test-command-builders.sh`
- `bash -n scripts/autofix/prepare-autofix-branch.sh scripts/core/lib.sh scripts/core/test-baseline-change-detection.sh`
- `for f in scripts/**/test-*.sh; do bash \"$f\"; done`

`homeboy lint homeboy-action --path /Users/chubes/Developer/homeboy-action@direct-baseline-main` was attempted locally but could not run because this local component has no extension provider configured for `homeboy-action`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.