### PR TITLE
feat(release): expose release-skip-publish and release-skip-github-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           commands: release
           release-dry-run: 'true'
+          release-skip-publish: 'true'
+          release-skip-github-release: 'true'
 
       - name: Decide whether to release
         id: check
@@ -109,6 +111,8 @@ jobs:
         with:
           commands: release
           release-dry-run: ${{ inputs.dry-run || 'false' }}
+          release-skip-publish: 'true'
+          release-skip-github-release: 'true'
           app-token: ${{ steps.app-token.outputs.token || '' }}
 
   # ── Record failed SHA to prevent retry loops ──

--- a/action.yml
+++ b/action.yml
@@ -194,6 +194,14 @@ inputs:
     description: 'Verify that a successful release has a GitHub Release for the emitted tag. Set false for tag-only release consumers.'
     required: false
     default: 'true'
+  release-skip-publish:
+    description: 'Pass --skip-publish to homeboy release. Skips the package and publish.<target> pipeline steps. Set true for components that publish artifacts outside the homeboy pipeline (binary cross-compile, hand-rolled gh release create, etc.). Defaults to false so components with release.publish-capable extensions ship artifacts through the standard pipeline.'
+    required: false
+    default: 'false'
+  release-skip-github-release:
+    description: 'Pass --no-github-release to homeboy release. Skips the github.release step that runs `gh release create`. Set true for components that create their GitHub Release through a separate workflow step (typically pairs with release-skip-publish=true). Defaults to false so components with a github.com remote get a GitHub Release on every tag.'
+    required: false
+    default: 'false'
 
 outputs:
   results:
@@ -617,6 +625,8 @@ runs:
         GH_TOKEN: ${{ inputs.app-token || github.token }}
         RELEASE_DRY_RUN: ${{ inputs.release-dry-run }}
         RELEASE_BRANCH: ${{ inputs.release-branch }}
+        RELEASE_SKIP_PUBLISH: ${{ inputs.release-skip-publish }}
+        RELEASE_SKIP_GITHUB_RELEASE: ${{ inputs.release-skip-github-release }}
         HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}
         COMPONENT_NAME: ${{ inputs.component }}
       run: bash ${{ github.action_path }}/scripts/release/run-release.sh

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -139,15 +139,32 @@ fi
 # `git pull --ff-only` here as a workaround, which was the original symptom
 # of the upstream gap fixed in homeboy core. See homeboy PR #2368.
 
+# Quality gates run in separate jobs before this script, so --skip-checks
+# is always safe here. The publish and github.release flags are
+# configurable: downstream consumers that wire up extensions like
+# homeboy-extensions/wordpress (release.package + release.publish) want
+# the full pipeline by default. Components that publish artifacts or
+# create GitHub Releases outside the homeboy pipeline (binary cross-
+# compile, hand-rolled gh release create, …) opt out via the action
+# inputs that set these env vars.
+RELEASE_SKIP_PUBLISH="${RELEASE_SKIP_PUBLISH:-false}"
+RELEASE_SKIP_GITHUB_RELEASE="${RELEASE_SKIP_GITHUB_RELEASE:-false}"
+
 RELEASE_OUTPUT_FILE="$(mktemp)"
 RELEASE_ARGS=(
   "${COMP_ID}"
   --path "${WORKSPACE}"
   --skip-checks
-  --skip-publish
-  --no-github-release
   --git-identity bot
 )
+
+if [ "${RELEASE_SKIP_PUBLISH}" = "true" ]; then
+  RELEASE_ARGS+=(--skip-publish)
+fi
+
+if [ "${RELEASE_SKIP_GITHUB_RELEASE}" = "true" ]; then
+  RELEASE_ARGS+=(--no-github-release)
+fi
 
 if [ "${DRY_RUN}" = "true" ]; then
   RELEASE_ARGS+=(--dry-run)


### PR DESCRIPTION
## Summary

Move the previously hardcoded `--skip-publish` and `--no-github-release` flags out of `scripts/release/run-release.sh` and into two new action inputs that default to `false`. Downstream consumers that wire up homeboy-extensions `release.publish`-capable extensions (e.g. WordPress plugins using the new `wordpress` v2.89+ extension) now get the full pipeline by default — `package` builds the artifact, `github.release` creates the Release, `publish.<target>` uploads — without each downstream repo needing to fight the wrapper.

