### PR TITLE
fix: report refactor source autofixes

### DIFF
--- a/scripts/autofix/test-open-autofix-pr-report.sh
+++ b/scripts/autofix/test-open-autofix-pr-report.sh
@@ -119,6 +119,39 @@ assert_contains "${SOURCE_BODY}" '- `homeboy.json` audit baseline metadata was r
 assert_contains "${SOURCE_BODY}" '- Workflow run: https://github.com/Extra-Chill/homeboy-action/actions/runs/12345' "verification includes workflow run"
 assert_not_contains "${SOURCE_BODY}" 'file(s) fixed via' "source report omits generic old summary"
 
+FALLBACK_OUTPUT_DIR="${TMP_DIR}/fallback-output"
+mkdir -p "${FALLBACK_OUTPUT_DIR}"
+cat > "${FALLBACK_OUTPUT_DIR}/fix.json" <<'JSON'
+{
+  "data": {
+    "command": "refactor.sources",
+    "applied": true,
+    "changed_files": [
+      "src/core/code_audit/duplication.rs",
+      "src/core/code_audit/requested_detectors.rs"
+    ],
+    "collected_edits": []
+  }
+}
+JSON
+
+FALLBACK_REPORT="$(extract_fix_report_from_output "${FALLBACK_OUTPUT_DIR}")"
+BODY_CAPTURE="${TMP_DIR}/fallback-create.md"
+export BODY_CAPTURE
+export HOMEBOY_PR_MODE="create"
+export AUTOFIX_FILE_COUNT="2"
+export AUTOFIX_CHANGED_FILES=$'src/core/code_audit/duplication.rs\nsrc/core/code_audit/requested_detectors.rs'
+export AUTOFIX_REPORT="${FALLBACK_REPORT}"
+
+bash "${ROOT}/scripts/autofix/open-autofix-pr.sh" >/tmp/homeboy-action-test-fallback.log
+FALLBACK_BODY="$(<"${BODY_CAPTURE}")"
+
+assert_contains "${FALLBACK_REPORT}" $'source_change\t2\tsrc/core/code_audit/duplication.rs, src/core/code_audit/requested_detectors.rs' "fallback report classifies refactor.sources changed files"
+assert_contains "${FALLBACK_BODY}" 'Applied autofix changes to **2** source files.' "fallback summary treats source changes as fixes"
+assert_contains "${FALLBACK_BODY}" '| `source_change` | 2 | `src/core/code_audit/duplication.rs` `src/core/code_audit/requested_detectors.rs` |' "fallback table includes changed source files"
+assert_not_contains "${FALLBACK_BODY}" 'No source fixes were reported by the autofix output.' "fallback avoids false no-source-fixes summary"
+assert_not_contains "${FALLBACK_BODY}" 'changed outside the reported source-fix set' "fallback does not misclassify source files as other changes"
+
 BODY_CAPTURE="${TMP_DIR}/baseline-create.md"
 export BODY_CAPTURE
 export AUTOFIX_FILE_COUNT="1"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -150,7 +150,8 @@ extract_fix_details_from_output() {
         "broken_doc_reference": "Broken doc references fixed",
         "missing_import": "Missing imports added",
         "namespace_mismatch": "Namespace mismatches fixed",
-        "directory_sprawl": "Directory sprawl reduced"
+        "directory_sprawl": "Directory sprawl reduced",
+        "source_change": "Source files changed"
       }[.] // .;
 
     # Collect insertions with normalized category (FixResult format)
@@ -170,8 +171,18 @@ extract_fix_details_from_output() {
     # Collect decompose plans (FixResult format — structural decompose operations)
     [.[].decompose_plans // [] | .[] | {cat: .source_finding, file}] as $decompose |
 
-    # Combine all sources and group by category
-    ($insertions + $new_files + $proposals + $collected_edits + $decompose) | group_by(.cat) |
+    ($insertions + $new_files + $proposals + $collected_edits + $decompose) as $structured |
+
+    # RefactorSourceRun can report applied changed_files without collected_edits
+    # when an extension applies fixes but does not emit the fix-results sidecar.
+    [ .[] | select((.command // "") == "refactor.sources" and (.applied // false)) |
+      (.changed_files // [])[] | {cat: "source_change", file: .}
+    ] as $source_changes |
+
+    # Prefer precise structured rows. Fall back to changed_files only when the
+    # source run would otherwise look like a metadata-only change.
+    (if ($structured | length) > 0 then $structured else $source_changes end) |
+    group_by(.cat) |
     map({
       cat: .[0].cat,
       count: length,
@@ -222,7 +233,12 @@ extract_fix_report_from_output() {
     [.[].collected_edits // [] | .[] | {cat: .rule_id, file}] as $collected_edits |
     [.[].decompose_plans // [] | .[] | {cat: .source_finding, file}] as $decompose |
 
-    ($insertions + $new_files + $proposals + $collected_edits + $decompose) |
+    ($insertions + $new_files + $proposals + $collected_edits + $decompose) as $structured |
+    [ .[] | select((.command // "") == "refactor.sources" and (.applied // false)) |
+      (.changed_files // [])[] | {cat: "source_change", file: .}
+    ] as $source_changes |
+
+    (if ($structured | length) > 0 then $structured else $source_changes end) |
     group_by(.cat) |
     map({
       cat: .[0].cat,
@@ -414,7 +430,13 @@ build_autofix_pr_body() {
     if [ "${row_count}" = "1" ]; then
       local only_type
       only_type="$(printf '%s\n' "${AUTOFIX_REPORT}" | awk -F '\t' 'NF >= 1 { print $1; exit }')"
-      printf -- '- Fixed **%s** `%s` %s.\n' "${total_fixes}" "${only_type}" "${label}"
+      if [ "${only_type}" = "source_change" ]; then
+        local source_label="source file"
+        [ "${total_fixes}" = "1" ] || source_label="source files"
+        printf -- '- Applied autofix changes to **%s** %s.\n' "${total_fixes}" "${source_label}"
+      else
+        printf -- '- Fixed **%s** `%s` %s.\n' "${total_fixes}" "${only_type}" "${label}"
+      fi
     else
       printf -- '- Fixed **%s** source %s across **%s** finding types.\n' "${total_fixes}" "${label}" "${row_count}"
     fi


### PR DESCRIPTION
## Summary
- Treat applied `refactor.sources` changed files as source autofixes when structured fix rows are missing.
- Keep richer structured categories preferred, and only fall back to `source_change` for sidecar-less extension fixes.
- Add regression coverage for the Homeboy Rust autofix report shape that previously appeared as “No source fixes”.

## Testing
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `bash -n scripts/core/lib.sh`
- `bash -n scripts/autofix/test-open-autofix-pr-report.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the autofix report contract mismatch, drafted the action fallback and regression test, and ran targeted verification. Chris requested immediate PR/merge.