### PR TITLE
fix: avoid artifact action bootstrap in quality jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,10 +311,10 @@ jobs:
 
       - name: Download built Homeboy binary
         if: inputs.build-command != ''
-        uses: actions/download-artifact@v4
-        with:
-          name: homeboy-binary
-          path: .homeboy-bin
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run download "${GITHUB_RUN_ID}" --name homeboy-binary --dir .homeboy-bin
 
       - name: Resolve Homeboy binary path
         id: binary-path


### PR DESCRIPTION
## Summary
- Replace the quality job's conditional `actions/download-artifact@v4` step with `gh run download`.
- Avoid forcing every quality job to bootstrap `actions/download-artifact` even when callers do not use `build-command`.
- Preserve built-binary support for workflows that do upload `homeboy-binary`.

## Verification
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Data Machine Code CI bootstrap failure and drafted the reusable workflow fix; Chris remains responsible for review and testing.