### PR TITLE
fix: guard unsafe autofix PR reports

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -607,6 +607,7 @@ runs:
         COMPONENT_NAME: ${{ inputs.component }}
         AUTOFIX_BRANCH: ${{ steps.autofix-prepare-nonpr.outputs.autofix-branch }}
         AUTOFIX_FILE_COUNT: ${{ steps.autofix-prepare-nonpr.outputs.autofix-file-count }}
+        AUTOFIX_TOTAL_FIXES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-total-fixes }}
         AUTOFIX_FIX_TYPES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-fix-types }}
         AUTOFIX_FINDING_TYPES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-finding-types }}
         AUTOFIX_CHANGED_FILES: ${{ steps.autofix-prepare-nonpr.outputs.autofix-changed-files }}

--- a/scripts/autofix/open-autofix-pr.sh
+++ b/scripts/autofix/open-autofix-pr.sh
@@ -28,6 +28,15 @@ TITLE="chore(ci): autofix ${COMP_ID} from ${BASE_BRANCH}"
 BODY_FILE="$(mktemp)"
 trap 'rm -f "${BODY_FILE}"' EXIT
 
+autofix_prepare_pr_report "${WORKSPACE}"
+if autofix_pr_has_unsafe_unreported_changes "${WORKSPACE}"; then
+  echo "Skipping unsafe autofix PR: changed files are not covered by the autofix report"
+  autofix_unreported_review_files "${WORKSPACE}" | sed 's/^/- /'
+  echo "created=false" >> "${GITHUB_OUTPUT}"
+  echo "unsafe-unreported-changes=true" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
 build_autofix_pr_body "${RUN_URL}" "${AUTOFIX_BRANCH}" "${BASE_BRANCH}" > "${BODY_FILE}"
 
 if [ -n "${PR_OPEN_POLICY:-}" ]; then

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -294,6 +294,7 @@ fi
 echo "committed=true" >> "${GITHUB_OUTPUT}"
 echo "autofix-branch=${AUTOFIX_BRANCH}" >> "${GITHUB_OUTPUT}"
 echo "autofix-file-count=${AUTOFIX_FILE_COUNT}" >> "${GITHUB_OUTPUT}"
+echo "autofix-total-fixes=${AUTOFIX_TOTAL_FIXES:-0}" >> "${GITHUB_OUTPUT}"
 echo "autofix-fix-types=${AUTOFIX_FIX_TYPES:-}" >> "${GITHUB_OUTPUT}"
 echo "autofix-finding-types=${AUTOFIX_FINDING_TYPES:-}" >> "${GITHUB_OUTPUT}"
 write_multiline_output "autofix-changed-files" "${AUTOFIX_CHANGED_FILES:-}"

--- a/scripts/autofix/test-open-autofix-pr-report.sh
+++ b/scripts/autofix/test-open-autofix-pr-report.sh
@@ -102,6 +102,33 @@ JSON
 
 SOURCE_REPORT="$(extract_fix_report_from_output "${OUTPUT_DIR}")"
 
+REAL_REF_OUTPUT_DIR="${TMP_DIR}/real-refactor-output"
+mkdir -p "${REAL_REF_OUTPUT_DIR}"
+cat > "${REAL_REF_OUTPUT_DIR}/fix.json" <<'JSON'
+{
+  "success": false,
+  "data": {
+    "applied": true,
+    "changed_files": [
+      "src/core/code_audit/detectors/field_patterns.rs"
+    ],
+    "collected_edits": [
+      {
+        "action": "insert",
+        "file": "src/core/code_audit/detectors/field_patterns.rs",
+        "rule_id": "missingimport",
+        "source": "audit"
+      }
+    ],
+    "command": "refactor.sources",
+    "files_modified": 1
+  }
+}
+JSON
+
+REAL_REF_REPORT="$(extract_fix_report_from_output "${REAL_REF_OUTPUT_DIR}")"
+assert_contains "${REAL_REF_REPORT}" $'missingimport\t1\tsrc/core/code_audit/detectors/field_patterns.rs' "report extractor handles refactor.sources collected edits"
+
 BODY_CAPTURE="${TMP_DIR}/source-create.md"
 export BODY_CAPTURE
 export HOMEBOY_PR_MODE="create"

--- a/scripts/autofix/test-open-autofix-pr-report.sh
+++ b/scripts/autofix/test-open-autofix-pr-report.sh
@@ -106,6 +106,7 @@ BODY_CAPTURE="${TMP_DIR}/source-create.md"
 export BODY_CAPTURE
 export HOMEBOY_PR_MODE="create"
 export AUTOFIX_FILE_COUNT="2"
+export AUTOFIX_TOTAL_FIXES="1"
 export AUTOFIX_CHANGED_FILES=$'docs/architecture/ci-results-contract.md\nhomeboy.json'
 export AUTOFIX_REPORT="${SOURCE_REPORT}"
 
