### PR TITLE
fix(release): treat empty categorizer input as success when nothing failed

### DIFF
--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -581,8 +581,65 @@ echo "  Issues updated: ${TOTAL_ISSUES_UPDATED}"
 echo "  Issues closed:  ${TOTAL_ISSUES_CLOSED}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-# Exit 1 if no commands were successfully processed — lets generic fallback handle it
-if [ "${COMMANDS_PROCESSED}" -eq 0 ]; then
-  echo "No commands produced valid structured output for categorized issues"
+if [ "${COMMANDS_PROCESSED}" -gt 0 ]; then
+  exit 0
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Empty-input handling (issue #214)
+#
+# COMMANDS_PROCESSED == 0 has two distinct shapes:
+#
+#   1. "Nothing happened here" — RESULTS is empty/`{}` AND COMMANDS is empty.
+#      The wrapper invocation didn't run any categorizable command (e.g. a
+#      release-only step where audit/lint/test ran in sibling jobs). There is
+#      genuinely nothing to categorize, so this is a no-op success path.
+#
+#   2. "A command ran but failed before producing structured output" — RESULTS
+#      records one of EXPECTED_COMMANDS as "fail" with no JSON to categorize.
+#      The categorizer can't file findings without structured output, but it
+#      must propagate the failure so the workflow doesn't ship a broken release.
+#
+# Anything else (commands ran, all passed, no findings) is a clean success path:
+# the codebase had nothing to categorize on this run.
+# ─────────────────────────────────────────────────────────────────────────────
+
+RESULTS_JSON="${RESULTS:-}"
+COMMANDS_LIST="${COMMANDS:-}"
+EXPECTED_LIST="${EXPECTED_COMMANDS:-}"
+
+# Detect commands that actually failed in this invocation's RESULTS.
+FAILED_COMMANDS=""
+if [ -n "${RESULTS_JSON}" ] && [ "${RESULTS_JSON}" != "{}" ]; then
+  if printf '%s\n' "${RESULTS_JSON}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    FAILED_COMMANDS=$(printf '%s\n' "${RESULTS_JSON}" \
+      | jq -r 'to_entries | map(select(.value == "fail")) | .[].key' 2>/dev/null \
+      | paste -sd ',' -)
+  else
+    echo "::warning::RESULTS is not a valid JSON object — treating as 'no commands ran'"
+  fi
+fi
+
+if [ -n "${FAILED_COMMANDS}" ]; then
+  echo "::error::Commands failed without producing structured output for categorization: ${FAILED_COMMANDS}"
+  echo "Cannot file categorized issues without structured JSON. The underlying command failure should be addressed before re-running."
   exit 1
 fi
+
+# No failed commands. Empty input is a legitimate success path:
+#   - release-only invocations route through RELEASE_COMMANDS, not COMMANDS
+#   - clean codebases produce zero findings to categorize
+#   - sibling jobs may own audit/lint/test (EXPECTED_COMMANDS lists them but
+#     they didn't run in this invocation)
+if [ -z "${RESULTS_JSON}" ] || [ "${RESULTS_JSON}" = "{}" ]; then
+  if [ -z "${COMMANDS_LIST}" ]; then
+    echo "Nothing to categorize: no categorizable commands ran in this invocation (RESULTS is empty, COMMANDS is empty)."
+    if [ -n "${EXPECTED_LIST}" ]; then
+      echo "Expected commands ${EXPECTED_LIST} are tracked by sibling jobs; this invocation has no findings to file."
+    fi
+    exit 0
+  fi
+fi
+
+echo "Nothing to categorize: all categorizable commands either passed cleanly or produced no structured output to reconcile."
+exit 0

--- a/scripts/issues/test-auto-file-categorized-issues.sh
+++ b/scripts/issues/test-auto-file-categorized-issues.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/issues/auto-file-categorized-issues.sh empty-input handling.
+#
+# Covers issue #214: the categorizer must distinguish "nothing to categorize"
+# (success) from "a command failed before producing output" (failure).
+#
+# These tests do not exercise the reconcile path against a real `homeboy`
+# binary — they target the decision logic at the tail of the script that
+# determines the final exit code when zero commands produced structured output.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/auto-file-categorized-issues.sh"
+
+if [ ! -f "${TARGET}" ]; then
+  printf 'FAIL: target script not found at %s\n' "${TARGET}" >&2
+  exit 1
+fi
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# run_categorizer LABEL EXPECTED_EXIT EXPECTED_SUBSTRING ENV_KEY=VAL ...
+#
+# Runs the categorizer with the given env, asserts the exit code, and asserts
+# the output contains EXPECTED_SUBSTRING (set to '' to skip the substring check).
+#
+# A throwaway HOMEBOY_OUTPUT_DIR is provided so the script's per-command
+# json-file probe finds nothing and falls through to the empty-input handler
+# we are testing. GITHUB_REPOSITORY / GITHUB_SERVER_URL / GITHUB_RUN_ID are
+# stubbed so the unconditional `set -u` references succeed.
+run_categorizer() {
+  local label="$1"
+  local expected_exit="$2"
+  local expected_substring="$3"
+  shift 3
+
+  local case_dir
+  case_dir=$(mktemp -d "${TMP_ROOT}/case.XXXXXX")
+  local output_dir="${case_dir}/output"
+  mkdir -p "${output_dir}"
+
+  local output status
+  set +e
+  output=$(env -i \
+    PATH="${PATH}" \
+    HOME="${HOME}" \
+    GITHUB_REPOSITORY="example-org/example-repo" \
+    GITHUB_SERVER_URL="https://github.com" \
+    GITHUB_RUN_ID="0" \
+    GITHUB_WORKSPACE="${case_dir}" \
+    HOMEBOY_OUTPUT_DIR="${output_dir}" \
+    COMPONENT_NAME="example" \
+    "$@" \
+    bash "${TARGET}" 2>&1)
+  status=$?
+  set -e
+
+  local fail=false
+  if [ "${status}" -ne "${expected_exit}" ]; then
+    fail=true
+  fi
+
+  if [ -n "${expected_substring}" ] && ! printf '%s\n' "${output}" | grep -qF -- "${expected_substring}"; then
+    fail=true
+  fi
+
+  if [ "${fail}" = true ]; then
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    printf 'FAIL: %s\n' "${label}"
+    printf '  expected exit:    %s\n' "${expected_exit}"
+    printf '  actual exit:      %s\n' "${status}"
+    if [ -n "${expected_substring}" ]; then
+      printf '  expected substr:  %s\n' "${expected_substring}"
+    fi
+    printf '  output:\n'
+    printf '    %s\n' "${output}" | sed 's/^/    /'
+    return
+  fi
+
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'PASS: %s\n' "${label}"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #214: empty-input branches
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Case 1 — release-wrapper shape: RESULTS={}, COMMANDS empty, EXPECTED set.
+# This is the exact failure mode from the bug report. Should exit 0.
+run_categorizer \
+  "release-wrapper empty inputs exit 0" \
+  0 \
+  "Nothing to categorize" \
+  RESULTS='{}' \
+  COMMANDS='' \
+  EXPECTED_COMMANDS='audit,lint,test'
+
+# Case 2 — totally empty env (no RESULTS at all). Should exit 0.
+run_categorizer \
+  "missing RESULTS exits 0" \
+  0 \
+  "Nothing to categorize" \
+  RESULTS='' \
+  COMMANDS='' \
+  EXPECTED_COMMANDS=''
+
+# Case 3 — RESULTS marks a command as failed. Categorizer can't file findings,
+# but must propagate the failure so the release pipeline doesn't proceed.
+run_categorizer \
+  "failed command in RESULTS propagates exit 1" \
+  1 \
+  "Commands failed without producing structured output" \
+  RESULTS='{"audit":"fail"}' \
+  COMMANDS='audit' \
+  EXPECTED_COMMANDS='audit,lint,test'
+
+# Case 4 — RESULTS marks all commands as passing but no JSON files exist.
+# This is the "clean codebase" path: nothing to categorize, exit 0.
+run_categorizer \
+  "all commands passed with no findings exits 0" \
+  0 \
+  "Nothing to categorize" \
+  RESULTS='{"audit":"pass","lint":"pass","test":"pass"}' \
+  COMMANDS='audit,lint,test' \
+  EXPECTED_COMMANDS='audit,lint,test'
+
+# Case 5 — Malformed RESULTS JSON. Should not crash; treats as empty and
+# exits 0 with a warning so release pipelines aren't blocked by env quirks.
+run_categorizer \
+  "malformed RESULTS treated as empty (exit 0 with warning)" \
+  0 \
+  "RESULTS is not a valid JSON object" \
+  RESULTS='not-json' \
+  COMMANDS='' \
+  EXPECTED_COMMANDS='audit,lint,test'
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+
+printf '\n%s passed, %s failed\n' "${PASS_COUNT}" "${FAIL_COUNT}"
+
+if [ "${FAIL_COUNT}" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #214 — the `Prepare Release` step exits 1 with `No commands produced valid structured output for categorized issues` whenever the homeboy-action wrapper invocation has nothing to categorize, even when all underlying CI checks (Build, Audit, Lint, Test) are green. This blocks every release on a clean codebase (e.g. https://github.com/Extra-Chill/homeboy/actions/runs/25523389406, https://github.com/Extra-Chill/homeboy/actions/runs/25523402048).

## Root cause

`scripts/issues/auto-file-categorized-issues.sh` always exited 1 when `COMMANDS_PROCESSED == 0`, conflating two distinct shapes:

1. **Nothing happened here** — release-only invocations route through `RELEASE_COMMANDS`, leaving `COMMANDS=""` and `RESULTS={}`. Sibling jobs own audit/lint/test. There is genuinely nothing to categorize.
2. **A command ran but failed before producing output** — `RESULTS` records one of the expected commands as `"fail"` with no JSON to reconcile.

Treating both as failure means clean releases never ship.

## Fix

After the per-command processing loop, decide based on what `RESULTS` actually says:

- Any `"fail"` entries in `RESULTS` → propagate with a clear `::error::` message naming the failed commands. The categorizer can't file findings without structured JSON, but it must not pretend the failure did not happen.
- Otherwise → no-op success, exit 0 with a clear log line so the release pipeline proceeds. Includes a side-note when `EXPECTED_COMMANDS` is set, explaining that those commands are tracked by sibling jobs.
- Malformed `RESULTS` JSON → warn and treat as empty, so an env quirk can't block a release.

## Tests

New `scripts/issues/test-auto-file-categorized-issues.sh` covers the four behavior shapes plus the malformed-input edge:

```
PASS: release-wrapper empty inputs exit 0
PASS: missing RESULTS exits 0
PASS: failed command in RESULTS propagates exit 1
PASS: all commands passed with no findings exits 0
PASS: malformed RESULTS treated as empty (exit 0 with warning)

5 passed, 0 failed
```

The first case is the exact failure mode from issue #214 (`RESULTS={}`, `COMMANDS=""`, `EXPECTED_COMMANDS=audit,lint,test`) — previously exited 1, now exits 0.

The third case ensures we don't trade one bug for another: if an expected command actually failed in this invocation's `RESULTS`, we still propagate exit 1 so a real failure isn't silently swallowed.

The existing `test-enforce-final-status.sh` continues to pass — the sibling enforcement logic for empty-results-as-success in `scripts/core/enforce-final-status.sh` is the pattern this fix mirrors for the categorizer.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted fix and tests from the issue's expected-behavior spec. Chris reviewed the failed-run evidence and approved scope.