### PR TITLE
fix(release): drop redundant tip-sync workarounds, defer to homeboy core

### DIFF
--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -131,10 +131,13 @@ if [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
   exit 1
 fi
 
-# The quality gate runs in separate jobs that may push autofix commits or new
-# PRs may merge while the pipeline is in flight. Pull before invoking Homeboy so
-# core releases from the actual branch head.
-git pull --ff-only origin "${RELEASE_BRANCH}" 2>/dev/null || true
+# Tip-sync handled in core: `homeboy release` runs `validate_remote_sync`
+# which fetches and fast-forwards from origin before the working-tree check,
+# and `get_uncommitted_changes` runs `git update-index --refresh` so any
+# stale stat info (from prior cargo build / extension setup steps) does not
+# surface as a false-positive dirty tree. The wrapper used to do its own
+# `git pull --ff-only` here as a workaround, which was the original symptom
+# of the upstream gap fixed in homeboy core. See homeboy PR #2368.
 
 RELEASE_OUTPUT_FILE="$(mktemp)"
 RELEASE_ARGS=(

--- a/scripts/release/test-run-release-wrapper.sh
+++ b/scripts/release/test-run-release-wrapper.sh
@@ -52,6 +52,7 @@ setup_fixture() {
   OUTPUT_FILE="${TEST_DIR}/github-output"
   HOMEBOY_ARGS_FILE="${TEST_DIR}/homeboy-args"
   HOMEBOY_AUTH_FILE="${TEST_DIR}/homeboy-auth"
+  MOCK_GIT_LOG="${TEST_DIR}/git-log"
   mkdir -p "${BIN_DIR}" "${WORKSPACE}"
 
   cat > "${WORKSPACE}/homeboy.json" <<'JSON'
@@ -61,15 +62,19 @@ JSON
   cat > "${BIN_DIR}/git" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+# Track every git invocation so the test can assert what the wrapper does
+# (and just as importantly, what it no longer does — see homeboy core PR
+# #2368, which moved tip-sync into `homeboy release` and removed the
+# wrapper's redundant `git pull --ff-only`).
+if [ -n "${MOCK_GIT_LOG:-}" ]; then
+  printf '%s\n' "$*" >> "${MOCK_GIT_LOG}"
+fi
 case "$1 $2" in
   "rev-parse --abbrev-ref")
     echo "${MOCK_BRANCH:-main}"
     ;;
   "symbolic-ref --short")
     echo "origin/${MOCK_DEFAULT_BRANCH:-main}"
-    ;;
-  "pull --ff-only")
-    exit 0
     ;;
   *)
     echo "unexpected git args: $*" >&2
@@ -154,9 +159,20 @@ run_wrapper() {
   HOMEBOY_ARGS_FILE="${HOMEBOY_ARGS_FILE}" \
   HOMEBOY_AUTH_FILE="${HOMEBOY_AUTH_FILE}" \
   HOMEBOY_MOCK_SCENARIO="${HOMEBOY_MOCK_SCENARIO}" \
+  MOCK_GIT_LOG="${MOCK_GIT_LOG}" \
   RELEASE_DRY_RUN="${RELEASE_DRY_RUN:-false}" \
   GH_TOKEN="${GH_TOKEN:-}" \
   bash "${RUN_RELEASE}"
+}
+
+assert_no_git_pull() {
+  local label="$1"
+  if grep -q '^pull ' "${MOCK_GIT_LOG}"; then
+    printf 'FAIL: %s\nwrapper invoked git pull (now owned by homeboy core):\n' "${label}"
+    cat "${MOCK_GIT_LOG}"
+    exit 1
+  fi
+  printf 'PASS: %s\n' "${label}"
 }
 
 setup_fixture
@@ -178,6 +194,7 @@ assert_output_line 'release-version=2.1.0' "${OUTPUT_FILE}" "release version out
 assert_output_line 'release-tag=v2.1.0' "${OUTPUT_FILE}" "release tag output is translated"
 assert_output_line 'release-bump-type=minor' "${OUTPUT_FILE}" "release bump type output is translated"
 assert_output_line 'bump-type=minor' "${OUTPUT_FILE}" "legacy step bump type output is preserved"
+assert_no_git_pull "wrapper does not run its own git pull (core owns tip-sync)"
 
 setup_fixture
 HOMEBOY_MOCK_SCENARIO="skipped"

--- a/scripts/setup/build-source-homeboy.sh
+++ b/scripts/setup/build-source-homeboy.sh
@@ -4,8 +4,13 @@ set -euo pipefail
 
 echo "Building homeboy from source at ${SOURCE_PATH}..."
 
