### PR TITLE
fix: reconcile autofix PR reports with committed files

### DIFF
--- a/scripts/autofix/test-open-autofix-pr-report.sh
+++ b/scripts/autofix/test-open-autofix-pr-report.sh
@@ -183,6 +183,20 @@ assert_contains "${FALLBACK_BODY}" '| `source_change` | 2 | `src/core/code_audit
 assert_not_contains "${FALLBACK_BODY}" 'No source fixes were reported by the autofix output.' "fallback avoids false no-source-fixes summary"
 assert_not_contains "${FALLBACK_BODY}" 'changed outside the reported source-fix set' "fallback does not misclassify source files as other changes"
 
+BODY_CAPTURE="${TMP_DIR}/stale-source-report-create.md"
+export BODY_CAPTURE
+export AUTOFIX_FILE_COUNT="1"
+export AUTOFIX_TOTAL_FIXES="2"
+export AUTOFIX_CHANGED_FILES="src/core/code_audit/duplication.rs"
+export AUTOFIX_REPORT="${FALLBACK_REPORT}"
+
+bash "${ROOT}/scripts/autofix/open-autofix-pr.sh" >/tmp/homeboy-action-test-stale-source-report.log
+STALE_SOURCE_BODY="$(<"${BODY_CAPTURE}")"
+
+assert_contains "${STALE_SOURCE_BODY}" 'Applied autofix changes to **1** source file.' "stale source report summary follows committed files"
+assert_contains "${STALE_SOURCE_BODY}" '| `source_change` | 1 | `src/core/code_audit/duplication.rs` |' "stale source report table drops uncommitted files"
+assert_not_contains "${STALE_SOURCE_BODY}" 'src/core/code_audit/requested_detectors.rs' "stale source report omits uncommitted source file"
+
 LINT_FIX_OUTPUT_DIR="${TMP_DIR}/lint-fix-output"
 mkdir -p "${LINT_FIX_OUTPUT_DIR}"
 cat > "${LINT_FIX_OUTPUT_DIR}/fix.json" <<'JSON'

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -372,6 +372,43 @@ autofix_synthesize_source_report() {
   printf 'source_change\t%s\t%s\n' "${count}" "${joined}"
 }
 
+autofix_reconcile_source_report_to_changed_files() {
+  local changed_file
+  local changed_files="${AUTOFIX_CHANGED_FILES:-}"
+  local reconciled=""
+
+  [ -n "${AUTOFIX_REPORT:-}" ] || return 0
+  [ -n "${changed_files}" ] || return 0
+
+  while IFS=$'\t' read -r cat count files; do
+    [ -n "${cat}" ] || continue
+
+    if [ "${cat}" != "source_change" ]; then
+      reconciled+="${cat}"$'\t'"${count}"$'\t'"${files}"$'\n'
+      continue
+    fi
+
+    local kept=""
+    local kept_count=0
+    while IFS= read -r changed_file; do
+      [ -n "${changed_file}" ] || continue
+      if printf '%s\n' "${files}" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -Fx -- "${changed_file}" >/dev/null 2>&1; then
+        if [ -n "${kept}" ]; then
+          kept+=", "
+        fi
+        kept+="${changed_file}"
+        kept_count=$((kept_count + 1))
+      fi
+    done <<< "$(autofix_changed_files_list)"
+
+    if [ "${kept_count}" -gt 0 ]; then
+      reconciled+="${cat}"$'\t'"${kept_count}"$'\t'"${kept}"$'\n'
+    fi
+  done <<< "${AUTOFIX_REPORT}"
+
+  AUTOFIX_REPORT="$(printf '%s' "${reconciled}" | sed '/^[[:space:]]*$/d')"
+}
+
 autofix_prepare_pr_report() {
   local workspace="${1:-$(resolve_workspace)}"
   local total_fixes="${AUTOFIX_TOTAL_FIXES:-0}"
@@ -379,6 +416,8 @@ autofix_prepare_pr_report() {
   if [ -z "${AUTOFIX_REPORT:-}" ] && [ "${total_fixes}" != "0" ]; then
     AUTOFIX_REPORT="$(autofix_synthesize_source_report "${workspace}")"
   fi
+
+  autofix_reconcile_source_report_to_changed_files
 }
 
 autofix_pr_has_unsafe_unreported_changes() {


### PR DESCRIPTION
## Summary
- Reconcile `source_change` autofix report rows against the actual committed file list before rendering autofix PR bodies.
- Prevent stale autofix output from claiming extra source files were changed when the pushed branch only contains a subset.
- Add regression coverage for the stale report case seen in Extra-Chill/homeboy#4402.

## Testing
- `bash scripts/autofix/test-open-autofix-pr-report.sh`
- `bash -n scripts/core/lib.sh scripts/autofix/test-open-autofix-pr-report.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the stale autofix report path, drafted the shell fix and regression test, and ran targeted verification. Chris requested the PR and merge.