### PR TITLE
Delegate PR comment tooling footer to core

### DIFF
--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -68,11 +68,6 @@ append_review_report_section() {
     return 0
   fi
 
-  if [[ "${review_md}" != *"finding(s) across"* ]]; then
-    SECTION_BODY+="> :warning: \`homeboy review --report=pr-comment\` returned an unexpected report shape. Check the action logs for details."$'\n\n'
-    return 0
-  fi
-
   SECTION_BODY+="${review_md}"$'\n\n'
 
   # Exit code 1 means the review found issues, which is exactly when the PR
@@ -276,13 +271,13 @@ build_section_body() {
   append_observation_artifact_guidance
 }
 
-# Build the shared `tooling` section body written at the bottom of every
-# Homeboy Results comment. This section is re-rendered idempotently by every
-# invocation of `post-pr-comment.sh` so versions always reflect the latest
-# run. Pinned last via `--section-order lint,build,test,audit,tooling`.
+# Build the shared tooling footer written at the bottom of every Homeboy Results
+# comment. The footer is handed to Homeboy core with `git pr comment
+# --footer-file`, so section merging, idempotency, and footer placement stay in
+# the core PR-comment surface.
 #
 # Writes to stdout so the caller can redirect to a tmp file.
-build_tooling_section() {
+build_tooling_footer() {
   local cli_version="${HOMEBOY_CLI_VERSION:-unknown}"
   local extension_id="${HOMEBOY_EXTENSION_ID:-auto}"
   local extension_source="${HOMEBOY_EXTENSION_SOURCE:-auto}"

--- a/scripts/pr/comment/test-review-report-section.sh
+++ b/scripts/pr/comment/test-review-report-section.sh
@@ -36,6 +36,10 @@ trap 'rm -rf "${fake_bin}"' EXIT
 cat > "${fake_bin}/homeboy" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${HOMEBOY_REVIEW_CALL_LOG}"
+if [ "${HOMEBOY_REVIEW_OUTPUT_MODE:-}" = "custom" ]; then
+  printf 'Custom core-rendered markdown without action-side shape coupling\n'
+  exit 0
+fi
 printf ':zap: Scope: **changed files only** (since `origin/main`)\n\n'
 printf '> :wrench: **autofix:** applied — 2 file(s) fixed via lint\n'
 printf '> :warning: **binary-source:** fallback release binary (source build failed)\n\n'
@@ -81,6 +85,11 @@ assert_contains "${SECTION_BODY}" "https://github.com/Extra-Chill/homeboy-action
 assert_not_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "legacy per-command audit block skipped"
 assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner autofix=applied — 2 file(s) fixed via lint" "autofix banner passed to core"
 assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner binary-source=fallback release binary (source build failed)" "binary-source banner passed to core"
+
+export HOMEBOY_REVIEW_OUTPUT_MODE="custom"
+build_section_body
+assert_contains "${SECTION_BODY}" "Custom core-rendered markdown without action-side shape coupling" "custom core markdown is appended without report-shape checks"
+unset HOMEBOY_REVIEW_OUTPUT_MODE
 
 export EXTRA_ARGS="--format json"
 build_section_body

--- a/scripts/pr/comment/test-skip-green-noop-comment.sh
+++ b/scripts/pr/comment/test-skip-green-noop-comment.sh
@@ -87,20 +87,23 @@ assert_equals "" "$(cat "${HOMEBOY_CALL_LOG}")" "clean run does not call homeboy
 
 output="$(RESULTS='{"audit":"fail"}' run_post_comment)"
 assert_contains "${output}" "PR comment posted successfully" "failed run comments"
-assert_equals "2" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "failed run posts section and tooling"
+assert_equals "1" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "failed run posts section with tooling footer"
+assert_contains "$(cat "${HOMEBOY_CALL_LOG}")" "--footer-file" "failed run delegates tooling footer to core"
 
 export COMMANDS="refactor"
 export AUTOFIX_ENABLED="true"
 export AUTOFIX_COMMITTED="true"
 output="$(RESULTS='{"refactor":"pass"}' run_post_comment)"
 assert_contains "${output}" "PR comment posted successfully" "autofix-applied run comments"
-assert_equals "2" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "autofix-applied run posts section and tooling"
+assert_equals "1" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "autofix-applied run posts section with tooling footer"
+assert_contains "$(cat "${HOMEBOY_CALL_LOG}")" "--footer-file" "autofix-applied run delegates tooling footer to core"
 
 export COMMANDS="audit"
 export AUTOFIX_ENABLED="false"
 export AUTOFIX_COMMITTED="false"
 output="$(RESULTS='{"audit":"mystery"}' run_post_comment)"
 assert_contains "${output}" "PR comment posted successfully" "unknown-status run comments"
-assert_equals "2" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "unknown-status run posts section and tooling"
+assert_equals "1" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "unknown-status run posts section with tooling footer"
+assert_contains "$(cat "${HOMEBOY_CALL_LOG}")" "--footer-file" "unknown-status run delegates tooling footer to core"
 
 printf 'All green no-op PR comment checks passed.\n'

--- a/scripts/pr/comment/test-tooling-section.sh
+++ b/scripts/pr/comment/test-tooling-section.sh
@@ -40,12 +40,12 @@ export HOMEBOY_ACTION_REF="feature/footer-test"
 
 source "${ROOT}/scripts/pr/comment/sections.sh"
 
-tooling_section="$(build_tooling_section)"
+tooling_footer="$(build_tooling_footer)"
 
-assert_contains "${tooling_section}" '- Homeboy CLI: `homeboy 1.2.3`' "tooling section includes CLI version"
-assert_contains "${tooling_section}" '- Action: `Extra-Chill/homeboy-action@feature/footer-test`' "tooling section renders actual action ref"
-assert_not_contains "${tooling_section}" 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v1' "tooling section does not hardcode v1 footer"
-assert_not_contains "${tooling_section}" 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v2' "tooling section does not hardcode v2 footer"
-assert_not_contains "${tooling_section}" '---' "tooling section has no redundant footer separator"
+assert_contains "${tooling_footer}" '- Homeboy CLI: `homeboy 1.2.3`' "tooling footer includes CLI version"
+assert_contains "${tooling_footer}" '- Action: `Extra-Chill/homeboy-action@feature/footer-test`' "tooling footer renders actual action ref"
+assert_not_contains "${tooling_footer}" 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v1' "tooling footer does not hardcode v1 footer"
+assert_not_contains "${tooling_footer}" 'Homeboy Action](https://github.com/Extra-Chill/homeboy-action) v2' "tooling footer does not hardcode v2 footer"
+assert_not_contains "${tooling_footer}" '---' "tooling footer has no redundant separator"
 
-printf 'All tooling section checks passed.\n'
+printf 'All tooling footer checks passed.\n'

--- a/scripts/pr/post-pr-comment.sh
+++ b/scripts/pr/post-pr-comment.sh
@@ -5,21 +5,21 @@
 # Uses the sectioned PR-comment primitive from Extra-Chill/homeboy#1353:
 #   homeboy git pr comment <component> \
 #     --comment-key <outer> --section-key <inner> \
-#     --body-file <path> --header "..." --section-order <...>
+#     --body-file <path> --header "..." --footer-file <path> \
+#     --section-order <...>
 #
 # Core handles:
 #   - parsing existing sections (new + legacy markers)
 #   - merging this invocation's section in place (preserving position)
 #   - race consolidation (canonical = lowest id, delete duplicates)
 #   - idempotency (identical body → noop, no PATCH)
-#   - header preservation across merges
+#   - header/footer preservation and replacement across merges
 #
 # This script delegates this job's section body to
-# `homeboy review --report=pr-comment`, then makes two primitive calls: one for
-# this job's section, one for the shared "tooling" section (re-rendered every
-# run so versions stay fresh).
+# `homeboy review --report=pr-comment`, then lets Homeboy core merge the section
+# and footer into the shared sticky comment.
 #
-# Renderer migration tracked in: Extra-Chill/homeboy-action#144.
+# Renderer migration tracked in: Extra-Chill/homeboy-action#239.
 
 set -euo pipefail
 
@@ -52,10 +52,10 @@ COMMENT_KEY="$(derive_comment_key)"
 SECTION_KEY="$(derive_section_key)"
 SECTION_TITLE="$(derive_section_title)"
 HEADER="## Homeboy Results — \`${COMP_ID}\`"
-# Preserve the current rendered order (lint, build, test, audit, bench). Core's
-# default is alphabetical; `tooling` is pinned last so the versions block
-# stays at the bottom of the comment.
-SECTION_ORDER="lint,build,test,audit,bench,tooling"
+# Preserve the current rendered section order (lint, build, test, audit, bench).
+# Tooling versions are passed as the core-managed footer instead of an action-
+# rendered pseudo-section.
+SECTION_ORDER="lint,build,test,audit,bench"
 
 if ! comment_has_actionable_content; then
   echo "Skipping PR comment — run passed with no actionable content"
@@ -65,11 +65,11 @@ fi
 build_section_body
 
 SECTION_FILE="$(mktemp)"
-TOOLING_FILE="$(mktemp)"
-trap 'rm -f "${SECTION_FILE}" "${TOOLING_FILE}"' EXIT
+TOOLING_FOOTER_FILE="$(mktemp)"
+trap 'rm -f "${SECTION_FILE}" "${TOOLING_FOOTER_FILE}"' EXIT
 
 printf '%s' "${SECTION_BODY}" > "${SECTION_FILE}"
-build_tooling_section > "${TOOLING_FILE}"
+build_tooling_footer > "${TOOLING_FOOTER_FILE}"
 
 # --- Post this job's section -------------------------------------------------
 POST_RESULT="$(
@@ -80,6 +80,7 @@ POST_RESULT="$(
     --section-key "${SECTION_KEY}" \
     --body-file "${SECTION_FILE}" \
     --header "${HEADER}" \
+    --footer-file "${TOOLING_FOOTER_FILE}" \
     --section-order "${SECTION_ORDER}" 2>/dev/null || true
 )"
 
@@ -97,28 +98,6 @@ echo "Posted section '${SECTION_KEY}' to comment #${POSTED_COMMENT_ID:-?} (${POS
 if [ -n "${POSTED_COMMENT_ID:-}" ]; then
   echo "HOMEBOY_PR_COMMENT_POSTED=true" >> "${GITHUB_ENV}"
   echo "HOMEBOY_PR_COMMENT_ID=${POSTED_COMMENT_ID}" >> "${GITHUB_ENV}"
-fi
-
-# --- Refresh the shared `tooling` section -----------------------------------
-# Every invocation idempotently rewrites the tooling footer with current env
-# values. Core's noop-on-identical-body guard means this is free when nothing
-# changed. Race-safe: last writer wins, content is always derivable from env.
-TOOLING_RESULT="$(
-  homeboy git pr comment "${COMP_ID}" \
-    --path "${WORKSPACE}" \
-    --number "${PR_NUMBER}" \
-    --comment-key "${COMMENT_KEY}" \
-    --section-key "tooling" \
-    --body-file "${TOOLING_FILE}" \
-    --header "${HEADER}" \
-    --section-order "${SECTION_ORDER}" 2>/dev/null || true
-)"
-
-if [ -z "${TOOLING_RESULT}" ]; then
-  echo "::warning::Could not refresh tooling section (continuing; section may be stale)."
-else
-  TOOLING_ACTION="$(printf '%s' "${TOOLING_RESULT}" | jq -r '.action // empty' 2>/dev/null || true)"
-  echo "Refreshed tooling section (${TOOLING_ACTION:-unknown})"
 fi
 
 echo "PR comment posted successfully"


### PR DESCRIPTION
## Summary
- collapse PR comment posting from separate result/tooling section updates into a single sectioned `homeboy git pr comment` call using core `--footer-file`
- keep sectioned sticky comments and actionable-content gating intact
- stop validating the exact `homeboy review --report=pr-comment` markdown shape in action shell code

Fixes https://github.com/Extra-Chill/homeboy-action/issues/239

## Testing
- `bash scripts/pr/comment/test-review-report-section.sh`
- `bash scripts/pr/comment/test-skip-green-noop-comment.sh`
- `bash scripts/pr/comment/test-tooling-section.sh`
- `bash scripts/pr/comment/test-unknown-status-rendering.sh`
- `bash scripts/pr/comment/test-section-key-slug.sh`
- `bash scripts/pr/comment/test-app-token-required.sh`
- `for test_script in scripts/**/test-*.sh; do bash "" || exit 1; done`

## Caveats
- The remaining split per-command renderer stays in place for command shapes that core `homeboy review --report=pr-comment` does not cover safely yet, such as single-command/custom-args paths.
- Existing sticky comments that already contain the old `tooling` section may keep that preserved section until a future core migration/delete API exists; new/updated footer content is now supplied through core `--footer-file`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the action shell cleanup and test updates; Chris remains responsible for review and merge.