+# --locked: never rewrite Cargo.lock during a CI build. Without this, a fresh
+# upstream release between commit time and build time can update the lockfile
+# and leave the working tree dirty — which makes the downstream `homeboy
+# release` working-tree check refuse to release. Reproducible builds want the
+# committed lockfile honored verbatim anyway.
 BUILD_EXIT=0
-cargo build --release --manifest-path "${SOURCE_PATH}/Cargo.toml" 2>&1 || BUILD_EXIT=$?
+cargo build --release --locked --manifest-path "${SOURCE_PATH}/Cargo.toml" 2>&1 || BUILD_EXIT=$?
 
 if [ "${BUILD_EXIT}" -eq 0 ]; then
   BINARY=$(find "${SOURCE_PATH}/target/release" -maxdepth 1 -name "homeboy" -type f | head -1)


### PR DESCRIPTION
## Summary

Two wrapper-layer workarounds for upstream gaps that homeboy core now owns properly. Removing them aligns with the action shrink-down work tracked in #173/#174 — the eventual goal being to run `homeboy` directly in CI with no wrapper at all.

## What changes

### `scripts/release/run-release.sh` — drop the redundant `git pull`

The wrapper had its own `git pull --ff-only origin "${RELEASE_BRANCH}"` before invoking `homeboy release`. homeboy core's release pipeline already runs `validate_remote_sync` (Stage 0.5) which fetches and fast-forwards from origin, and Extra-Chill/homeboy#2368 added `git update-index --refresh` to `get_uncommitted_changes` so stale stat info from prior steps no longer surfaces as a false-positive dirty tree.

Keeping the wrapper's pull after the upstream fix would be the shim that calcifies into convention (RULES.md "Fix upstream first, never paper over"). The wrapper's pull was the original symptom of the bug, not a layer we want to keep.

The wrapper test gains a regression assertion (`assert_no_git_pull`) so the shim cannot quietly come back. The mock git stub now logs every invocation so future tests can pin down what the wrapper does and does not do.

### `scripts/setup/build-source-homeboy.sh` — add `--locked` to cargo build

Without `--locked`, a fresh upstream crate release between commit-time and build-time can update `Cargo.lock` in the working tree. Even with core's index refresh in place, a content-changed lockfile legitimately reads as dirty and blocks the downstream release working-tree check.

Reproducible CI builds want the committed lockfile honored verbatim anyway. This is a no-op when the lockfile is already consistent and fails fast (build error, not silent dirty release) when it is not.

## Tests

```
=== scripts/release/test-run-release-wrapper.sh ===
PASS: release passes component id
PASS: release passes component path
PASS: release skips duplicate checks
PASS: release leaves publishing to tag workflow
PASS: release delegates bot identity to homeboy
PASS: normal release uses one non-dry-run homeboy invocation
PASS: release exposes GitHub token username through askpass
PASS: release exposes GitHub token password through askpass
PASS: release disables interactive git prompts
PASS: released output is true
PASS: release version output is translated
PASS: release tag output is translated
PASS: release bump type output is translated
PASS: legacy step bump type output is preserved
PASS: wrapper does not run its own git pull (core owns tip-sync)
PASS: skipped release output is false
PASS: skipped reason comes from homeboy
PASS: skipped release preserves bump type when present
PASS: dry-run mode passes through to homeboy
PASS: dry-run output is not released
PASS: dry-run preserves planned version
PASS: dry-run preserves planned tag
PASS: dry-run preserves planned bump
PASS: dry-run reason is action glue
All run-release wrapper checks passed.
```

All sibling test suites (`scripts/setup/test-*.sh`, `scripts/release/test-*.sh`, `scripts/core/test-*.sh`, `scripts/issues/test-*.sh`) still green.

## Companion changes

- **homeboy core PR #2368** (Extra-Chill/homeboy) — the upstream fix this PR depends on. Adds index refresh to `get_uncommitted_changes` and preserves error context through `ValidationCollector`.
- **homeboy-action PR #215** (already merged) — fixed the categorizer's empty-input handling at the wrapper layer where it actually lives.

## Merge ordering

Land Extra-Chill/homeboy#2368 first, cut a homeboy release, then merge this. The wrapper relies on core's `validate_remote_sync` + index refresh to keep the release safe once the wrapper's own pull is gone. Releases triggered against a homeboy version older than the upstream fix would degrade to the same race condition this PR aims to eliminate — but only on the cross-job tip-advance window, not the steady state.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Diagnosed the wrapper-vs-core layering, identified the redundant `git pull` and `cargo build` lockfile race, drafted fixes and regression test. Chris reviewed scope, approved the upstream-first split between core and wrapper, and approved the explicit goal of shrinking the action toward zero.