### PR TITLE
fix(autofix): direct-push Cargo.lock alongside audit baseline

### DIFF
--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -52,44 +52,71 @@ push_refspec() {
   fi
 }
 
-push_direct_baseline_update() {
+drift_commit_message() {
+  local files="$1"
+
+  # Single-file commits get a tight subject; multi-file uses a generic one
+  # since drift mixes different bookkeeping concerns (baseline + lockfile).
+  case "$(printf '%s\n' "${files}" | sed '/^$/d' | wc -l | xargs)" in
+    1)
+      case "${files}" in
+        *Cargo.lock*) printf 'chore(ci): refresh Cargo.lock\n' ;;
+        *homeboy.json*) printf 'chore(ci): update audit baseline\n' ;;
+        *) printf 'chore(ci): refresh post-merge drift\n' ;;
+      esac
+      ;;
+    *)
+      printf 'chore(ci): refresh post-merge drift\n'
+      ;;
+  esac
+}
+
+push_direct_drift_update() {
   local base_branch="$1"
 
-  if ! changes_are_only_audit_baseline "${WORKSPACE}"; then
+  if ! changes_are_only_drift "${WORKSPACE}"; then
     return 1
   fi
 
-  git add "$(baseline_file_path "${WORKSPACE}")"
+  local staged_files=""
+  while IFS= read -r drift_file; do
+    [ -n "${drift_file}" ] || continue
+    if [ -e "${drift_file}" ] || git ls-files --error-unmatch -- "${drift_file}" >/dev/null 2>&1; then
+      git add -- "${drift_file}"
+      staged_files+="${drift_file}"$'\n'
+    fi
+  done < <(drift_file_paths "${WORKSPACE}")
+
   if git diff --cached --quiet; then
     return 1
   fi
 
   configure_autofix_bot_identity
-  commit_with_autofix_bot "chore(ci): update audit baseline"
+  commit_with_autofix_bot "$(drift_commit_message "${staged_files}")"
 
-  echo "Pushing audit baseline update directly to ${base_branch}"
+  echo "Pushing post-merge drift update directly to ${base_branch}"
   if push_refspec "HEAD:refs/heads/${base_branch}"; then
     echo "baseline-committed=true" >> "${GITHUB_OUTPUT}"
     echo "committed=false" >> "${GITHUB_OUTPUT}"
     return 0
   fi
 
-  echo "::warning::Direct audit baseline push to ${base_branch} failed; excluding baseline from autofix PR"
+  echo "::warning::Direct drift push to ${base_branch} failed; excluding drift files from autofix PR"
   git reset --soft HEAD~1
   return 1
 }
 
