### PR TITLE
fix(autofix): exclude baseline from autofix PRs

### DIFF
--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -74,9 +74,22 @@ push_direct_baseline_update() {
     return 0
   fi
 
-  echo "::warning::Direct audit baseline push to ${base_branch} failed; falling back to autofix PR"
+  echo "::warning::Direct audit baseline push to ${base_branch} failed; excluding baseline from autofix PR"
   git reset --soft HEAD~1
   return 1
+}
+
+restore_audit_baseline_file() {
+  local baseline_file
+
+  baseline_file="$(baseline_file_path "${WORKSPACE}")"
+  if git diff --quiet -- "${baseline_file}" && git diff --cached --quiet -- "${baseline_file}"; then
+    return 0
+  fi
+
+  echo "Excluding ${baseline_file} from autofix PR changes"
+  git restore --staged --worktree -- "${baseline_file}" 2>/dev/null || \
+    git checkout -- "${baseline_file}"
 }
 
 if [ -n "${AUTOFIX_COMMANDS:-}" ]; then
@@ -168,8 +181,11 @@ if git diff --quiet && git diff --cached --quiet; then
     git branch -D "${AUTOFIX_BRANCH}"
     exit 0
   fi
+
+  restore_audit_baseline_file
 else
   echo "Skipping direct audit baseline update because autofix changed source files"
+  restore_audit_baseline_file
 fi
 
 if git diff --quiet && git diff --cached --quiet; then
@@ -181,6 +197,7 @@ if git diff --quiet && git diff --cached --quiet; then
 fi
 
 git add -A
+git restore --staged -- "$(baseline_file_path "${WORKSPACE}")" 2>/dev/null || true
 if git diff --cached --quiet; then
   echo "No staged changes after non-PR autofix"
   git checkout -


### PR DESCRIPTION
## Summary
- Follow-up to #205: exclude the component `homeboy.json` baseline file from the non-PR autofix PR path.
- If direct baseline push fails, leave the baseline update out of the autofix PR instead of filing a baseline-only PR.

## Testing
- `bash scripts/core/test-baseline-change-detection.sh`
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `bash -n scripts/autofix/prepare-autofix-branch.sh scripts/core/lib.sh scripts/core/test-baseline-change-detection.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.