### PR TITLE
fix: defer release verification to tag workflow

### DIFF
--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -199,8 +199,6 @@ if [ "${DRY_RUN}" = "true" ]; then
   exit 0
 fi
 
-homeboy_verify_github_release_exists "${TAG}" "${GITHUB_REPOSITORY:-}"
-
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Released ${TAG} (${BUMP_TYPE})"

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -52,7 +52,7 @@ assert_contains 'GIT_ASKPASS' "${RUN_RELEASE}" "run-release provides token auth 
 assert_not_contains 'git config user.name' "${RUN_RELEASE}" "run-release does not configure git identity directly"
 assert_not_contains 'git config --local' "${RUN_RELEASE}" "run-release does not configure git auth directly"
 assert_not_contains 'remote set-url origin' "${RUN_RELEASE}" "run-release does not rewrite origin to an authenticated URL"
-assert_contains 'homeboy_verify_github_release_exists "${TAG}" "${GITHUB_REPOSITORY:-}"' "${RUN_RELEASE}" "run-release verifies the GitHub Release after successful release"
+assert_not_contains 'homeboy_verify_github_release_exists "${TAG}" "${GITHUB_REPOSITORY:-}"' "${RUN_RELEASE}" "run-release does not verify GitHub Release before tag workflow creates it"
 assert_contains 'release-verify-github-release:' "${ROOT_DIR}/action.yml" "action exposes GitHub Release verification toggle"
 assert_contains 'HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}' "${ROOT_DIR}/action.yml" "action passes verification toggle to release script"
 assert_contains 'name: homeboy-observations-${{ github.job }}' "${ROOT_DIR}/action.yml" "observation artifacts are scoped per job"


### PR DESCRIPTION
## Summary
- Stop verifying a GitHub Release in the prepare wrapper after `homeboy release --no-github-release`.
- Keep tag push as the prepare job's success boundary so the later tag workflow owns GitHub Release creation and verification.
- Update the release workflow contract to guard against early verification returning.

## Testing
- `bash scripts/release/test-release-workflow.sh`
- `bash scripts/release/test-run-release-wrapper.sh`
- `bash scripts/release/test-github-release-verification.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the prepare-release timing failure, drafted the wrapper fix, and ran focused verification; Chris remains responsible for review and merge.