### PR TITLE
fix(bench): forward typed settings json

### DIFF
--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -578,6 +578,27 @@ has_lint_command() {
   printf '%s\n' "false"
 }
 
+settings_json_flags() {
+  local raw="${HOMEBOY_SETTINGS_JSON:-}"
+  if [ -z "${raw}" ] || [ "${raw}" = "{}" ]; then
+    return 0
+  fi
+
+  if ! printf '%s' "${raw}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    echo "::warning::HOMEBOY_SETTINGS_JSON must be a JSON object; ignoring settings override"
+    return 0
+  fi
+
+  local key
+  local value
+  local flag_value
+  while IFS=$'\t' read -r key value; do
+    [ -n "${key}" ] || continue
+    flag_value="${key}=${value}"
+    printf ' --setting-json %q' "${flag_value}"
+  done < <(printf '%s' "${raw}" | jq -r 'to_entries[] | [.key, (.value | tojson)] | @tsv')
+}
+
 build_run_command() {
   local cmd="$1"
   local component_id="$2"
@@ -628,6 +649,7 @@ build_run_command() {
     if [ -n "${BENCH_REGRESSION_THRESHOLD:-}" ]; then
       full_cmd="${full_cmd} --regression-threshold ${BENCH_REGRESSION_THRESHOLD}"
     fi
+    full_cmd="${full_cmd}$(settings_json_flags)"
   fi
 
   printf '%s\n' "${full_cmd}"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -18,6 +18,38 @@ assert_equals() {
   printf 'PASS: %s\n' "${label}"
 }
 
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  case "${haystack}" in
+    *"${needle}"*)
+      printf 'PASS: %s\n' "${label}"
+      ;;
+    *)
+      printf 'FAIL: %s\nexpected to contain: %s\nactual:              %s\n' "${label}" "${needle}" "${haystack}"
+      exit 1
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+
+  case "${haystack}" in
+    *"${needle}"*)
+      printf 'FAIL: %s\nexpected not to contain: %s\nactual:                  %s\n' "${label}" "${needle}" "${haystack}"
+      exit 1
+      ;;
+    *)
+      printf 'PASS: %s\n' "${label}"
+      ;;
+  esac
+}
+
 WORKSPACE="/tmp/workspace"
 COMPONENT="data-machine"
 OUTPUT_JSON="/tmp/workspace/out.json"
@@ -104,6 +136,13 @@ assert_equals \
   "$(build_run_command "bench" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "bench includes first-class benchmark flags"
 unset BENCH_RIG BENCH_SCENARIO BENCH_RUNS BENCH_ITERATIONS BENCH_REGRESSION_THRESHOLD
+
+HOMEBOY_SETTINGS_JSON='{"playground_workloads":[{"id":"ssi-import","run":[{"type":"wp-cli","command":"wp static-site-importer import-theme static-sites/demo/index.html --format=json","parse":"json"}]}],"playground_blueprint":{"preferredVersions":{"php":"8.3","wp":"latest"}}}'
+bench_settings_cmd="$(build_run_command "bench" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")"
+assert_contains "${bench_settings_cmd}" "--setting-json playground_workloads=" "bench forwards playground workloads as typed settings"
+assert_contains "${bench_settings_cmd}" "--setting-json playground_blueprint=" "bench forwards playground blueprint as typed settings"
+assert_not_contains "${bench_settings_cmd}" "HOMEBOY_SETTINGS_JSON" "bench does not pass raw settings env name as argument"
+unset HOMEBOY_SETTINGS_JSON
 EXTRA_ARGS="--format json"
 
 assert_equals \


### PR DESCRIPTION
## Summary
- Forward `HOMEBOY_SETTINGS_JSON` into `homeboy bench` as typed `--setting-json` flags.
- Cover the command builder so Playground workload settings reach extension runners.

## Validation
- `bash scripts/core/test-command-builders.sh`
- `bash scripts/core/test-bench-command.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the missing action-to-CLI settings forwarding and drafted the focused shell/test changes; Chris remains responsible for review and merge.