### PR TITLE
fix(autofix): consume drift_files from homeboy core instead of hardcoding

### DIFF
--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -313,30 +313,64 @@ baseline_file_path() {
 }
 
 # Files whose changes on `main` are merge-aftermath drift, never authored
-# changes:
-#   - homeboy.json: audit baseline metadata refresh after a merge.
-#   - Cargo.lock:   lockfile bump after a release version commit.
-# Both are review-worthless. When autofix sees ONLY these as workspace drift,
-# we commit them directly to the base branch instead of opening a PR. When
-# autofix produces real source fixes, we strip drift files from the PR so
-# they don't pile onto a reviewable change.
+# changes — the audit baseline (`homeboy.json`) plus extension-declared
+# lockfiles (`Cargo.lock`, `composer.lock`, etc.) and any component-declared
+# extras. All review-worthless. When autofix sees ONLY drift in the working
+# tree, we commit it directly to the base branch instead of opening a PR.
+# When autofix produces real source fixes, we strip drift files so they
+# don't pile onto a reviewable change.
 #
-# Emits one path per line, repo-relative, only for files that actually exist.
+# The drift list comes from homeboy core via `homeboy component show`,
+# which composes:
+#   1. `homeboy.json` (always — the audit baseline file).
+#   2. `build.lockfile_paths` from each enabled extension manifest.
+#   3. `extra_drift_files` from the component's homeboy.json.
+#
+# Homeboy returns workspace-relative paths. We prefix with the component's
+# git-root-relative directory so the resulting paths match `git diff
+# --name-only` output (which is always repo-root-relative).
+#
+# Emits one path per line, repo-root-relative. Existence is the caller's
+# responsibility — `drift_file_paths` includes paths that may not exist on
+# disk (e.g. a wordpress component without a yarn.lock); push/restore
+# helpers existence-check before staging.
+#
+# Falls back to a `homeboy.json`-only list when `homeboy component show`
+# is unavailable or doesn't expose `drift_files` (older homeboy versions),
+# preserving the pre-#209 behavior.
 drift_file_paths() {
   local workspace="${1:-$(resolve_workspace)}"
   local prefix
-
   prefix="$(git -C "${workspace}" rev-parse --show-prefix 2>/dev/null || true)"
-  local repo_root
-  repo_root="$(git -C "${workspace}" rev-parse --show-toplevel 2>/dev/null || true)"
 
-  printf '%shomeboy.json\n' "${prefix}"
+  local raw_paths=""
 
-  # Cargo.lock is a release-owned file at the repo root. Only emit it when
-  # the repo actually has one (Rust components only).
-  if [ -n "${repo_root}" ] && [ -f "${repo_root}/Cargo.lock" ]; then
-    printf 'Cargo.lock\n'
+  if command -v homeboy >/dev/null 2>&1; then
+    local show_output
+    show_output="$(homeboy component show --path "${workspace}" 2>/dev/null || true)"
+    if [ -n "${show_output}" ]; then
+      raw_paths="$(printf '%s' "${show_output}" | jq -r '.data.entity.drift_files // empty | .[]?' 2>/dev/null || true)"
+    fi
   fi
+
+  if [ -z "${raw_paths}" ]; then
+    # Older homeboy or no homeboy on PATH — emit just the audit baseline.
+    printf '%shomeboy.json\n' "${prefix}"
+    return 0
+  fi
+
+  while IFS= read -r path; do
+    [ -n "${path}" ] || continue
+    case "${path}" in
+      /*)
+        # Defensive: skip absolute paths the resolver shouldn't have emitted.
+        continue
+        ;;
+      *)
+        printf '%s%s\n' "${prefix}" "${path}"
+        ;;
+    esac
+  done <<< "${raw_paths}"
 }
 
 git_changed_files() {

--- a/scripts/core/test-baseline-change-detection.sh
+++ b/scripts/core/test-baseline-change-detection.sh
@@ -42,9 +42,43 @@ assert_equals() {
   printf 'PASS: %s\n' "${label}"
 }
 
-REPO="$(mktemp -d)"
-trap 'rm -rf "${REPO}"' EXIT
+# ── Fake homeboy ──
+# drift_file_paths shells out to `homeboy component show` and parses the
+# `data.entity.drift_files` array. Tests inject a fake binary so we can
+# control the resolver output deterministically without depending on a
+# specific homeboy version, extension layout, or registry state.
+FAKE_BIN="$(mktemp -d)"
+trap 'rm -rf "${FAKE_BIN}" "${REPO:-}" "${NON_RUST_REPO:-}" "${LEGACY_REPO:-}" "${ABSENT_REPO:-}"' EXIT
 
+cat > "${FAKE_BIN}/homeboy" <<'SH'
+#!/usr/bin/env bash
+# Reads `${HOMEBOY_FAKE_RESPONSE}` (a path to a JSON file) and emits it
+# verbatim. When the variable is unset, exits non-zero so drift_file_paths
+# falls back to the audit-baseline-only legacy path.
+if [ -z "${HOMEBOY_FAKE_RESPONSE:-}" ]; then
+  exit 1
+fi
+cat "${HOMEBOY_FAKE_RESPONSE}"
+SH
+chmod +x "${FAKE_BIN}/homeboy"
+export PATH="${FAKE_BIN}:${PATH}"
+
+write_response() {
+  local file="$1"
+  shift
+  local items=()
+  for item in "$@"; do
+    items+=("\"${item}\"")
+  done
+  local joined
+  joined="$(IFS=','; echo "${items[*]}")"
+  cat > "${file}" <<JSON
+{ "data": { "entity": { "drift_files": [${joined}] } } }
+JSON
+}
+
+# ── Repo fixtures ──
+REPO="$(mktemp -d)"
 git -C "${REPO}" init -q
 git -C "${REPO}" config user.name test
 git -C "${REPO}" config user.email test@example.com
@@ -58,30 +92,35 @@ git -C "${REPO}" commit -q -m initial
 
 cd "${REPO}"
 
-# baseline_file_path keeps emitting the homeboy.json path for legacy callers.
+# Simulate a Rust component: homeboy core resolves drift to
+# `homeboy.json + Cargo.lock`.
+RUST_RESPONSE="$(mktemp)"
+write_response "${RUST_RESPONSE}" "homeboy.json" "Cargo.lock"
+export HOMEBOY_FAKE_RESPONSE="${RUST_RESPONSE}"
+
+# baseline_file_path stays workspace-relative (legacy contract).
 assert_equals "homeboy.json" "$(baseline_file_path "${REPO}")" "root baseline path"
 assert_equals "packages/plugin/homeboy.json" "$(baseline_file_path "${REPO}/packages/plugin")" "component baseline path"
 
-# drift_file_paths includes Cargo.lock when one exists at the repo root.
+# drift_file_paths returns repo-root-relative paths from homeboy's resolver.
 expected_drift="$(printf 'homeboy.json\nCargo.lock\n')"
-assert_equals "${expected_drift}" "$(drift_file_paths "${REPO}")" "root drift list includes Cargo.lock"
+assert_equals "${expected_drift}" "$(drift_file_paths "${REPO}")" "root drift list (Rust component)"
 
-# Component workspaces share the root Cargo.lock — only the component's
-# homeboy.json is component-scoped.
-expected_drift_component="$(printf 'packages/plugin/homeboy.json\nCargo.lock\n')"
-assert_equals "${expected_drift_component}" "$(drift_file_paths "${REPO}/packages/plugin")" "component drift list includes root Cargo.lock"
+# A sub-component workspace gets its prefix stitched onto every drift path.
+expected_drift_component="$(printf 'packages/plugin/homeboy.json\npackages/plugin/Cargo.lock\n')"
+assert_equals "${expected_drift_component}" "$(drift_file_paths "${REPO}/packages/plugin")" "sub-component drift list keeps prefix"
 
 # homeboy.json-only diff is drift-only.
 printf '{"id":"root","audit":{"baseline":[]}}\n' > homeboy.json
 assert_true "root homeboy.json-only diff is drift-only" changes_are_only_drift "${REPO}"
 assert_true "legacy alias accepts homeboy.json-only diff" changes_are_only_audit_baseline "${REPO}"
 
-# Cargo.lock-only diff is drift-only.
+# Cargo.lock-only diff is drift-only when the resolver lists Cargo.lock.
 git checkout -q -- homeboy.json
 printf '# bumped lockfile\n' > Cargo.lock
 assert_true "Cargo.lock-only diff is drift-only" changes_are_only_drift "${REPO}"
 
-# homeboy.json + Cargo.lock together is still drift-only.
+# Both files together is still drift-only.
 printf '{"id":"root","audit":{"baseline":[]}}\n' > homeboy.json
 assert_true "homeboy.json + Cargo.lock diff is drift-only" changes_are_only_drift "${REPO}"
 
@@ -91,13 +130,10 @@ assert_false "source plus drift diff is not drift-only" changes_are_only_drift "
 
 git checkout -q -- README.md homeboy.json Cargo.lock
 
-# Component-only baseline change is still drift-only.
-printf '{"id":"plugin","audit":{"baseline":[]}}\n' > packages/plugin/homeboy.json
-assert_true "component homeboy.json-only diff is drift-only" changes_are_only_drift "${REPO}/packages/plugin"
-
-git checkout -q -- packages/plugin/homeboy.json
-
-# Repos without a Cargo.lock get a single-file drift list.
+# ── Non-Rust repo: resolver omits Cargo.lock ──
+# WordPress component fixture: composer.lock is in the resolver list, but
+# this repo doesn't have one on disk. drift_file_paths returns the resolver
+# list verbatim — existence checking lives in push/restore helpers.
 NON_RUST_REPO="$(mktemp -d)"
 git -C "${NON_RUST_REPO}" init -q
 git -C "${NON_RUST_REPO}" config user.name test
@@ -107,7 +143,48 @@ printf 'README\n' > "${NON_RUST_REPO}/README.md"
 git -C "${NON_RUST_REPO}" add .
 git -C "${NON_RUST_REPO}" commit -q -m initial
 
-assert_equals "homeboy.json" "$(drift_file_paths "${NON_RUST_REPO}")" "non-Rust repo drift list omits Cargo.lock"
-rm -rf "${NON_RUST_REPO}"
+WP_RESPONSE="$(mktemp)"
+write_response "${WP_RESPONSE}" "homeboy.json" "composer.lock"
+export HOMEBOY_FAKE_RESPONSE="${WP_RESPONSE}"
+expected_wp="$(printf 'homeboy.json\ncomposer.lock\n')"
+assert_equals "${expected_wp}" "$(drift_file_paths "${NON_RUST_REPO}")" "non-Rust repo follows resolver list"
+
+# ── Legacy homeboy fallback ──
+# When `homeboy component show` returns nothing parseable (older homeboy
+# without drift_files, or homeboy missing entirely), fall back to the
+# audit-baseline-only behavior shipped pre-#209.
+LEGACY_REPO="$(mktemp -d)"
+git -C "${LEGACY_REPO}" init -q
+git -C "${LEGACY_REPO}" config user.name test
+git -C "${LEGACY_REPO}" config user.email test@example.com
+printf '{"id":"legacy"}\n' > "${LEGACY_REPO}/homeboy.json"
+git -C "${LEGACY_REPO}" add .
+git -C "${LEGACY_REPO}" commit -q -m initial
+
+LEGACY_RESPONSE="$(mktemp)"
+cat > "${LEGACY_RESPONSE}" <<'JSON'
+{ "data": { "entity": { "id": "legacy" } } }
+JSON
+export HOMEBOY_FAKE_RESPONSE="${LEGACY_RESPONSE}"
+assert_equals "homeboy.json" "$(drift_file_paths "${LEGACY_REPO}")" "legacy homeboy without drift_files falls back to baseline only"
+
+unset HOMEBOY_FAKE_RESPONSE
+assert_equals "homeboy.json" "$(drift_file_paths "${LEGACY_REPO}")" "homeboy show failure falls back to baseline only"
+
+# ── Absent homeboy on PATH ──
+# Stash the fake binary to simulate a host without homeboy. drift_file_paths
+# must still return the audit baseline so the action is usable in
+# bootstrap-style runs.
+ABSENT_REPO="$(mktemp -d)"
+git -C "${ABSENT_REPO}" init -q
+git -C "${ABSENT_REPO}" config user.name test
+git -C "${ABSENT_REPO}" config user.email test@example.com
+printf '{"id":"absent"}\n' > "${ABSENT_REPO}/homeboy.json"
+git -C "${ABSENT_REPO}" add .
+git -C "${ABSENT_REPO}" commit -q -m initial
+
+mv "${FAKE_BIN}/homeboy" "${FAKE_BIN}/homeboy.bak"
+assert_equals "homeboy.json" "$(drift_file_paths "${ABSENT_REPO}")" "no homeboy on PATH falls back to baseline only"
+mv "${FAKE_BIN}/homeboy.bak" "${FAKE_BIN}/homeboy"
 
 printf 'All baseline change detection checks passed.\n'


### PR DESCRIPTION
## Summary
- Replace the hardcoded `homeboy.json + Cargo.lock` shell helper (added in #209) with a `homeboy component show` query that returns the full drift list composed from extension manifests + component config.
- The action shouldn't know that Rust projects have `Cargo.lock` or that WordPress projects have `composer.lock` — that's extension policy. With homeboy#2326 (drift_files surface) and the companion extensions PR, each extension declares its own lockfiles and homeboy core composes them into a per-component list.

## Behavior

```
drift_file_paths(workspace)
  ├─ homeboy component show --path <workspace> --output -
  ├─ jq '.data.entity.drift_files[]?'
  ├─ prefix each with `git rev-parse --show-prefix`
  └─ on any failure, fall back to `${prefix}homeboy.json`
```

- **Single-component repos** (homeboy itself): prefix is empty, output is `homeboy.json` + `Cargo.lock`.
- **Sub-component workspaces** (e.g. `packages/plugin/`): prefix is `packages/plugin/`, output is `packages/plugin/homeboy.json` + `packages/plugin/Cargo.lock`. Matches `git diff --name-only` semantics.
- **Legacy homeboy** without the `drift_files` field: falls back to `homeboy.json`-only, preserving pre-#209 behavior.
- **Homeboy missing from PATH**: same fallback, so the action stays usable in bootstrap-style runs.

Existence checking stays at the call site (`push_direct_drift_update`, `restore_drift_files`). Homeboy emits every declared path (e.g. all four WordPress lockfiles) and the action skips ones not on disk — keeps the resolver pure and the action defensive.

## Why this PR exists

#209 hardcoded `Cargo.lock` in the shell helper:

```bash
if [ -n "${repo_root}" ] && [ -f "${repo_root}/Cargo.lock" ]; then
  printf 'Cargo.lock\n'
fi
```

That worked for homeboy itself but wouldn't help a WordPress repo with `composer.lock` drift, and adding more languages would mean editing this action for every language. Pushing the policy down to extensions makes the action infrastructure-agnostic.

## Dependencies

This PR is the third in a chain:
1. **homeboy#2326** — adds `build.lockfile_paths` to extension manifests + `Component::extra_drift_files` + `homeboy component show` exposes a computed `drift_files` array.
2. **homeboy-extensions#423** — declares lockfiles on rust, wordpress, nodejs, and go extensions.
3. **This PR** — consumes the surface.

The fallback path means this action can ship before homeboy#2326 is everywhere; pre-#2326 hosts get the audit-baseline-only behavior, post-#2326 hosts pick up extension-driven lockfile drift automatically.

## Tests

Injects a fake `homeboy` binary on `PATH` that emits whatever JSON the test wants. Covers:

| Scenario | Expected |
|----------|----------|
| Rust component | `homeboy.json`, `Cargo.lock` |
| WordPress component | `homeboy.json`, `composer.lock` |
| Sub-component workspace | prefixed correctly |
| Legacy homeboy without `drift_files` | `homeboy.json` only |
| `homeboy component show` fails | `homeboy.json` only |
| Homeboy missing from PATH | `homeboy.json` only |
| Source change + drift | not drift-only (autofix PR proceeds) |
| `Cargo.lock`-only diff | drift-only (direct push) |

## Testing
- `bash scripts/core/test-baseline-change-detection.sh` — 13 cases, all green
- `bash scripts/autofix/test-open-autofix-pr-report.sh` — unchanged, still green
- `bash -n scripts/core/lib.sh scripts/core/test-baseline-change-detection.sh` — syntax clean

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** implementation draft and verification, reviewed/tested by Chris before merge.