@@ -116,7 +117,9 @@ assert_contains "${SOURCE_BODY}" 'Fixed **1** `broken_doc_reference` finding.' "
 assert_contains "${SOURCE_BODY}" 'Changed **2** files.' "source summary includes changed file count"
 assert_contains "${SOURCE_BODY}" '| `broken_doc_reference` | 1 | `docs/architecture/ci-results-contract.md` |' "source table includes category/count/file"
 assert_contains "${SOURCE_BODY}" '- `homeboy.json` audit baseline metadata was refreshed.' "source report separates baseline churn"
+assert_contains "${SOURCE_BODY}" 'Autofix branch pushed; use the PR branch checks as merge verification.' "verification points to PR branch checks"
 assert_contains "${SOURCE_BODY}" '- Workflow run: https://github.com/Extra-Chill/homeboy-action/actions/runs/12345' "verification includes workflow run"
+assert_not_contains "${SOURCE_BODY}" 'Opened immediately after autofix without rerunning quality gates.' "verification avoids stale no-gates wording"
 assert_not_contains "${SOURCE_BODY}" 'file(s) fixed via' "source report omits generic old summary"
 
 FALLBACK_OUTPUT_DIR="${TMP_DIR}/fallback-output"
@@ -140,6 +143,7 @@ BODY_CAPTURE="${TMP_DIR}/fallback-create.md"
 export BODY_CAPTURE
 export HOMEBOY_PR_MODE="create"
 export AUTOFIX_FILE_COUNT="2"
+export AUTOFIX_TOTAL_FIXES="2"
 export AUTOFIX_CHANGED_FILES=$'src/core/code_audit/duplication.rs\nsrc/core/code_audit/requested_detectors.rs'
 export AUTOFIX_REPORT="${FALLBACK_REPORT}"
 
@@ -152,9 +156,36 @@ assert_contains "${FALLBACK_BODY}" '| `source_change` | 2 | `src/core/code_audit
 assert_not_contains "${FALLBACK_BODY}" 'No source fixes were reported by the autofix output.' "fallback avoids false no-source-fixes summary"
 assert_not_contains "${FALLBACK_BODY}" 'changed outside the reported source-fix set' "fallback does not misclassify source files as other changes"
 
+BODY_CAPTURE="${TMP_DIR}/synthesized-create.md"
+export BODY_CAPTURE
+export AUTOFIX_FILE_COUNT="1"
+export AUTOFIX_TOTAL_FIXES="1"
+export AUTOFIX_CHANGED_FILES="src/core/code_audit/detectors/field_patterns.rs"
+export AUTOFIX_REPORT=""
+
+bash "${ROOT}/scripts/autofix/open-autofix-pr.sh" >/tmp/homeboy-action-test-synthesized.log
+SYNTHESIZED_BODY="$(<"${BODY_CAPTURE}")"
+
+assert_contains "${SYNTHESIZED_BODY}" 'Applied autofix changes to **1** source file.' "synthesized report treats transported-empty fix as source change"
+assert_contains "${SYNTHESIZED_BODY}" '| `source_change` | 1 | `src/core/code_audit/detectors/field_patterns.rs` |' "synthesized report includes changed source file"
+assert_not_contains "${SYNTHESIZED_BODY}" 'changed outside the reported source-fix set' "synthesized report avoids unsafe other-change wording"
+
+BODY_CAPTURE="${TMP_DIR}/unsafe-create.md"
+export BODY_CAPTURE
+export AUTOFIX_FILE_COUNT="1"
+export AUTOFIX_TOTAL_FIXES="0"
+export AUTOFIX_CHANGED_FILES="src/core/code_audit/detectors/field_patterns.rs"
+export AUTOFIX_REPORT=""
+
+UNSAFE_LOG="$(bash "${ROOT}/scripts/autofix/open-autofix-pr.sh")"
+
+assert_contains "${UNSAFE_LOG}" 'Skipping unsafe autofix PR: changed files are not covered by the autofix report' "unsafe unreported source changes skip PR creation"
+assert_contains "$(<"${GITHUB_OUTPUT}")" 'unsafe-unreported-changes=true' "unsafe skip writes output flag"
+
 BODY_CAPTURE="${TMP_DIR}/baseline-create.md"
 export BODY_CAPTURE
 export AUTOFIX_FILE_COUNT="1"
+export AUTOFIX_TOTAL_FIXES="0"
 export AUTOFIX_CHANGED_FILES="homeboy.json"
 export AUTOFIX_REPORT=""
 
@@ -170,6 +201,7 @@ BODY_CAPTURE="${TMP_DIR}/source-edit.md"
 export BODY_CAPTURE
 export HOMEBOY_PR_MODE="find-existing"
 export AUTOFIX_FILE_COUNT="1"
