### PR TITLE
Bump GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Restore failure cache
         id: failure-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/homeboy-release-last-failed
           key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
@@ -92,13 +92,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -120,13 +120,13 @@ jobs:
     if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.release.result == 'failure' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Save failed SHA
         run: git rev-parse HEAD > "${RUNNER_TEMP}/homeboy-release-last-failed"
 
       - name: Cache failed SHA
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/homeboy-release-last-failed
           key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}

--- a/action.yml
+++ b/action.yml
@@ -261,7 +261,7 @@ runs:
 
     - name: Cache cargo (source build)
       if: inputs.binary-path == '' && inputs.source != ''
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/registry
@@ -290,7 +290,7 @@ runs:
     - name: Cache Homeboy
       id: cache-homeboy
       if: inputs.binary-path == '' && (inputs.source == '' || steps.source-build.outputs.built != 'true')
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           /usr/local/bin/homeboy
@@ -359,7 +359,7 @@ runs:
 
     - name: Setup Node.js
       if: steps.detect-env.outputs.portable-node != ''
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ steps.detect-env.outputs.portable-node }}
 
@@ -419,7 +419,7 @@ runs:
 
     - name: Upload Homeboy CI results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: homeboy-ci-results
         path: homeboy-ci-results/*.json


### PR DESCRIPTION
## Summary
- Bumps GitHub-maintained actions to current majors that support the Node 24 action runtime.
- Updates release workflow cache, checkout, app-token, setup-node, and artifact action pins to avoid Node 20 deprecation warnings.

## Validation
- `git diff --check origin/main...HEAD`
- `ruby -e 'require "yaml"; YAML.load_file("action.yml"); YAML.load_file(".github/workflows/release.yml"); puts "YAML syntax ok"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the action version bump, ran local metadata/syntax checks, and prepared this PR. Chris remains responsible for review and merge.