-restore_audit_baseline_file() {
-  local baseline_file
+restore_drift_files() {
+  while IFS= read -r drift_file; do
+    [ -n "${drift_file}" ] || continue
+    if git diff --quiet -- "${drift_file}" && git diff --cached --quiet -- "${drift_file}"; then
+      continue
+    fi
 
-  baseline_file="$(baseline_file_path "${WORKSPACE}")"
-  if git diff --quiet -- "${baseline_file}" && git diff --cached --quiet -- "${baseline_file}"; then
-    return 0
-  fi
-
-  echo "Excluding ${baseline_file} from autofix PR changes"
-  git restore --staged --worktree -- "${baseline_file}" 2>/dev/null || \
-    git checkout -- "${baseline_file}"
+    echo "Excluding ${drift_file} from autofix PR changes"
+    git restore --staged --worktree -- "${drift_file}" 2>/dev/null || \
+      git checkout -- "${drift_file}" 2>/dev/null || true
+  done < <(drift_file_paths "${WORKSPACE}")
 }
 
 if [ -n "${AUTOFIX_COMMANDS:-}" ]; then
@@ -162,10 +189,14 @@ if [ -n "${json_files}" ]; then
   fi
 fi
 
-# If autofix made no source changes, ratchet baseline drift directly on the
-# base branch. Source autofixes stay on the autofix PR path; their baseline
-# effects are handled by the next main run after the PR merges.
-if git diff --quiet && git diff --cached --quiet; then
+# If autofix produced no source changes, push merge-aftermath drift (audit
+# baseline + Cargo.lock) directly to the base branch. The drift gate is
+# `changes_are_only_drift`, not "zero changes" — Cargo.lock can be dirty
+# from a release-version-bump on main that the autofix's cargo build
+# resolved into the lockfile, and we still want the direct-push path.
+# Source autofixes stay on the autofix PR path; their drift effects are
+# handled by the next main run after the PR merges.
+if changes_are_only_drift "${WORKSPACE}" || (git diff --quiet && git diff --cached --quiet); then
   echo "Updating audit baseline..."
   set +e
   homeboy audit "${COMP_ID}" --baseline --path "${WORKSPACE}"
@@ -175,17 +206,17 @@ if git diff --quiet && git diff --cached --quiet; then
     echo "Baseline update exited non-zero (${BASELINE_EXIT}), continuing"
   fi
 
-  if push_direct_baseline_update "${BASE_BRANCH}"; then
+  if push_direct_drift_update "${BASE_BRANCH}"; then
     rm -rf "${AUTOFIX_OUTPUT_DIR}"
     git checkout -
     git branch -D "${AUTOFIX_BRANCH}"
     exit 0
   fi
 
-  restore_audit_baseline_file
+  restore_drift_files
 else
-  echo "Skipping direct audit baseline update because autofix changed source files"
-  restore_audit_baseline_file
+  echo "Skipping direct drift update because autofix changed source files"
+  restore_drift_files
 fi
 
 if git diff --quiet && git diff --cached --quiet; then
@@ -197,7 +228,15 @@ if git diff --quiet && git diff --cached --quiet; then
 fi
 
 git add -A
-git restore --staged -- "$(baseline_file_path "${WORKSPACE}")" 2>/dev/null || true
+# Strip drift files (audit baseline, Cargo.lock) from the staged set. They
+# get committed directly to main on the next baseline-only run, never as
+# part of a reviewable autofix PR. Without this, `git add -A` re-stages
+# any drift that survived restore_drift_files (e.g. files homeboy
+# regenerated mid-flow).
+while IFS= read -r drift_file; do
+  [ -n "${drift_file}" ] || continue
+  git restore --staged -- "${drift_file}" 2>/dev/null || true
+done < <(drift_file_paths "${WORKSPACE}")
 if git diff --cached --quiet; then
   echo "No staged changes after non-PR autofix"
   git checkout -

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -312,18 +312,55 @@ baseline_file_path() {
   printf '%shomeboy.json\n' "${prefix}"
 }
 
+# Files whose changes on `main` are merge-aftermath drift, never authored
+# changes:
+#   - homeboy.json: audit baseline metadata refresh after a merge.
+#   - Cargo.lock:   lockfile bump after a release version commit.
+# Both are review-worthless. When autofix sees ONLY these as workspace drift,
+# we commit them directly to the base branch instead of opening a PR. When
+# autofix produces real source fixes, we strip drift files from the PR so
+# they don't pile onto a reviewable change.
+#
+# Emits one path per line, repo-relative, only for files that actually exist.
+drift_file_paths() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local prefix
+
+  prefix="$(git -C "${workspace}" rev-parse --show-prefix 2>/dev/null || true)"
+  local repo_root
+  repo_root="$(git -C "${workspace}" rev-parse --show-toplevel 2>/dev/null || true)"
+
+  printf '%shomeboy.json\n' "${prefix}"
+
+  # Cargo.lock is a release-owned file at the repo root. Only emit it when
+  # the repo actually has one (Rust components only).
+  if [ -n "${repo_root}" ] && [ -f "${repo_root}/Cargo.lock" ]; then
+    printf 'Cargo.lock\n'
+  fi
+}
+
 git_changed_files() {
   git diff --name-only HEAD -- | sed '/^[[:space:]]*$/d' | sort -u
 }
 
