### PR TITLE
Add deterministic PR policy merge gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ Use these outputs to gate downstream jobs:
 | `comment-key` | No | *(auto)* | Shared PR comment key so multiple jobs aggregate into one sticky comment |
 | `comment-section-key` | No | *(auto)* | Section key within the shared PR comment |
 | `comment-section-title` | No | *(auto)* | Visible heading for this section in the shared PR comment |
+| `pr-policy` | No | | Path to a repo-local PR policy file for deterministic PR auto-merge eligibility |
+| `pr-policy-merge` | No | `false` | Merge the PR when `pr-policy` marks it safe |
+| `pr-policy-merge-method` | No | `squash` | Merge method for `pr-policy-merge`: `merge`, `squash`, or `rebase` |
 | `release-dry-run` | No | `false` | Preview the release without making changes |
 | `release-branch` | No | `main` | Branch that releases are allowed from |
 | `release-skip-changelog` | No | `false` | Skip auto-generating changelog entries from conventional commits |
@@ -186,6 +189,9 @@ Use these outputs to gate downstream jobs:
 | `release-version` | The released version number (e.g. `1.2.3`) |
 | `release-tag` | The release git tag (e.g. `v1.2.3`) |
 | `release-bump-type` | The bump type used (`patch`, `minor`, `major`) |
+| `pr-policy-safe` | Whether the PR policy marked the PR safe for auto-merge (`true`/`false`) |
+| `pr-policy-merged` | Whether the PR policy gate merged the PR (`true`/`false`) |
+| `pr-policy-report` | Markdown summary from the PR policy gate |
 
 ## Examples
 
@@ -281,6 +287,46 @@ When enabled, the action will:
 For fork PRs, Homeboy Action now attempts the same direct-to-PR autofix flow first. Actual push success still depends on the token/permission model available to the workflow run.
 
 **Merge guard:** If the PR is merged or closed while CI is running, autofix and PR comments are automatically skipped. This prevents zombie commits to deleted branches and stale result noise on already-merged PRs. Pair with a `concurrency` group to cancel the entire run early.
+
+### Deterministic PR Policy Gate
+
+Use `pr-policy` to classify whether a PR is safe for deterministic auto-merge after Homeboy checks pass. The policy gate reads changed files from GitHub, applies repo-local author, branch, path, and content rules, then exposes `pr-policy-safe` and optionally merges the PR.
+
+```yaml
+- uses: actions/checkout@v4
+
+- uses: Extra-Chill/homeboy-action@v2
+  with:
+    extension: wordpress
+    commands: lint,test
+    pr-policy: .homeboy/pr-policy.yml
+    pr-policy-merge: 'true'
+    pr-policy-merge-method: squash
+```
+
+Example policy:
+
+```yaml
+title: World PR policy
+allowed_authors:
+  - github-actions[bot]
+allowed_head_branches:
+  - world-day/**
+allowed_paths:
+  - content/**
+  - themes/world-of-wordpress/patterns/**
+blocked_paths:
+  - .github/**
+  - bundles/**
+  - plugins/**
+blocked_content_patterns:
+  - 'eval[[:space:]]*\('
+  - 'shell_exec[[:space:]]*\('
+require_same_repository: true
+delete_branch_on_merge: true
+```
+
+The gate fails closed for missing policy, unknown changed files, blocked paths, unexpected authors, fork PRs when `require_same_repository` is true, or blocked content patterns. Unsafe PRs are not merged; the action still emits outputs so a workflow can decide whether to fail, comment, or route to human review.
 
 ### Auto-open Fix PRs on non-PR runs
 

--- a/action.yml
+++ b/action.yml
@@ -149,6 +149,20 @@ inputs:
     required: false
     default: 'true'
 
+  # ── PR policy gate ──
+  pr-policy:
+    description: 'Path to a repo-local PR policy file. When set on pull_request events, classifies the PR for deterministic auto-merge eligibility.'
+    required: false
+    default: ''
+  pr-policy-merge:
+    description: 'Merge the pull request when pr-policy marks it safe. Requires pr-policy and a token with pull request write permissions.'
+    required: false
+    default: 'false'
+  pr-policy-merge-method:
+    description: 'Merge method for pr-policy-merge: merge, squash, or rebase.'
+    required: false
+    default: 'squash'
+
   # ── SSH (for fleet/deploy) ──
   ssh-key:
     description: 'SSH private key for fleet/deploy commands. Writes to ~/.ssh, starts ssh-agent, configures known_hosts. If empty, assumes SSH is pre-configured.'
