### PR TITLE
Print scoped failure reproduction commands

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -636,6 +636,7 @@ runs:
         AUTOFIX_ENABLED: ${{ inputs.autofix == 'true' }}
         AUTOFIX_ATTEMPTED: ${{ steps.autofix-commit.outputs.committed == 'true' || steps.autofix-prepare-nonpr.outputs.committed == 'true' }}
         AUTOFIX_COMMANDS: ${{ inputs.autofix-commands }}
+        COMPONENT_NAME: ${{ inputs.component }}
       run: bash ${{ github.action_path }}/scripts/digest/generate-failure-digest.sh
 
     - name: Run release

--- a/scripts/digest/generate-failure-digest.sh
+++ b/scripts/digest/generate-failure-digest.sh
@@ -15,6 +15,43 @@ COMMANDS_CSV="${COMMANDS:-}"
 AUTOFIX_ENABLED="${AUTOFIX_ENABLED:-false}"
 AUTOFIX_ATTEMPTED="${AUTOFIX_ATTEMPTED:-false}"
 AUTOFIX_COMMANDS="${AUTOFIX_COMMANDS:-}"
+COMPONENT_NAME="${COMPONENT_NAME:-${HOMEBOY_COMPONENT_ID:-}}"
+
+append_local_reproduction_commands() {
+  local digest_file="$1"
+  local failed_commands
+  local command
+  local scope_args=""
+
+  failed_commands="$(jq -r '
+    to_entries[]
+    | select(.value == "fail" and (.key == "lint" or .key == "test"))
+    | .key
+  ' <<< "${RESULTS_JSON}" 2>/dev/null || true)"
+
+  [ -n "${failed_commands}" ] || return 0
+
+  if [ -z "${COMPONENT_NAME}" ]; then
+    return 0
+  fi
+
+  if [ "${SCOPE_MODE:-full}" = "changed" ] && [ -n "${SCOPE_BASE_REF:-}" ]; then
+    scope_args=" --changed-since ${SCOPE_BASE_REF}"
+  fi
+
+  {
+    printf '\n### Local reproduction\n'
+    printf -- '- Scope context: `%s`\n' "${SCOPE_CONTEXT:-unknown}"
+    printf -- '- Scope mode: `%s`\n' "${SCOPE_MODE:-full}"
+    printf -- '- Scope base ref: `%s`\n' "${SCOPE_BASE_REF:-none}"
+    printf '\n```bash\n'
+    while IFS= read -r command; do
+      [ -n "${command}" ] || continue
+      printf 'homeboy %s %s --path .%s\n' "${command}" "${COMPONENT_NAME}" "${scope_args}"
+    done <<< "${failed_commands}"
+    printf '```\n'
+  } >> "${digest_file}"
+}
 
 if [ -z "${OUTPUT_DIR}" ] || [ ! -d "${OUTPUT_DIR}" ]; then
   echo "No output directory available; skipping failure digest"
@@ -72,6 +109,8 @@ if [ ! -s "${DIGEST_FILE}" ]; then
   rm -f "${DIGEST_FILE}"
   exit 0
 fi
+
+append_local_reproduction_commands "${DIGEST_FILE}"
 
 if [ -n "${GITHUB_ENV:-}" ]; then
   echo "HOMEBOY_FAILURE_DIGEST_FILE=${DIGEST_FILE}" >> "${GITHUB_ENV}"

--- a/scripts/digest/test-generate-failure-digest.sh
+++ b/scripts/digest/test-generate-failure-digest.sh
@@ -28,7 +28,7 @@ chmod +x "${BIN_DIR}/homeboy"
 export PATH="${BIN_DIR}:${PATH}"
 export HOMEBOY_STUB_ARGS_FILE="${ARGS_FILE}"
 export HOMEBOY_OUTPUT_DIR="${OUTPUT_DIR}"