+export AUTOFIX_TOTAL_FIXES="1"
 export AUTOFIX_CHANGED_FILES="docs/architecture/ci-results-contract.md"
 export AUTOFIX_REPORT="${SOURCE_REPORT}"
 

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -283,6 +283,86 @@ autofix_other_files() {
   printf '%s\n' "${changed}" | sed '/^[[:space:]]*$/d'
 }
 
+autofix_is_metadata_change() {
+  local file="$1"
+  case "${file}" in
+    homeboy.json|*.json|*.yml|*.yaml|*.toml|*.lock)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+autofix_review_files() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local changed drift_files file
+
+  changed="$(autofix_changed_files_list)"
+  [ -n "${changed}" ] || return 0
+  drift_files="$(drift_file_paths "${workspace}" | sort -u)"
+
+  while IFS= read -r file; do
+    [ -n "${file}" ] || continue
+    if printf '%s\n' "${drift_files}" | grep -Fx -- "${file}" >/dev/null 2>&1; then
+      continue
+    fi
+    if autofix_is_metadata_change "${file}"; then
+      continue
+    fi
+    printf '%s\n' "${file}"
+  done <<< "${changed}"
+}
+
+autofix_unreported_review_files() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local other drift_files file
+
+  other="$(autofix_other_files)"
+  [ -n "${other}" ] || return 0
+  drift_files="$(drift_file_paths "${workspace}" | sort -u)"
+
+  while IFS= read -r file; do
+    [ -n "${file}" ] || continue
+    if printf '%s\n' "${drift_files}" | grep -Fx -- "${file}" >/dev/null 2>&1; then
+      continue
+    fi
+    if autofix_is_metadata_change "${file}"; then
+      continue
+    fi
+    printf '%s\n' "${file}"
+  done <<< "${other}"
+}
+
+autofix_synthesize_source_report() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local files count joined
+
+  files="$(autofix_review_files "${workspace}")"
+  [ -n "${files}" ] || return 0
+  count="$(printf '%s\n' "${files}" | sed '/^[[:space:]]*$/d' | wc -l | xargs)"
+  joined="$(printf '%s\n' "${files}" | awk 'NR == 1 { out = $0; next } { out = out ", " $0 } END { print out }')"
+  printf 'source_change\t%s\t%s\n' "${count}" "${joined}"
+}
+
+autofix_prepare_pr_report() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local total_fixes="${AUTOFIX_TOTAL_FIXES:-0}"
+
+  if [ -z "${AUTOFIX_REPORT:-}" ] && [ "${total_fixes}" != "0" ]; then
+    AUTOFIX_REPORT="$(autofix_synthesize_source_report "${workspace}")"
+  fi
+}
+
+autofix_pr_has_unsafe_unreported_changes() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local unreported
+
+  unreported="$(autofix_unreported_review_files "${workspace}")"
+  [ -n "${unreported}" ]
+}
+
 autofix_count_report_rows() {
   printf '%s\n' "${AUTOFIX_REPORT:-}" | sed '/^[[:space:]]*$/d' | wc -l | xargs
 }
@@ -468,7 +548,7 @@ build_autofix_pr_body() {
   fi
 
   printf '## Verification\n'
-  printf -- '- Opened immediately after autofix without rerunning quality gates.\n'
+  printf -- '- Autofix branch pushed; use the PR branch checks as merge verification.\n'
   printf -- '- Workflow run: %s\n\n' "${run_url}"
 
   printf '## Context\n'

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -245,7 +245,7 @@ extract_fix_report_from_output() {
       count: length,
       files: ([.[].file] | unique | sort)
     }) |
-    sort_by(-.count, .cat) |
+    sort_by([-.count, .cat]) |
     .[] |
     [.cat, (.count | tostring), (.files | join(", "))] | @tsv
   ' ${json_files} 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Carry the autofix total-fix count into the non-PR PR-opening step so a transported-empty structured report can still render source changes accurately.
- Synthesize a conservative `source_change` report only when the autofix commit reported fixes, and skip PR creation when reviewable changed files remain outside the reported fix set.
- Replace the stale verification wording with guidance that PR branch checks are the merge verification signal.

## Investigation
- Extra-Chill/homeboy#2726 was created from an autofix commit whose message reported `1 fixes` / `missingimport`, but the PR body saw an empty `AUTOFIX_REPORT` and labeled `field_patterns.rs` as an unreported other change.
- That made the action produce a contradictory PR body: no source fixes reported, one source file changed, and no useful safety stop.

## Verification
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `for test_script in scripts/**/*test*.sh scripts/**/test-*.sh; do [ -f "$test_script" ] || continue; bash "$test_script"; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigating the unsafe autofix PR report path, drafting the shell/action changes, and running the test suite; Chris remains responsible for review and merge.