```diff
- # Hardcoded in run-release.sh, no way to opt out:
- RELEASE_ARGS=(... --skip-publish --no-github-release ...)
+
+ # action.yml inputs (both default false):
+   release-skip-publish:
+   release-skip-github-release:
+
+ # run-release.sh, conditional:
+ if [ "${RELEASE_SKIP_PUBLISH}" = "true" ]; then RELEASE_ARGS+=(--skip-publish); fi
+ if [ "${RELEASE_SKIP_GITHUB_RELEASE}" = "true" ]; then RELEASE_ARGS+=(--no-github-release); fi
```

## Background

Extra-Chill/data-machine adopted the homeboy-native release pattern (tracked in [homeboy#2572](https://github.com/Extra-Chill/homeboy/issues/2572)) and every release produced no ZIP and no GitHub release asset, even though:

- The wordpress extension v2.90.0 correctly declares both `release.package` and `release.publish` actions
- The extension is freshly installed in CI (verified `source_revision: dd47f26a`)
- The homeboy v0.182.0 release planner correctly adds `package`, `github.release`, and `publish.wordpress` steps when running locally with the same DM repo + same wordpress extension

The divergence between local-working and CI-broken turned out to be this wrapper: `scripts/release/run-release.sh` hardcoded `--skip-publish` and `--no-github-release`, which short-circuit the planner's `publish_targets`-driven step addition entirely. The release planner's own gates (extensions must provide `release.publish`, component must have a github.com remote) already prevent inappropriate step addition — there was no need for the wrapper to apply its own unconditional suppression on top.

## What changes

| Before | After |
|---|---|
| Always pass `--skip-publish` | Pass only when `release-skip-publish: 'true'` (default `false`) |
| Always pass `--no-github-release` | Pass only when `release-skip-github-release: 'true'` (default `false`) |

| Component type | Behavior before | Behavior after (no opt-in) |
|---|---|---|
| WordPress plugin (DM, DMC, etc.) with wordpress extension declared | No ZIP, no GH release asset (broken) | Full pipeline runs package → tag → push → github.release → publish.wordpress |
| Self-releasing component without extensions (homeboy CLI, homeboy-action, homeboy-extensions monorepo components) | Tag + push only (correct) | Adds github.release (would conflict with hand-rolled `gh release create` steps) |

The self-releasing repos need to explicitly opt back into the previous behavior. This PR updates `homeboy-action`'s own `release.yml` to pass `release-skip-publish: 'true'` and `release-skip-github-release: 'true'`. Companion PRs against `Extra-Chill/homeboy` and `Extra-Chill/homeboy-extensions` will do the same.

## Sequencing

GitHub Actions silently ignores unknown action inputs, so the consumer-side updates (homeboy, homeboy-extensions) can land before this PR — the inputs are no-ops on v2.5.4. Once this PR lands and the floating `v2` tag updates to v2.5.5+, the inputs take effect for any caller passing them.

For downstream consumers like DM and DMC that want the **new** default behavior: no action needed. Their next release after the v2 tag floats forward will start emitting ZIPs and `release-latest` branch pushes.

## Validation

- `bash -n scripts/release/run-release.sh` passes
- `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"` passes
- Diff is small and additive: 3 files changed, 33 insertions, 2 deletions

## Risk

- **Unknown external callers using `@v2`.** A code search for `homeboy-action@v2 commands: release` returned only Extra-Chill repos (data-machine, homeboy, homeboy-extensions, homeboy README/docs). No external callers found. The defaults change is safe.
- **Existing `@v2.5.4` callers that pin the SHA.** They keep the old behavior because they don't pull this commit. No breakage.
- **The `release-verify-github-release: true` default still applies.** When a downstream caller doesn't opt out of github.release, the verification check at the end of `run-release.sh` expects the GitHub Release to exist. With the new default (don't skip github.release), this stays consistent — the planner creates the Release and the verifier confirms it.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Traced the chain from Extra-Chill/data-machine v0.119.0-v0.119.3 release runs (no ZIPs, no `release-latest` branch) back through the homeboy release planner to homeboy-action's `run-release.sh`, identified the hardcoded `--skip-publish` and `--no-github-release` as the failure mode, and drafted the input + conditional flag wiring. Chris focused us on the upstream fix instead of a workaround revert.