### PR TITLE
Fix GitHub Actions hot-runner Homeboy checks

### DIFF
--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -727,19 +727,31 @@ settings_json_flags() {
   done < <(printf '%s' "${raw}" | jq -r 'to_entries[] | [.key, (.value | tojson)] | @tsv')
 }
 
+homeboy_global_flags() {
+  local output_file="${1:-}"
+  local flags=""
+
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    flags="${flags}--force-hot --allow-local-hot "
+  fi
+
+  # --output is a global flag and must appear before the subcommand
+  # (clap global args don't propagate when placed after positional args)
+  if [ -n "${output_file}" ]; then
+    flags="${flags}--output ${output_file} "
+  fi
+
+  printf '%s' "${flags}"
+}
+
 build_run_command() {
   local cmd="$1"
   local component_id="$2"
   local workspace="$3"
   local output_file="${4:-}"
   local full_cmd
-  local global_flags=""
-
-  # --output is a global flag and must appear before the subcommand
-  # (clap global args don't propagate when placed after positional args)
-  if [ -n "${output_file}" ]; then
-    global_flags="--output ${output_file} "
-  fi
+  local global_flags
+  global_flags="$(homeboy_global_flags "${output_file}")"
 
   if [[ "${cmd}" == refactor* ]]; then
     full_cmd="homeboy ${global_flags}refactor ${component_id} ${cmd#refactor } --path ${workspace}"
@@ -828,12 +840,8 @@ build_autofix_command() {
   local workspace="$3"
   local output_file="${4:-}"
   local full_cmd
-  local global_flags=""
-
-  # --output is a global flag and must appear before the subcommand
-  if [ -n "${output_file}" ]; then
-    global_flags="--output ${output_file} "
-  fi
+  local global_flags
+  global_flags="$(homeboy_global_flags "${output_file}")"
 
   if [[ "${fix_cmd}" == refactor* ]]; then
     full_cmd="homeboy ${global_flags}refactor ${component_id} ${fix_cmd#refactor } --path ${workspace}"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -55,7 +55,7 @@ COMPONENT="data-machine"
 OUTPUT_JSON="/tmp/workspace/out.json"
 
 # ── Unscoped (full mode) ──
-unset SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true
+unset GITHUB_ACTIONS SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true
 SCOPE_MODE="full"
 assert_equals \
   "homeboy lint data-machine --path /tmp/workspace" \
@@ -80,6 +80,19 @@ assert_equals \
   "homeboy --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "lint keeps output path with changed-since"
+
+GITHUB_ACTIONS="true"
+assert_equals \
+  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "GitHub Actions lint opts into hot-runner execution"
+
+assert_equals \
+  "homeboy --force-hot --allow-local-hot test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
+  "GitHub Actions test opts into hot-runner execution"
+
+unset GITHUB_ACTIONS
 
 assert_equals \
   "homeboy test data-machine --path /tmp/workspace --changed-since origin/main" \


### PR DESCRIPTION
## Summary
- Add GitHub Actions-specific Homeboy global flags so action-managed quality commands explicitly run on the GitHub runner instead of failing the hot/warm resource-policy gate.
- Keep local command generation unchanged and cover the GitHub Actions command shape in command-builder tests.

## Testing
- `bash scripts/core/test-command-builders.sh`
- `for f in scripts/**/test-*.sh; do bash \"$f\" || exit 1; done`
- `GITHUB_ACTIONS=true homeboy --force-hot --allow-local-hot --version`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the CI wrapper failure, drafted the shell helper/test changes, and ran local verification. Chris remains responsible for review and merge.