### PR TITLE
fix: stage autofix source changes without report rows

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -160,7 +160,7 @@ stage_autofix_changes() {
       git add -- "${file}"
       staged_any=true
     fi
-  done < <(autofix_source_files_from_report)
+  done < <(autofix_stage_source_files "${WORKSPACE}")
 
   if [ "${staged_any}" != "true" ]; then
     echo "Skipping autofix commit: no reported source files to stage"

--- a/scripts/autofix/test-open-autofix-pr-report.sh
+++ b/scripts/autofix/test-open-autofix-pr-report.sh
@@ -204,6 +204,23 @@ JSON
 LINT_FIX_REPORT="$(extract_fix_report_from_output "${LINT_FIX_OUTPUT_DIR}")"
 assert_contains "${LINT_FIX_REPORT}" $'source_change	1	inc/wiki/class-intelligence-wiki-brain-coverage-planner.php' "lint --fix report classifies autofix changed files"
 
+STAGE_REPO="${TMP_DIR}/stage-source-fallback"
+mkdir -p "${STAGE_REPO}/src/Runtime"
+git -C "${STAGE_REPO}" init -q
+git -C "${STAGE_REPO}" config user.name "Test User"
+git -C "${STAGE_REPO}" config user.email "test@example.com"
+printf '{"component":"agents-api"}\n' > "${STAGE_REPO}/homeboy.json"
+printf '<?php\nclass WP_Agent_Conversation_Loop {}\n' > "${STAGE_REPO}/src/Runtime/class-wp-agent-conversation-loop.php"
+git -C "${STAGE_REPO}" add .
+git -C "${STAGE_REPO}" commit -q -m "initial"
+printf '{"component":"agents-api","baseline":true}\n' > "${STAGE_REPO}/homeboy.json"
+printf '<?php\nclass WP_Agent_Conversation_Loop { }\n' > "${STAGE_REPO}/src/Runtime/class-wp-agent-conversation-loop.php"
+
+export AUTOFIX_REPORT=""
+STAGE_SOURCE_FILES="$(cd "${STAGE_REPO}" && autofix_stage_source_files "${STAGE_REPO}")"
+assert_contains "${STAGE_SOURCE_FILES}" "src/Runtime/class-wp-agent-conversation-loop.php" "empty report falls back to changed source files"
+assert_not_contains "${STAGE_SOURCE_FILES}" "homeboy.json" "empty report fallback excludes drift files"
+
 BODY_CAPTURE="${TMP_DIR}/synthesized-create.md"
 export BODY_CAPTURE
 export AUTOFIX_FILE_COUNT="1"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -325,6 +325,22 @@ autofix_review_files() {
   done <<< "${changed}"
 }
 
+autofix_stage_source_files() {
+  local workspace="${1:-$(resolve_workspace)}"
+  local reported previous_changed
+
+  reported="$(autofix_source_files_from_report)"
+  if [ -n "${reported}" ]; then
+    printf '%s\n' "${reported}"
+    return 0
+  fi
+
+  previous_changed="${AUTOFIX_CHANGED_FILES-}"
+  AUTOFIX_CHANGED_FILES="$(git_changed_files)"
+  autofix_review_files "${workspace}"
+  AUTOFIX_CHANGED_FILES="${previous_changed}"
+}
+
 autofix_unreported_review_files() {
   local workspace="${1:-$(resolve_workspace)}"
   local other drift_files file


### PR DESCRIPTION
## Summary
- Fixes PR autofix staging when Homeboy generated source changes but the machine-readable report rows are missing or empty.
- Falls back to the actual Git diff and filters out drift/metadata files before staging source changes.
- Adds regression coverage for the issue #3388 shape: changed source file plus `homeboy.json` drift with no `AUTOFIX_REPORT` rows.

Fixes Extra-Chill/homeboy#3388.

## Verification
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `for test_script in scripts/autofix/test-*.sh scripts/core/test-*.sh; do printf '\n== %s ==\n' "$test_script"; bash "$test_script" || exit 1; done`
- `for test_script in scripts/setup/test-*.sh scripts/scope/test-*.sh scripts/release/test-*.sh scripts/pr/test-*.sh scripts/pr/comment/test-*.sh scripts/issues/test-*.sh scripts/digest/test-*.sh; do printf '\n== %s ==\n' "$test_script"; bash "$test_script" || exit 1; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Investigated the issue, drafted the staging fallback and regression test, and ran the shell verification suite. Chris remains responsible for review and merge.