### PR TITLE
Add PR comment suppression input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,10 @@ inputs:
     description: 'Section title within the shared PR comment.'
     required: false
     default: ''
+  pr-comment:
+    description: 'Post the default Homeboy PR comment. Set false when the workflow publishes a domain-specific report.'
+    required: false
+    default: 'true'
 
   # ── SSH (for fleet/deploy) ──
   ssh-key:
@@ -581,7 +585,7 @@ runs:
       run: bash ${{ github.action_path }}/scripts/core/enforce-final-status.sh
 
     - name: Post PR comment
-      if: always() && github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false'
+      if: always() && github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false' && inputs.pr-comment != 'false'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token }}

--- a/scripts/pr/comment/test-app-token-required.sh
+++ b/scripts/pr/comment/test-app-token-required.sh
@@ -43,6 +43,7 @@ post_script="$(cat "${ROOT}/scripts/pr/post-pr-comment.sh")"
 
 assert_contains "${action_yml}" 'GH_TOKEN: ${{ inputs.app-token }}' "PR comment uses app token"
 assert_not_contains "${action_yml}" 'GH_TOKEN: ${{ inputs.app-token || github.token }}' "PR comment does not fall back to github token"
+assert_contains "${action_yml}" "inputs.pr-comment != 'false'" "PR comment can be disabled explicitly"
 assert_contains "${post_script}" 'Refusing to post as github-actions[bot]' "missing token warning explains bot identity"
 
 printf 'PR comment app-token checks passed.\n'


### PR DESCRIPTION
## Summary
- Add a `pr-comment` input to disable Homeboy Action's default PR comment.
- Keep the default behavior unchanged (`true`).
- Cover the new condition in the PR comment app-token guard test.

## Validation
- `bash scripts/pr/comment/test-app-token-required.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the duplicate PR-comment issue and drafted the action input/test; Chris remains responsible for review and merge decisions.