### PR TITLE
fix: restore scope input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ on:
         description: 'Additional arguments passed to each Homeboy command.'
         type: string
         default: ''
+      scope:
+        description: 'Execution scope: auto, changed, or full.'
+        type: string
+        default: 'auto'
       rig:
         description: 'Bench rig pair/list passed to homeboy bench.'
         type: string
@@ -355,6 +359,7 @@ jobs:
           expected-commands: ${{ inputs.expected-commands || inputs.commands }}
           component: ${{ inputs.component }}
           args: ${{ inputs.args }}
+          scope: ${{ inputs.scope }}
           rig: ${{ inputs.rig }}
           scenario: ${{ inputs.scenario }}
           runs: ${{ inputs.runs }}

--- a/README.md
+++ b/README.md
@@ -182,9 +182,7 @@ Use these outputs to gate downstream jobs:
 | `autofix-max-commits` | No | `2` | Safety limit for autofix commit chain depth per branch |
 | `autofix-commands` | No | | Override autofix commands (comma-separated, e.g. `lint --fix,test --fix`) |
 | `autofix-label` | No | | Optional PR label required before autofix runs (e.g. `autofix`) |
-| `scope` | No | `changed` | Execution scope: `changed` for PRs or `full` for entire codebase |
-| `lint-changed-only` | No | `true` | Deprecated: use `scope` instead |
-| `test-scope` | No | `changed` | Deprecated: use `scope` instead |
+| `scope` | No | `auto` | Execution scope: `auto` uses changed scope on PRs and full scope elsewhere; `changed` forces `--changed-since` when a base SHA is available; `full` scans the full workspace. |
 | `auto-issue` | No | *(auto)* | Reconcile categorized audit, lint, and test issues on non-PR runs. Empty means enabled for non-PR events and disabled for PRs; set `false` to suppress issue maintenance. |
 | `comment-key` | No | *(auto)* | Shared PR comment key so multiple jobs aggregate into one sticky comment |
 | `comment-section-key` | No | *(auto)* | Section key within the shared PR comment |
@@ -237,6 +235,10 @@ jobs:
       node-version: '20'
     secrets: inherit
 ```
+
+### Scope
+
+By default, `scope: auto` uses changed-file scope for pull requests and full-workspace scope for non-PR events. Set `scope: changed` to force changed-file scope when a pull request base SHA is available, or `scope: full` to scan the full workspace.
 
 ### PR Scoped Checks (Changed Files)
 
@@ -539,9 +541,9 @@ If you also run continuous release, keep release as its own workflow or separate
 
 > **Avoid cron-based release triggers.** A `schedule` cron fires whether there are new commits or not. Push-to-main triggers the quality/release pipeline only when there is new code to evaluate.
 
-#### Single workflow with event-aware inputs
+#### Single workflow with default scope
 
-If you prefer one workflow, make the scope and issue-filing policy event-aware:
+If you prefer one workflow, keep the default `scope: auto` behavior and make only the issue-filing policy event-aware:
 
 ```yaml
 name: Homeboy CI
@@ -568,14 +570,13 @@ jobs:
         with:
           extension: wordpress
           commands: lint,test,audit
