### PR TITLE
fix: ignore stale PR command results after merge

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -637,6 +637,24 @@ runs:
         RUN_GROUP_PREFIX: homeboy
       run: bash ${{ github.action_path }}/scripts/operations/run-operations.sh
 
+    # Re-check PR state just before enforcement/reporting. A PR can merge while
+    # quality commands are still running, and merged/closed PR runs should not
+    # fail as zombie CI after the branch is already gone.
+    - name: Check final PR state
+      id: final-pr-state
+      if: always() && github.event_name == 'pull_request'
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
+        if ! pr_is_active; then
+          echo "::warning::PR #${PR_NUMBER} is no longer open (merged or closed) — skipping final enforcement"
+          echo "active=false" >> "${GITHUB_OUTPUT}"
+        else
+          echo "active=true" >> "${GITHUB_OUTPUT}"
+        fi
+
     - name: Enforce final status
       id: enforce-status
       if: always()
@@ -645,12 +663,12 @@ runs:
         RESULTS: ${{ steps.select-results.outputs.results }}
         COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
         OPERATIONS_RESULTS: ${{ steps.run-operations.outputs.results }}
-        PR_ACTIVE: ${{ steps.check-pr-state.outputs.active }}
+        PR_ACTIVE: ${{ steps.final-pr-state.outputs.active || steps.check-pr-state.outputs.active }}
       run: bash ${{ github.action_path }}/scripts/core/enforce-final-status.sh
 
     - name: Evaluate PR policy
       id: pr-policy
-      if: github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false' && inputs.pr-policy != ''
+      if: github.event_name == 'pull_request' && steps.final-pr-state.outputs.active != 'false' && inputs.pr-policy != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token || github.token }}
@@ -665,7 +683,7 @@ runs:
       run: bash ${{ github.action_path }}/scripts/pr/policy-gate.sh
 
     - name: Post PR comment
-      if: always() && github.event_name == 'pull_request' && steps.check-pr-state.outputs.active != 'false' && inputs.pr-comment != 'false'
+      if: always() && github.event_name == 'pull_request' && steps.final-pr-state.outputs.active != 'false' && inputs.pr-comment != 'false'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.app-token }}

--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -20,17 +20,16 @@ validate_results_json() {
   fi
 }
 
+if [ "${PR_ACTIVE:-}" = "false" ]; then
+  echo "PR was merged or closed before final enforcement — ignoring stale command results"
+  exit 0
+fi
+
 validate_results_json "Quality command" "${RESULTS:-}"
 validate_results_json "Operations command" "${OPERATIONS_RESULTS}"
 
 if [ -z "${RESULTS:-}" ] || [ "${RESULTS}" = "{}" ]; then
   HAS_QUALITY_COMMANDS=false
-
-  # If the PR was merged/closed before commands ran, empty results are expected
-  if [ "${PR_ACTIVE:-}" = "false" ]; then
-    echo "PR was merged or closed before commands ran — nothing to enforce"
-    exit 0
-  fi
 
   # If there are no quality commands, empty quality results are expected.
   COMMANDS="${COMMANDS:-}"

--- a/scripts/core/test-enforce-final-status.sh
+++ b/scripts/core/test-enforce-final-status.sh
@@ -30,6 +30,12 @@ assert_exit 1 "malformed quality results fail closed" \
 assert_exit 1 "failing quality results fail" \
   env RESULTS='{"test":"fail"}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
 
+assert_exit 0 "closed PR ignores stale failing quality results" \
+  env RESULTS='{"test":"fail"}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='false' bash "${ENFORCE_STATUS}"
+
+assert_exit 0 "closed PR ignores malformed stale results" \
+  env RESULTS='{"test":"fail"}}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='false' bash "${ENFORCE_STATUS}"
+
 assert_exit 0 "passing quality results pass" \
   env RESULTS='{"test":"pass"}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
 


### PR DESCRIPTION
## Summary
- Re-check PR state immediately before final status enforcement/reporting.
- Treat merged/closed PR runs as stale so zombie quality results do not fail CI after merge.
- Cover stale failing and malformed command results in final-status tests.

## Verification
- `bash scripts/core/test-enforce-final-status.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Diagnosed the stale merged-PR CI failure, drafted the final-state guard, and ran the targeted shell test; Chris approved committing/opening the PR.