### PR TITLE
fix: stage reported autofix files

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -148,7 +148,25 @@ stage_autofix_changes() {
     return 1
   fi
 
-  git add -A
+  local staged_any=false
+  while IFS= read -r file; do
+    [ -n "${file}" ] || continue
+    if [ ! -e "${file}" ] && git ls-files --error-unmatch -- "${file}" >/dev/null 2>&1; then
+      git add -u -- "${file}"
+      staged_any=true
+      continue
+    fi
+    if [ -e "${file}" ]; then
+      git add -- "${file}"
+      staged_any=true
+    fi
+  done < <(autofix_source_files_from_report)
+
+  if [ "${staged_any}" != "true" ]; then
+    echo "Skipping autofix commit: no reported source files to stage"
+    return 1
+  fi
+
   if git diff --cached --quiet; then
     return 1
   fi
@@ -161,7 +179,6 @@ commit_autofix_changes() {
   AUTOFIX_CHANGED_FILES="$(git diff --cached --name-only | sort)"
   AUTOFIX_FIX_TYPES=""
   AUTOFIX_FINDING_TYPES=""
-  AUTOFIX_REPORT=""
 
   for FIX_CMD in "${FIX_ARRAY[@]}"; do
     FIX_CMD=$(echo "${FIX_CMD}" | xargs)
@@ -171,22 +188,6 @@ commit_autofix_changes() {
     fi
     AUTOFIX_FIX_TYPES+="${BASE}"
   done
-
-  AUTOFIX_DETAILS=""
-  AUTOFIX_TOTAL_FIXES=""
-  # Read fix details from the autofix run's own output (AUTOFIX_OUTPUT_DIR),
-  # not the diagnostic run's output (HOMEBOY_OUTPUT_DIR). The autofix run
-  # captures --output with the actual fix results and fixer categories.
-  local details_dir="${AUTOFIX_OUTPUT_DIR:-${HOMEBOY_OUTPUT_DIR:-}}"
-  if [ -n "${details_dir}" ] && [ -d "${details_dir}" ]; then
-    local raw_details
-    raw_details="$(extract_fix_details_from_output "${details_dir}")"
-    if [ -n "${raw_details}" ]; then
-      AUTOFIX_TOTAL_FIXES="$(echo "${raw_details}" | head -1)"
-      AUTOFIX_DETAILS="$(echo "${raw_details}" | tail -n +2)"
-    fi
-    AUTOFIX_REPORT="$(extract_fix_report_from_output "${details_dir}")"
-  fi
 
   COMMIT_MSG="$(build_autofix_commit_message "${AUTOFIX_FIX_TYPES}" "${AUTOFIX_FILE_COUNT}" "${AUTOFIX_DETAILS}" "${AUTOFIX_TOTAL_FIXES}")"
 
@@ -199,6 +200,23 @@ commit_autofix_changes() {
   GIT_COMMITTER_NAME="${BOT_NAME}" \
   GIT_COMMITTER_EMAIL="${BOT_EMAIL}" \
     git commit -m "${COMMIT_MSG}"
+}
+
+load_autofix_metadata() {
+  AUTOFIX_DETAILS=""
+  AUTOFIX_TOTAL_FIXES=""
+  AUTOFIX_REPORT=""
+
+  local details_dir="${AUTOFIX_OUTPUT_DIR:-${HOMEBOY_OUTPUT_DIR:-}}"
+  if [ -n "${details_dir}" ] && [ -d "${details_dir}" ]; then
+    local raw_details
+    raw_details="$(extract_fix_details_from_output "${details_dir}")"
+    if [ -n "${raw_details}" ]; then
+      AUTOFIX_TOTAL_FIXES="$(echo "${raw_details}" | head -1)"
+      AUTOFIX_DETAILS="$(echo "${raw_details}" | tail -n +2)"
+    fi
+    AUTOFIX_REPORT="$(extract_fix_report_from_output "${details_dir}")"
+  fi
 }
 
 push_autofix_commit() {
@@ -267,6 +285,8 @@ if [ -n "${AUTOFIX_OUTPUT_DIR:-}" ] && check_core_guard_block "${AUTOFIX_OUTPUT_
 fi
 
 maybe_update_baseline
+
+load_autofix_metadata
 
 if ! stage_autofix_changes; then
   echo "No autofix changes detected"

--- a/scripts/autofix/test-open-autofix-pr-report.sh
+++ b/scripts/autofix/test-open-autofix-pr-report.sh
@@ -183,6 +183,27 @@ assert_contains "${FALLBACK_BODY}" '| `source_change` | 2 | `src/core/code_audit
 assert_not_contains "${FALLBACK_BODY}" 'No source fixes were reported by the autofix output.' "fallback avoids false no-source-fixes summary"
 assert_not_contains "${FALLBACK_BODY}" 'changed outside the reported source-fix set' "fallback does not misclassify source files as other changes"
 
+LINT_FIX_OUTPUT_DIR="${TMP_DIR}/lint-fix-output"
+mkdir -p "${LINT_FIX_OUTPUT_DIR}"
+cat > "${LINT_FIX_OUTPUT_DIR}/fix.json" <<'JSON'
+{
+  "success": true,
+  "data": {
+    "autofix": {
+      "changed_files": [
+        "inc/wiki/class-intelligence-wiki-brain-coverage-planner.php"
+      ],
+      "files_modified": 1
+    },
+    "component": "intelligence",
+    "status": "passed"
+  }
+}
+JSON
+
+LINT_FIX_REPORT="$(extract_fix_report_from_output "${LINT_FIX_OUTPUT_DIR}")"
+assert_contains "${LINT_FIX_REPORT}" $'source_change	1	inc/wiki/class-intelligence-wiki-brain-coverage-planner.php' "lint --fix report classifies autofix changed files"
+
 BODY_CAPTURE="${TMP_DIR}/synthesized-create.md"
 export BODY_CAPTURE
 export AUTOFIX_FILE_COUNT="1"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -182,10 +182,13 @@ extract_fix_details_from_output() {
     [ .[] | select((.command // "") == "refactor.sources" and (.applied // false)) |
       (.changed_files // [])[] | {cat: "source_change", file: .}
     ] as $source_changes |
+    [ .[] | select(((.autofix.changed_files // []) | length) > 0) |
+      (.autofix.changed_files // [])[] | {cat: "source_change", file: .}
+    ] as $lint_autofix_changes |
 
     # Prefer precise structured rows. Fall back to changed_files only when the
     # source run would otherwise look like a metadata-only change.
-    (if ($structured | length) > 0 then $structured else $source_changes end) |
+    (if ($structured | length) > 0 then $structured else ($source_changes + $lint_autofix_changes) end) |
     group_by(.cat) |
     map({
       cat: .[0].cat,
@@ -241,8 +244,11 @@ extract_fix_report_from_output() {
     [ .[] | select((.command // "") == "refactor.sources" and (.applied // false)) |
       (.changed_files // [])[] | {cat: "source_change", file: .}
     ] as $source_changes |
+    [ .[] | select(((.autofix.changed_files // []) | length) > 0) |
+      (.autofix.changed_files // [])[] | {cat: "source_change", file: .}
+    ] as $lint_autofix_changes |
 
-    (if ($structured | length) > 0 then $structured else $source_changes end) |
+    (if ($structured | length) > 0 then $structured else ($source_changes + $lint_autofix_changes) end) |
     group_by(.cat) |
     map({
       cat: .[0].cat,


### PR DESCRIPTION
## Summary
- Stage only source files reported by Homeboy autofix output for PR autofix commits instead of using `git add -A`.
- Teach autofix report extraction to read `lint --fix` autofix changed files.
- Add regression coverage for lint autofix report extraction.

This is a safety rail for the formatter-scope fix in Extra-Chill/homeboy#2910 and Extra-Chill/homeboy-extensions#789.

## Testing
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `bash scripts/core/test-command-builders.sh`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the oversized PR autofix commit path, constrained action staging to reported autofix files, and added targeted shell coverage. Chris remains responsible for review and merge.