### PR TITLE
fix: avoid observation artifact name collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ Run `homeboy bench` in CI and preserve the raw structured output for downstream 
 
 Bench runs write the exact `homeboy bench --output` payload to `homeboy-ci-results/bench.json`, upload it as the `homeboy-ci-results` artifact, and render a compact PR-summary section when PR comments are enabled.
 
-Homeboy Action also runs `homeboy runs export --since 24h --output homeboy-observations` after command execution and uploads the result as a separate `homeboy-observations` artifact. This export is best-effort: if the current Homeboy version does not support observation export or no observations exist, the CI result is unchanged.
+Homeboy Action also runs `homeboy runs export --since 24h --output homeboy-observations` after command execution and uploads the result as a separate `homeboy-observations-<job>-<commands>` artifact. This export is best-effort: if the current Homeboy version does not support observation export or no observations exist, the CI result is unchanged.
 
 Artifact boundaries:
 
 - `homeboy-ci-results`: immediate structured command outputs used for pass/fail decisions and PR rendering, such as `bench.json`.
-- `homeboy-observations`: persisted Homeboy run history exported for later import/query by agents and other tooling.
+- `homeboy-observations-<job>-<commands>`: persisted Homeboy run history exported for later import/query by agents and other tooling. The suffix prevents collisions when a workflow splits audit/lint/test across jobs or invokes the action multiple times in one job.
 
 #### Continuous release outputs
 
@@ -157,7 +157,7 @@ Use these outputs to gate downstream jobs:
 | `iterations` | No | | Bench iteration count passed to `homeboy bench --iterations` |
 | `regression-threshold` | No | | Bench regression threshold passed to `homeboy bench --regression-threshold` |
 | `differential-gating` | No | `false` | On PRs, compare `audit`/`test` counts against the base SHA and fail only when the PR is worse. Opt-in; `lint` still gates on exit code. PR autofix is skipped while enabled. |
-| `observation-window` | No | `24h` | Duration window passed to best-effort `homeboy runs export --since` for the separate `homeboy-observations` artifact. |
+| `observation-window` | No | `24h` | Duration window passed to best-effort `homeboy runs export --since` for the separate `homeboy-observations-<job>-<commands>` artifact. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |
 | `node-version` | No | | Node.js version (sets up via `actions/setup-node`) |
 | `autofix` | No | `false` | On PR failures, run safe autofixes, commit, push, and re-run checks |

--- a/action.yml
+++ b/action.yml
@@ -467,7 +467,7 @@ runs:
       if: always() && steps.check-pr-state.outputs.active != 'false' && steps.resolve-commands.outputs.resolved-commands != ''
       uses: actions/upload-artifact@v4
       with:
-        name: homeboy-observations-${{ github.job }}
+        name: homeboy-observations-${{ github.job }}-${{ steps.resolve-commands.outputs.resolved-commands }}
         path: homeboy-observations/**
         if-no-files-found: ignore
 


### PR DESCRIPTION
## Summary
- Include both the GitHub job id and resolved command set in `homeboy-observations` artifact names.
- Update README artifact docs to describe the collision-resistant naming shape.

## Testing
- `bash -n scripts/core/export-observations.sh && git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the artifact naming fix and docs after observing a CI upload collision on split Homeboy jobs.