### PR TITLE
fix(issues): align reconcile CLI invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ Recommended policy:
 
 The main lane is the right place to maintain issue state because it runs against the full repository and can update, close, or suppress stale findings consistently. PR lanes should focus on author feedback and should not maintain long-lived audit issues from partial data.
 
-When a rule is useful as a health metric but not safe as an actionable task list, configure it as dashboard-only or suppress it from issue reconciliation in Homeboy's audit config. Homeboy Action passes `--suppress-from-config` to `homeboy issues reconcile`, so repository-level audit policy is honored during auto-issue maintenance.
+When a rule is useful as a health metric but not safe as an actionable task list, keep it in job summaries or dashboards rather than turning every item into a tracker task. Homeboy Action delegates issue policy to `homeboy issues reconcile`, so auto-issue maintenance follows the current Homeboy CLI contract.
 
 ### PR Comment Identity
 

--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -499,7 +499,6 @@ reconcile_command() {
     --findings "${input_file}" \
     --path "${RECONCILE_PATH}" \
     --apply \
-    --suppress-from-config \
     > "${result_file}" 2>&1; then
     echo "::warning::homeboy issues reconcile failed for ${cmd_type} — see log above"
     cat "${result_file}"


### PR DESCRIPTION
## Summary
- Remove the stale `--suppress-from-config` argument from categorized issue reconciliation.
- Update README guidance to reflect that issue policy is owned by the current Homeboy CLI contract.

## Testing
- `bash -n scripts/issues/auto-file-categorized-issues.sh`
- Stubbed `homeboy issues reconcile` harness verifying the action no longer passes `--suppress-from-config`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the homeboy-action/Homeboy CLI mismatch, drafted the minimal script/doc update, and ran targeted validation.