### PR TITLE
fix: scope autofix stale binary guard

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -573,6 +573,7 @@ runs:
         AUTOFIX_LABEL: ${{ inputs.autofix-label }}
         AUTOFIX_MAX_COMMITS: ${{ inputs.autofix-max-commits }}
         AUTOFIX_MODE: ${{ inputs.autofix-mode }}
+        BINARY_SOURCE: ${{ steps.resolve-binary.outputs.binary-source }}
         PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -37,7 +37,7 @@ TARGET_REF="refs/remotes/homeboy-autofix-target/${TARGET_BRANCH}"
 ORIGINAL_HEAD_SHA="$(git rev-parse HEAD 2>/dev/null || true)"
 BUILT_HEAD_SHA="${HOMEBOY_CLI_HEAD_SHA:-}"
 
-if [ -n "${BUILT_HEAD_SHA}" ] && [ -n "${ORIGINAL_HEAD_SHA}" ] && [ "${BUILT_HEAD_SHA}" != "${ORIGINAL_HEAD_SHA}" ]; then
+if should_enforce_source_binary_freshness && [ -n "${ORIGINAL_HEAD_SHA}" ] && [ "${BUILT_HEAD_SHA}" != "${ORIGINAL_HEAD_SHA}" ]; then
   echo "Skipping autofix: installed homeboy binary was built from ${BUILT_HEAD_SHA}, but checkout is at ${ORIGINAL_HEAD_SHA}" 
   echo "attempted=false" >> "${GITHUB_OUTPUT}"
   echo "status=skipped-stale-binary" >> "${GITHUB_OUTPUT}"
@@ -239,7 +239,7 @@ else
   echo "Fetched latest PR head ${TARGET_REPO}:${TARGET_BRANCH}"
   if git show-ref --verify --quiet "${TARGET_REF}"; then
     TARGET_HEAD_SHA="$(git rev-parse "${TARGET_REF}" 2>/dev/null || true)"
-    if [ -n "${BUILT_HEAD_SHA}" ] && [ -n "${TARGET_HEAD_SHA}" ] && [ "${BUILT_HEAD_SHA}" != "${TARGET_HEAD_SHA}" ]; then
+    if should_enforce_source_binary_freshness && [ -n "${TARGET_HEAD_SHA}" ] && [ "${BUILT_HEAD_SHA}" != "${TARGET_HEAD_SHA}" ]; then
       echo "Skipping autofix: installed homeboy binary was built from ${BUILT_HEAD_SHA}, but latest PR head is ${TARGET_HEAD_SHA}"
       echo "attempted=false" >> "${GITHUB_OUTPUT}"
       echo "status=skipped-stale-binary" >> "${GITHUB_OUTPUT}"

--- a/scripts/autofix/test-source-binary-freshness-guard.sh
+++ b/scripts/autofix/test-source-binary-freshness-guard.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+source "${ROOT}/scripts/core/lib.sh"
+
+assert_guard() {
+  local expected="$1"
+  local binary_source="$2"
+  local built_head_sha="$3"
+  local label="$4"
+
+  set +e
+  BINARY_SOURCE="${binary_source}" HOMEBOY_CLI_HEAD_SHA="${built_head_sha}" should_enforce_source_binary_freshness
+  local actual="$?"
+  set -e
+
+  if [ "${actual}" != "${expected}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual: %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_guard 0 "source" "abc123" "source builds enforce freshness"
+assert_guard 1 "source" "" "source builds without metadata skip freshness guard"
+assert_guard 1 "release" "abc123" "release binaries skip freshness guard"
+assert_guard 1 "prebuilt" "abc123" "prebuilt binaries skip freshness guard"
+assert_guard 1 "fallback" "abc123" "fallback binaries skip freshness guard"
+assert_guard 1 "" "abc123" "unknown binary source skips freshness guard"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -63,6 +63,10 @@ pr_is_active() {
   esac
 }
 
+should_enforce_source_binary_freshness() {
+  [ "${BINARY_SOURCE:-}" = "source" ] && [ -n "${HOMEBOY_CLI_HEAD_SHA:-}" ]
+}
+
 # Build an informative autofix commit message.
 # Subject: chore(ci): homeboy autofix — audit (7 files, 33 fixes)
 # Body: per-category fix counts with affected files.


### PR DESCRIPTION
## Summary
- Scope the autofix stale-binary guard to source-built Homeboy binaries only.
- Pass the resolved `BINARY_SOURCE` into the PR autofix commit step.
- Add coverage proving release, prebuilt, fallback, and unknown binary sources skip the source-checkout freshness guard.

## Testing
- `bash scripts/autofix/test-source-binary-freshness-guard.sh`
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `for test_file in scripts/**/test-*.sh; do printf '== %s ==\n' "$test_file"; bash "$test_file"; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the targeted shell/action changes and test coverage; Chris remains responsible for review and merge.