@@ -207,6 +221,15 @@ outputs:
   skipped-reason:
     description: 'Why release was skipped when released is false'
     value: ${{ steps.release.outputs.skipped-reason }}
+  pr-policy-safe:
+    description: 'Whether the PR policy marked this pull request safe for auto-merge (true/false)'
+    value: ${{ steps.pr-policy.outputs.safe }}
+  pr-policy-merged:
+    description: 'Whether the PR policy gate merged this pull request (true/false)'
+    value: ${{ steps.pr-policy.outputs.merged }}
+  pr-policy-report:
+    description: 'Markdown summary from the PR policy gate'
+    value: ${{ steps.pr-policy.outputs.report }}
 
 runs:
   using: 'composite'
@@ -583,6 +606,22 @@ runs:
         OPERATIONS_RESULTS: ${{ steps.run-operations.outputs.results }}
         PR_ACTIVE: ${{ steps.check-pr-state.outputs.active }}
       run: bash ${{ github.action_path }}/scripts/core/enforce-final-status.sh
+
+    - name: Evaluate PR policy
+      id: pr-policy
+      if: github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false' && inputs.pr-policy != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.app-token || github.token }}
+        POLICY_PATH: ${{ inputs.pr-policy }}
+        POLICY_MERGE: ${{ inputs.pr-policy-merge }}
+        POLICY_MERGE_METHOD: ${{ inputs.pr-policy-merge-method }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        REPOSITORY: ${{ github.repository }}
+      run: bash ${{ github.action_path }}/scripts/pr/policy-gate.sh
 
     - name: Post PR comment
       if: always() && github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false' && inputs.pr-comment != 'false'

--- a/scripts/pr/policy-gate.sh
+++ b/scripts/pr/policy-gate.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+POLICY_PATH="${POLICY_PATH:-}"
+POLICY_MERGE="${POLICY_MERGE:-false}"
+POLICY_MERGE_METHOD="${POLICY_MERGE_METHOD:-squash}"
+PR_NUMBER="${PR_NUMBER:-}"
+REPO="${REPOSITORY:-${GITHUB_REPOSITORY:-}}"
+PR_AUTHOR="${PR_AUTHOR:-}"
+PR_HEAD_REF="${PR_HEAD_REF:-}"
+PR_HEAD_REPO="${PR_HEAD_REPO:-}"
+
+write_output() {
+  local name="$1"
+  local value="$2"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      printf '%s<<HOMEBOY_PR_POLICY\n' "${name}"
+      printf '%s\n' "${value}"
+      printf 'HOMEBOY_PR_POLICY\n'
+    } >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+finish() {
+  local safe="$1"
+  local merged="$2"
+  local reason="$3"
+  local report="$4"
+
+  write_output "safe" "${safe}"
+  write_output "merged" "${merged}"
+  write_output "reason" "${reason}"
+  write_output "report" "${report}"
+  printf '%s\n' "${report}"
+}
+
+fail_closed() {
+  local reason="$1"
+  finish "false" "false" "${reason}" "$(printf '## PR policy\n\nUnsafe for auto-merge: %s' "${reason}")"
+  exit 0
+}
+
+json_array_lines() {
+  local json="$1"
+  local selector="$2"
+  printf '%s' "${json}" | jq -r "${selector} // [] | .[]" 2>/dev/null || true
+}
+
+json_bool() {
+  local json="$1"
+  local selector="$2"
+  local default_value="$3"
+  printf '%s' "${json}" | jq -r "${selector} // ${default_value}" 2>/dev/null || printf '%s' "${default_value}"
+}
+
+json_string() {
+  local json="$1"
+  local selector="$2"
+  local default_value="$3"
+  printf '%s' "${json}" | jq -r "${selector} // \"${default_value}\"" 2>/dev/null || printf '%s' "${default_value}"
+}
+
+load_policy_json() {
+  local path="$1"
+
+  if [ ! -f "${path}" ]; then
+    fail_closed "policy file not found: ${path}"
+  fi
+
+  if jq -e . "${path}" >/dev/null 2>&1; then
+    jq -c . "${path}"
+    return
+  fi
+
+  if command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)) || {})' "${path}" 2>/dev/null && return
+  fi
+
+  fail_closed "policy file is not valid JSON and Ruby YAML support is unavailable"
+}
+
+matches_pattern() {
+  local value="$1"
+  local pattern="$2"
+
+  if [ "${value}" = "${pattern}" ]; then
+    return 0
+  fi
+
+  case "${value}" in
+    ${pattern}) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+matches_any_pattern() {
+  local value="$1"
+  shift
+
+  local pattern
+  for pattern in "$@"; do
+    if matches_pattern "${value}" "${pattern}"; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+join_lines() {
+  local joined=""
+  local line
+
+  while IFS= read -r line; do
+    [ -n "${line}" ] || continue
+    if [ -n "${joined}" ]; then
+      joined="${joined}, ${line}"
+    else
+      joined="${line}"
+    fi
+  done
+
+  printf '%s' "${joined}"
+}
+
+if [ -z "${POLICY_PATH}" ]; then
+  fail_closed "POLICY_PATH is required"
+fi
+
+if [ -z "${PR_NUMBER}" ] || [ -z "${REPO}" ]; then
+  fail_closed "PR_NUMBER and repository are required"
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  fail_closed "jq is required"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  fail_closed "gh is required"
+fi
+
+POLICY_JSON="$(load_policy_json "${POLICY_PATH}")"
+
+mapfile -t ALLOWED_AUTHORS < <(json_array_lines "${POLICY_JSON}" '.allowed_authors')
+mapfile -t ALLOWED_HEAD_BRANCHES < <(json_array_lines "${POLICY_JSON}" '.allowed_head_branches')
+mapfile -t ALLOWED_HEAD_REPOS < <(json_array_lines "${POLICY_JSON}" '.allowed_head_repositories')
+mapfile -t ALLOWED_PATHS < <(json_array_lines "${POLICY_JSON}" '.allowed_paths')
+mapfile -t BLOCKED_PATHS < <(json_array_lines "${POLICY_JSON}" '.blocked_paths')
+mapfile -t BLOCKED_CONTENT < <(json_array_lines "${POLICY_JSON}" '.blocked_content_patterns')
+
+REQUIRE_SAME_REPO="$(json_bool "${POLICY_JSON}" '.require_same_repository' 'true')"
+DELETE_BRANCH="$(json_bool "${POLICY_JSON}" '.delete_branch_on_merge' 'true')"
+POLICY_TITLE="$(json_string "${POLICY_JSON}" '.title' 'PR policy')"
+
+if [ "${REQUIRE_SAME_REPO}" = "true" ] && [ -n "${PR_HEAD_REPO}" ] && [ "${PR_HEAD_REPO}" != "${REPO}" ]; then
+  fail_closed "head repository ${PR_HEAD_REPO} does not match ${REPO}"
+fi
+
+if [ "${#ALLOWED_AUTHORS[@]}" -gt 0 ] && ! matches_any_pattern "${PR_AUTHOR}" "${ALLOWED_AUTHORS[@]}"; then
+  fail_closed "author ${PR_AUTHOR:-unknown} is not allowed"
+fi
+
+if [ "${#ALLOWED_HEAD_REPOS[@]}" -gt 0 ] && ! matches_any_pattern "${PR_HEAD_REPO}" "${ALLOWED_HEAD_REPOS[@]}"; then
+  fail_closed "head repository ${PR_HEAD_REPO:-unknown} is not allowed"
+fi
+
+if [ "${#ALLOWED_HEAD_BRANCHES[@]}" -gt 0 ] && ! matches_any_pattern "${PR_HEAD_REF}" "${ALLOWED_HEAD_BRANCHES[@]}"; then
+  fail_closed "head branch ${PR_HEAD_REF:-unknown} is not allowed"
+fi
+
+FILES="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" --jq '.[].filename' 2>/dev/null || true)"
+if [ -z "${FILES}" ]; then
+  fail_closed "could not read changed files"
+fi
+
+UNALLOWED_FILES=()
+BLOCKED_FILES=()
+while IFS= read -r file; do
+  [ -n "${file}" ] || continue
+
+  if [ "${#BLOCKED_PATHS[@]}" -gt 0 ] && matches_any_pattern "${file}" "${BLOCKED_PATHS[@]}"; then
+    BLOCKED_FILES+=("${file}")
+  fi
+
+  if [ "${#ALLOWED_PATHS[@]}" -gt 0 ] && ! matches_any_pattern "${file}" "${ALLOWED_PATHS[@]}"; then
+    UNALLOWED_FILES+=("${file}")
+  fi
+done <<< "${FILES}"
+
+if [ "${#BLOCKED_FILES[@]}" -gt 0 ]; then
+  fail_closed "blocked paths changed: $(printf '%s\n' "${BLOCKED_FILES[@]}" | join_lines)"
+fi
+
+if [ "${#UNALLOWED_FILES[@]}" -gt 0 ]; then
+  fail_closed "paths outside allowed set changed: $(printf '%s\n' "${UNALLOWED_FILES[@]}" | join_lines)"
+fi
+
+CONTENT_HITS=()
+if [ "${#BLOCKED_CONTENT[@]}" -gt 0 ]; then
+  BLOCKED_CONTENT_PATTERN="$(printf '%s\n' "${BLOCKED_CONTENT[@]}" | paste -sd '|' -)"
+
+  while IFS= read -r file; do
+    [ -n "${file}" ] || continue
+    [ -f "${file}" ] || continue
+
+    if grep -Eq "${BLOCKED_CONTENT_PATTERN}" "${file}"; then
+      CONTENT_HITS+=("${file}")
+    fi
+  done <<< "${FILES}"
+fi
+
+if [ "${#CONTENT_HITS[@]}" -gt 0 ]; then
+  fail_closed "blocked content patterns found in: $(printf '%s\n' "${CONTENT_HITS[@]}" | join_lines)"
+fi
+
+MERGED="false"
+MERGE_NOTE="Merge was not requested."
+if [ "${POLICY_MERGE}" = "true" ]; then
+  case "${POLICY_MERGE_METHOD}" in
+    merge|squash|rebase) ;;
+    *) fail_closed "unsupported merge method: ${POLICY_MERGE_METHOD}" ;;
+  esac
+
+  MERGE_ARGS=("pr" "merge" "${PR_NUMBER}" "--repo" "${REPO}" "--${POLICY_MERGE_METHOD}")
+  if [ "${DELETE_BRANCH}" = "true" ]; then
+    MERGE_ARGS+=("--delete-branch")
+  fi
+
+  gh "${MERGE_ARGS[@]}"
+  MERGED="true"
+  MERGE_NOTE="Merged with ${POLICY_MERGE_METHOD}."
+fi
+
+FILE_COUNT="$(printf '%s\n' "${FILES}" | sed '/^$/d' | wc -l | tr -d ' ')"
+REPORT="$(printf '## %s\n\nSafe for auto-merge: %s changed file(s) matched policy. %s' "${POLICY_TITLE}" "${FILE_COUNT}" "${MERGE_NOTE}")"
+finish "true" "${MERGED}" "safe" "${REPORT}"