-changes_are_only_audit_baseline() {
+changes_are_only_drift() {
   local workspace="${1:-$(resolve_workspace)}"
-  local baseline_file changed
+  local changed drift_files diff_extra
 
-  baseline_file="$(baseline_file_path "${workspace}")"
   changed="$(git_changed_files)"
+  [ -n "${changed}" ] || return 1
 
-  [ -n "${changed}" ] && [ "${changed}" = "${baseline_file}" ]
+  drift_files="$(drift_file_paths "${workspace}" | sort -u)"
+
+  # Every changed file must be in the drift set. `comm -23` lists lines in
+  # changed-but-not-drift; non-empty means there's a non-drift change.
+  diff_extra="$(comm -23 <(printf '%s\n' "${changed}") <(printf '%s\n' "${drift_files}"))"
+  [ -z "${diff_extra}" ]
+}
+
+# Backwards-compat alias used by tests written against the old name.
+changes_are_only_audit_baseline() {
+  changes_are_only_drift "$@"
 }
 
 build_autofix_pr_body() {

--- a/scripts/core/test-baseline-change-detection.sh
+++ b/scripts/core/test-baseline-change-detection.sh
@@ -49,6 +49,7 @@ git -C "${REPO}" init -q
 git -C "${REPO}" config user.name test
 git -C "${REPO}" config user.email test@example.com
 printf '{"id":"root"}\n' > "${REPO}/homeboy.json"
+printf '# placeholder lockfile\n' > "${REPO}/Cargo.lock"
 mkdir -p "${REPO}/packages/plugin"
 printf '{"id":"plugin"}\n' > "${REPO}/packages/plugin/homeboy.json"
 printf 'initial\n' > "${REPO}/README.md"
@@ -57,16 +58,56 @@ git -C "${REPO}" commit -q -m initial
 
 cd "${REPO}"
 
-printf '{"id":"root","audit":{"baseline":[]}}\n' > homeboy.json
+# baseline_file_path keeps emitting the homeboy.json path for legacy callers.
 assert_equals "homeboy.json" "$(baseline_file_path "${REPO}")" "root baseline path"
-assert_true "root homeboy.json-only diff is baseline-only" changes_are_only_audit_baseline "${REPO}"
-
-printf 'changed\n' > README.md
-assert_false "source plus baseline diff is not baseline-only" changes_are_only_audit_baseline "${REPO}"
-
-git checkout -q -- README.md homeboy.json
-printf '{"id":"plugin","audit":{"baseline":[]}}\n' > packages/plugin/homeboy.json
 assert_equals "packages/plugin/homeboy.json" "$(baseline_file_path "${REPO}/packages/plugin")" "component baseline path"
-assert_true "component homeboy.json-only diff is baseline-only" changes_are_only_audit_baseline "${REPO}/packages/plugin"
+
+# drift_file_paths includes Cargo.lock when one exists at the repo root.
+expected_drift="$(printf 'homeboy.json\nCargo.lock\n')"
+assert_equals "${expected_drift}" "$(drift_file_paths "${REPO}")" "root drift list includes Cargo.lock"
+
+# Component workspaces share the root Cargo.lock — only the component's
+# homeboy.json is component-scoped.
+expected_drift_component="$(printf 'packages/plugin/homeboy.json\nCargo.lock\n')"
+assert_equals "${expected_drift_component}" "$(drift_file_paths "${REPO}/packages/plugin")" "component drift list includes root Cargo.lock"
+
+# homeboy.json-only diff is drift-only.
+printf '{"id":"root","audit":{"baseline":[]}}\n' > homeboy.json
+assert_true "root homeboy.json-only diff is drift-only" changes_are_only_drift "${REPO}"
+assert_true "legacy alias accepts homeboy.json-only diff" changes_are_only_audit_baseline "${REPO}"
+
+# Cargo.lock-only diff is drift-only.
+git checkout -q -- homeboy.json
+printf '# bumped lockfile\n' > Cargo.lock
+assert_true "Cargo.lock-only diff is drift-only" changes_are_only_drift "${REPO}"
+
+# homeboy.json + Cargo.lock together is still drift-only.
+printf '{"id":"root","audit":{"baseline":[]}}\n' > homeboy.json
+assert_true "homeboy.json + Cargo.lock diff is drift-only" changes_are_only_drift "${REPO}"
+
+# Source change alongside drift breaks the drift-only invariant.
+printf 'changed\n' > README.md
+assert_false "source plus drift diff is not drift-only" changes_are_only_drift "${REPO}"
+
+git checkout -q -- README.md homeboy.json Cargo.lock
+
+# Component-only baseline change is still drift-only.
+printf '{"id":"plugin","audit":{"baseline":[]}}\n' > packages/plugin/homeboy.json
+assert_true "component homeboy.json-only diff is drift-only" changes_are_only_drift "${REPO}/packages/plugin"
+
+git checkout -q -- packages/plugin/homeboy.json
+
+# Repos without a Cargo.lock get a single-file drift list.
+NON_RUST_REPO="$(mktemp -d)"
+git -C "${NON_RUST_REPO}" init -q
+git -C "${NON_RUST_REPO}" config user.name test
+git -C "${NON_RUST_REPO}" config user.email test@example.com
+printf '{"id":"php"}\n' > "${NON_RUST_REPO}/homeboy.json"
+printf 'README\n' > "${NON_RUST_REPO}/README.md"
+git -C "${NON_RUST_REPO}" add .
+git -C "${NON_RUST_REPO}" commit -q -m initial
+
+assert_equals "homeboy.json" "$(drift_file_paths "${NON_RUST_REPO}")" "non-Rust repo drift list omits Cargo.lock"
+rm -rf "${NON_RUST_REPO}"
 
 printf 'All baseline change detection checks passed.\n'


### PR DESCRIPTION
## Summary
- `Cargo.lock` bumps after a release commit on main are the same shape of merge-aftermath drift as `homeboy.json` baseline refreshes — both show up as review-worthless one-line diffs in `chore(ci): autofix … from main` PRs (e.g. [homeboy#2321](https://github.com/Extra-Chill/homeboy/pull/2321), [homeboy#2290](https://github.com/Extra-Chill/homeboy/pull/2290)).
- Generalize the direct-push-to-main path introduced in #205/#206 to cover any drift file, not just the audit baseline.

## Changes
- New `drift_file_paths` helper enumerates merge-aftermath drift: `homeboy.json` always, `Cargo.lock` when the repo has one. PHP-only repos get a single-file drift list.
- New `changes_are_only_drift` predicate replaces the baseline-only check. `changes_are_only_audit_baseline` stays as a thin alias for any out-of-tree callers.
- `push_direct_baseline_update` → `push_direct_drift_update`. Stages every drift file that exists, commits with a context-aware subject (`refresh Cargo.lock` / `update audit baseline` / `refresh post-merge drift`), and pushes the whole batch in one commit to the base branch.
- `restore_audit_baseline_file` → `restore_drift_files`. Loops over the drift list so a dirty `Cargo.lock` can't pile onto a real source-fix PR.
- The trailing `git add -A` cleanup now strips every drift path, not just `homeboy.json` — closes the gap where a regenerated drift file slipped past `restore_*` and re-staged itself.
- The drift-push gate triggers when changes are drift-only, not only when the working tree is clean. `Cargo.lock` is typically dirty *before* `homeboy audit --baseline` runs (the autofix's own `cargo build` resolves the bumped version into the lockfile), so the old "zero changes" gate would skip the direct-push path and dump `Cargo.lock` into a PR.

## Testing
- `bash scripts/core/test-baseline-change-detection.sh` — extended with `Cargo.lock`-only, mixed `homeboy.json + Cargo.lock`, source-plus-drift (negative), and non-Rust-repo cases. All green.
- `bash scripts/autofix/test-open-autofix-pr-report.sh` — unchanged, still green.
- `bash -n scripts/autofix/prepare-autofix-branch.sh scripts/core/lib.sh scripts/core/test-baseline-change-detection.sh` — syntax clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.