-export RESULTS='{"test":"fail"}'
+export RESULTS='{"lint":"fail","test":"fail"}'
 export GITHUB_SERVER_URL="https://github.com"
 export GITHUB_REPOSITORY="Extra-Chill/homeboy-action"
 export GITHUB_RUN_ID="12345"
@@ -38,10 +38,14 @@ export HOMEBOY_EXTENSION_SOURCE="https://github.com/Extra-Chill/homeboy-extensio
 export HOMEBOY_EXTENSION_REVISION="abc123"
 export HOMEBOY_ACTION_REPOSITORY="Extra-Chill/homeboy-action"
 export HOMEBOY_ACTION_REF="v2"
-export COMMANDS="test,audit"
+export COMMANDS="lint,test,audit"
 export AUTOFIX_ENABLED="true"
 export AUTOFIX_ATTEMPTED="true"
 export AUTOFIX_COMMANDS="test"
+export COMPONENT_NAME="wordpress"
+export SCOPE_CONTEXT="pr"
+export SCOPE_MODE="changed"
+export SCOPE_BASE_REF="abc123base"
 export GITHUB_ENV="${ENV_FILE}"
 export GITHUB_STEP_SUMMARY="${SUMMARY_FILE}"
 
@@ -57,6 +61,12 @@ fi
 
 grep -F "HOMEBOY_FAILURE_DIGEST_FILE=${DIGEST_FILE}" "${ENV_FILE}" >/dev/null
 grep -F "### Test Failure Digest" "${SUMMARY_FILE}" >/dev/null
+grep -F "### Local reproduction" "${DIGEST_FILE}" >/dev/null
+grep -F -- "- Scope context: \`pr\`" "${DIGEST_FILE}" >/dev/null
+grep -F -- "- Scope mode: \`changed\`" "${DIGEST_FILE}" >/dev/null
+grep -F -- "- Scope base ref: \`abc123base\`" "${DIGEST_FILE}" >/dev/null
+grep -F "homeboy lint wordpress --path . --changed-since abc123base" "${DIGEST_FILE}" >/dev/null
+grep -F "homeboy test wordpress --path . --changed-since abc123base" "${DIGEST_FILE}" >/dev/null
 
 grep -Fx -- "report" "${ARGS_FILE}" >/dev/null
 grep -Fx -- "failure-digest" "${ARGS_FILE}" >/dev/null
@@ -69,7 +79,7 @@ grep -Fx -- "https://github.com/Extra-Chill/homeboy-action/actions/runs/12345" "
 grep -Fx -- "--tooling-json" "${ARGS_FILE}" >/dev/null
 grep -Fx -- "${TOOLING_JSON}" "${ARGS_FILE}" >/dev/null
 grep -Fx -- "--commands" "${ARGS_FILE}" >/dev/null
-grep -Fx -- "test,audit" "${ARGS_FILE}" >/dev/null
+grep -Fx -- "lint,test,audit" "${ARGS_FILE}" >/dev/null
 grep -Fx -- "--autofix-commands" "${ARGS_FILE}" >/dev/null
 grep -Fx -- "test" "${ARGS_FILE}" >/dev/null
 grep -Fx -- "--autofix-enabled" "${ARGS_FILE}" >/dev/null


### PR DESCRIPTION
## Summary
- Append local reproduction commands to the generated failure digest for failed `lint` and `test` commands.
- Include the resolved scope context, scope mode, and base ref so PR-scoped local runs match CI's changed-file selection.
- Pass the action component input into digest generation so the copy-paste command includes the same Homeboy component ID.

Fixes Extra-Chill/homeboy-extensions#1065.

## Verification
- `bash scripts/digest/test-generate-failure-digest.sh`
- `bash -n scripts/digest/generate-failure-digest.sh scripts/digest/test-generate-failure-digest.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Inspected the Homeboy Extensions/action failure digest flow, implemented the scoped reproduction command append, updated targeted shell tests, and ran verification. Chris remains responsible for review and merge.