### PR TITLE
docs: remove stale release skip changelog input

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ Use these outputs to gate downstream jobs:
 | `pr-policy-merge-method` | No | `squash` | Merge method for `pr-policy-merge`: `merge`, `squash`, or `rebase` |
 | `release-dry-run` | No | `false` | Preview the release without making changes |
 | `release-branch` | No | `main` | Branch that releases are allowed from |
-| `release-skip-changelog` | No | `false` | Skip auto-generating changelog entries from conventional commits |
 
 ## Outputs
 


### PR DESCRIPTION
## Summary
- Remove the obsolete `release-skip-changelog` row from the README inputs table.
- Keep the documented inputs aligned with `action.yml`.

## Testing
- Not run; documentation-only change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identifying the docs/API drift and drafting the README cleanup.