-          scope: ${{ github.event_name == 'pull_request' && 'changed' || 'full' }}
           auto-issue: ${{ github.event_name != 'pull_request' && 'true' || 'false' }}
           php-version: '8.3'
 ```
 
 #### Compatibility notes
 
-`scope: changed` is a thin wrapper around the Homeboy CLI. On PRs, the action resolves the base SHA and passes `--changed-since <base-sha>` to Homeboy for `audit`, `lint`, and `test`.
+`scope: changed` is a thin wrapper around the Homeboy CLI. When a pull request base SHA is available, the action resolves the base SHA and passes `--changed-since <base-sha>` to Homeboy for scoped commands.
 
 Use changed scope for a command only when the installed Homeboy CLI and extension implement changed-file semantics for that command. If a command does not support changed scope yet, prefer one of these patterns:
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
     description: 'Additional arguments to pass to each command.'
     required: false
     default: ''
+  scope:
+    description: 'Execution scope: auto uses changed scope on PRs and full scope elsewhere; changed forces --changed-since when a base SHA is available; full scans the full workspace.'
+    required: false
+    default: 'auto'
   rig:
     description: 'Bench rig pair/list to pass to `homeboy bench --rig` when command includes bench.'
     required: false
@@ -256,6 +260,7 @@ runs:
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        SCOPE_INPUT: ${{ inputs.scope }}
       run: bash ${{ github.action_path }}/scripts/scope/resolve.sh
 
     - name: Resolve commands

--- a/scripts/scope/resolve.sh
+++ b/scripts/scope/resolve.sh
@@ -2,14 +2,16 @@
 
 # Unified scope resolver — detects execution context and computes scope state.
 #
-# v2: Scope is always context-driven. PRs use changed-file scope automatically.
-# Non-PR events always use full scope. No user input needed.
+# v2: Scope defaults to context-driven. PRs use changed-file scope automatically
+# and non-PR events use full scope. Consumers may override with scope=changed
+# or scope=full when a workflow needs explicit policy.
 #
 # Inputs (env vars):
 #   GITHUB_EVENT_NAME  — pull_request, schedule, workflow_dispatch, push
 #   BASE_SHA           — PR base commit (from github.event.pull_request.base.sha)
 #   PR_HEAD_REPO       — full_name of PR head repo (fork detection)
 #   GITHUB_REPOSITORY  — full_name of the base repo
+#   SCOPE_INPUT        — auto | changed | full (default: auto)
 #
 # Outputs (GITHUB_ENV + GITHUB_OUTPUT):
 #   SCOPE_CONTEXT      — pr | push | cron | manual
@@ -53,8 +55,20 @@ fi
 
 SCOPE_BASE_REF=""
 SCOPE_MODE="full"
+SCOPE_INPUT="${SCOPE_INPUT:-auto}"
 
-if [ "${SCOPE_CONTEXT}" = "pr" ]; then
+case "${SCOPE_INPUT}" in
+  ""|auto|changed|full)
+    ;;
+  *)
+    echo "::warning::Unsupported scope '${SCOPE_INPUT}' - falling back to auto"
+    SCOPE_INPUT="auto"
+    ;;
+esac
+
+if [ "${SCOPE_INPUT}" = "full" ]; then
+  SCOPE_MODE="full"
+elif [ "${SCOPE_CONTEXT}" = "pr" ] || [ "${SCOPE_INPUT}" = "changed" ]; then
   if [ -n "${BASE_SHA:-}" ]; then
     # Fetch enough ancestry for three-dot diff (base...HEAD) to find the merge base.
     # GitHub's default checkout is --depth=1 (shallow), which only has the tip commits.
@@ -82,12 +96,15 @@ if [ "${SCOPE_CONTEXT}" = "pr" ]; then
       echo "::warning::Could not find merge base — falling back to full scope"
       SCOPE_MODE="full"
     fi
-  else
+  elif [ "${SCOPE_CONTEXT}" = "pr" ]; then
     echo "::warning::PR event but no BASE_SHA provided — falling back to full scope"
+    SCOPE_MODE="full"
+  else
+    echo "::warning::scope=changed requires a pull request base SHA - falling back to full scope"
     SCOPE_MODE="full"
   fi
 else
-  # Non-PR events always use full scope
+  # Non-PR auto scope uses full scope.
   SCOPE_MODE="full"
 fi
 
@@ -103,4 +120,4 @@ echo "scope-base-ref=${SCOPE_BASE_REF}" >> "${GITHUB_OUTPUT}"
 echo "scope-mode=${SCOPE_MODE}" >> "${GITHUB_OUTPUT}"
 echo "scope-is-fork=${SCOPE_IS_FORK}" >> "${GITHUB_OUTPUT}"
 
-echo "Scope resolved: context=${SCOPE_CONTEXT} mode=${SCOPE_MODE} fork=${SCOPE_IS_FORK} base_ref=${SCOPE_BASE_REF:-(none)}"
+echo "Scope resolved: context=${SCOPE_CONTEXT} input=${SCOPE_INPUT} mode=${SCOPE_MODE} fork=${SCOPE_IS_FORK} base_ref=${SCOPE_BASE_REF:-(none)}"

--- a/scripts/scope/test-resolve.sh
+++ b/scripts/scope/test-resolve.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_SCRIPT="${SCRIPT_DIR}/resolve.sh"
+
+assert_env_contains() {
+  local file="$1"
+  local expected="$2"
+  local label="$3"
+
+  if grep -qx "${expected}" "${file}"; then
+    printf 'PASS: %s\n' "${label}"
+    return
+  fi
+
+  printf 'FAIL: %s\nexpected env line: %s\nactual:\n' "${label}" "${expected}"
+  sed 's/^/  /' "${file}"
+  exit 1
+}
+
+run_resolve() {
+  local env_file output_file
+  env_file="$(mktemp)"
+  output_file="$(mktemp)"
+
+  GITHUB_ENV="${env_file}" \
+    GITHUB_OUTPUT="${output_file}" \
+    "$@" \
+    bash "${RESOLVE_SCRIPT}" >/dev/null
+
+  printf '%s\n' "${env_file}"
+}
+
+env_file="$(run_resolve env GITHUB_EVENT_NAME=push SCOPE_INPUT=auto)"
+assert_env_contains "${env_file}" "SCOPE_MODE=full" "auto push uses full scope"
+
+env_file="$(run_resolve env GITHUB_EVENT_NAME=pull_request SCOPE_INPUT=full BASE_SHA=missing)"
+assert_env_contains "${env_file}" "SCOPE_MODE=full" "explicit full scope bypasses PR base resolution"
+
+env_file="$(run_resolve env GITHUB_EVENT_NAME=workflow_dispatch SCOPE_INPUT=changed)"
+assert_env_contains "${env_file}" "SCOPE_MODE=full" "changed scope without base falls back to full"
+
+env_file="$(run_resolve env GITHUB_EVENT_NAME=push SCOPE_INPUT=unexpected)"
+assert_env_contains "${env_file}" "SCOPE_MODE=full" "invalid scope falls back to auto"
+
+base_sha="$(git rev-parse HEAD~1)"
+env_file="$(run_resolve env GITHUB_EVENT_NAME=pull_request SCOPE_INPUT=auto BASE_SHA="${base_sha}" PR_HEAD_REPO=Extra-Chill/homeboy-action GITHUB_REPOSITORY=Extra-Chill/homeboy-action)"
+assert_env_contains "${env_file}" "SCOPE_MODE=changed" "auto PR uses changed scope"
+assert_env_contains "${env_file}" "SCOPE_BASE_REF=${base_sha}" "auto PR records base ref"
+
+printf 'All scope resolver checks passed.\n'


### PR DESCRIPTION
## Summary
- Restore the documented `scope` input on the composite action and reusable CI workflow.
- Preserve current default behavior with `scope: auto`: changed scope on PRs, full scope elsewhere.
- Add resolver coverage for auto/full/changed/invalid scope behavior and update README examples.

## Testing
- `git diff --check`
- `bash scripts/core/test-command-builders.sh`
- `bash scripts/scope/test-resolve.sh`
- `ruby -e 'require "yaml"; YAML.load_file("action.yml"); YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the scope input wiring, resolver logic, tests, and documentation updates for Chris to review.