### PR TITLE
fix: scope observation artifacts by job

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -464,10 +464,10 @@ runs:
       run: bash ${{ github.action_path }}/scripts/core/export-observations.sh
 
     - name: Upload Homeboy observations
-      if: always()
+      if: always() && steps.check-pr-state.outputs.active != 'false' && steps.resolve-commands.outputs.resolved-commands != ''
       uses: actions/upload-artifact@v4
       with:
-        name: homeboy-observations
+        name: homeboy-observations-${{ github.job }}
         path: homeboy-observations/**
         if-no-files-found: ignore
 

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -55,6 +55,8 @@ assert_not_contains 'remote set-url origin' "${RUN_RELEASE}" "run-release does n
 assert_contains 'homeboy_verify_github_release_exists "${TAG}" "${GITHUB_REPOSITORY:-}"' "${RUN_RELEASE}" "run-release verifies the GitHub Release after successful release"
 assert_contains 'release-verify-github-release:' "${ROOT_DIR}/action.yml" "action exposes GitHub Release verification toggle"
 assert_contains 'HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}' "${ROOT_DIR}/action.yml" "action passes verification toggle to release script"
+assert_contains 'name: homeboy-observations-${{ github.job }}' "${ROOT_DIR}/action.yml" "observation artifacts are scoped per job"
+assert_not_contains 'name: homeboy-observations$' "${ROOT_DIR}/action.yml" "observation artifacts do not use a shared static name"
 assert_contains 'release-bump-type:' "${ROOT_DIR}/action.yml" "action exposes release bump type output"
 assert_contains 'skipped-reason:' "${ROOT_DIR}/action.yml" "action exposes skipped release reason output"
 assert_contains 'git/ref/tags/v${release_version}' "${HOMEBOY_CONFIG}" "post-release hook reads the pushed release tag ref"


### PR DESCRIPTION
## Summary
- Scope `homeboy-observations` artifacts by GitHub job to avoid cross-job upload collisions.
- Skip observation upload when the action did not run a Homeboy command.
- Add a release workflow contract check so the shared static artifact name does not regress.

## Testing
- `bash scripts/release/test-release-workflow.sh`
- `bash scripts/core/test-command-builders.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the release-blocking artifact collision, drafted the scoped artifact-name fix, and ran focused verification; Chris remains responsible for review and merge.