--- a/scripts/pr/test-policy-gate.sh
+++ b/scripts/pr/test-policy-gate.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLICY_GATE="${SCRIPT_DIR}/policy-gate.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+FAKE_BIN="${TMPDIR}/bin"
+mkdir -p "${FAKE_BIN}"
+
+cat > "${FAKE_BIN}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "api" ]; then
+  printf '%s\n' "${GH_FAKE_FILES}"
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then
+  printf '%s\n' "$*" >> "${GH_FAKE_MERGES}"
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "${FAKE_BIN}/gh"
+
+assert_policy() {
+  local expected_safe="$1"
+  local expected_merged="$2"
+  local label="$3"
+  shift 3
+
+  local output_file merge_file output safe merged
+  output_file="${TMPDIR}/output-${label// /-}"
+  merge_file="${TMPDIR}/merge-${label// /-}"
+  : > "${merge_file}"
+
+  PATH="${FAKE_BIN}:${PATH}" \
+    GITHUB_OUTPUT="${output_file}" \
+    GH_FAKE_MERGES="${merge_file}" \
+    "$@" >/dev/null
+
+  safe="$(awk '/^safe<<HOMEBOY_PR_POLICY$/{getline; print; exit}' "${output_file}")"
+  merged="$(awk '/^merged<<HOMEBOY_PR_POLICY$/{getline; print; exit}' "${output_file}")"
+
+  if [ "${safe}" != "${expected_safe}" ] || [ "${merged}" != "${expected_merged}" ]; then
+    printf 'FAIL: %s\nexpected safe/merged: %s/%s\nactual safe/merged:   %s/%s\n' \
+      "${label}" "${expected_safe}" "${expected_merged}" "${safe}" "${merged}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+POLICY="${TMPDIR}/policy.json"
+cat > "${POLICY}" <<'EOF'
+{
+  "allowed_authors": ["github-actions[bot]"],
+  "allowed_head_branches": ["world-day/**"],
+  "allowed_paths": ["content/**", "themes/world-of-wordpress/patterns/**"],
+  "blocked_paths": [".github/**", "bundles/**"],
+  "blocked_content_patterns": ["eval[[:space:]]*\\("]
+}
+EOF
+
+mkdir -p "${TMPDIR}/repo/content/page" "${TMPDIR}/repo/.github/workflows"
+printf '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->\n' > "${TMPDIR}/repo/content/page/world-index.md"
+printf 'eval( $code );\n' > "${TMPDIR}/repo/content/page/bad.md"
+
+assert_policy true false "safe content" \
+  env -C "${TMPDIR}/repo" \
+    POLICY_PATH="${POLICY}" \
+    PR_NUMBER="7" \
+    REPOSITORY="chubes4/world-of-wordpress" \
+    PR_AUTHOR="github-actions[bot]" \
+    PR_HEAD_REF="world-day/2026-05-10" \
+    PR_HEAD_REPO="chubes4/world-of-wordpress" \
+    GH_FAKE_FILES='content/page/world-index.md' \
+    bash "${POLICY_GATE}"
+
+assert_policy false false "blocked path" \
+  env -C "${TMPDIR}/repo" \
+    POLICY_PATH="${POLICY}" \
+    PR_NUMBER="7" \
+    REPOSITORY="chubes4/world-of-wordpress" \
+    PR_AUTHOR="github-actions[bot]" \
+    PR_HEAD_REF="world-day/2026-05-10" \
+    PR_HEAD_REPO="chubes4/world-of-wordpress" \
+    GH_FAKE_FILES='.github/workflows/world.yml' \
+    bash "${POLICY_GATE}"
+
+assert_policy false false "blocked content" \
+  env -C "${TMPDIR}/repo" \
+    POLICY_PATH="${POLICY}" \
+    PR_NUMBER="7" \
+    REPOSITORY="chubes4/world-of-wordpress" \
+    PR_AUTHOR="github-actions[bot]" \
+    PR_HEAD_REF="world-day/2026-05-10" \
+    PR_HEAD_REPO="chubes4/world-of-wordpress" \
+    GH_FAKE_FILES='content/page/bad.md' \
+    bash "${POLICY_GATE}"
+
+assert_policy true true "safe merge" \
+  env -C "${TMPDIR}/repo" \
+    POLICY_PATH="${POLICY}" \
+    POLICY_MERGE="true" \
+    POLICY_MERGE_METHOD="squash" \
+    PR_NUMBER="7" \
+    REPOSITORY="chubes4/world-of-wordpress" \
+    PR_AUTHOR="github-actions[bot]" \
+    PR_HEAD_REF="world-day/2026-05-10" \
+    PR_HEAD_REPO="chubes4/world-of-wordpress" \
+    GH_FAKE_FILES='content/page/world-index.md' \
+    bash "${POLICY_GATE}"
+
+printf 'All PR policy gate checks passed.\n'


### PR DESCRIPTION
## Summary
- Add a `pr-policy` action input that evaluates repo-local author, branch, repository, path, and content rules on pull requests.
- Expose policy outputs for downstream workflows and optionally merge safe PRs through `gh pr merge`.
- Document the policy schema and add a shell smoke test with a fake `gh` binary.

## Testing
- `bash scripts/pr/test-policy-gate.sh`
- `bash -n scripts/pr/policy-gate.sh && bash -n scripts/pr/test-policy-gate.sh`
- `bash scripts/core/test-enforce-final-status.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the action input wiring, policy gate script, smoke test, and README documentation; Chris reviewed through the PR workflow.