### PR TITLE
fix(ci): clarify missing build-artifact errors and autofix push visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,14 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh run download "${GITHUB_RUN_ID}" --name homeboy-binary --dir .homeboy-bin
+          BUILD_ARTIFACT_FILE: ${{ inputs.build-artifact-file }}
+        run: |
+          gh run download "${GITHUB_RUN_ID}" --name homeboy-binary --dir .homeboy-bin
+          if [ ! -f ".homeboy-bin/${BUILD_ARTIFACT_FILE}" ]; then
+            echo "::error::Build artifact 'homeboy-binary/${BUILD_ARTIFACT_FILE}' was not downloaded from run ${GITHUB_RUN_ID}. The upstream Build job may have failed, been skipped, or not uploaded the artifact. This is a CI plumbing issue, not a code finding. Verify the Build job succeeded and that this workflow grants the 'actions: read' permission."
+            exit 1
+          fi
+          echo "Downloaded homeboy binary to .homeboy-bin/${BUILD_ARTIFACT_FILE}"
 
       - name: Resolve Homeboy binary path
         id: binary-path

--- a/action.yml
+++ b/action.yml
@@ -294,7 +294,7 @@ runs:
       run: |
         BINARY="${{ inputs.binary-path }}"
         if [ ! -f "${BINARY}" ]; then
-          echo "::error::binary-path '${BINARY}' does not exist"
+          echo "::error::Homeboy binary not found at '${BINARY}'. This is a CI build-artifact handoff problem, not a code finding — the upstream Build job may have failed, been skipped, or not uploaded the binary. Verify the Build job succeeded, the artifact was uploaded, and this workflow grants the 'actions: read' permission needed to download it."
           exit 1
         fi
         chmod +x "${BINARY}"

--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -360,9 +360,11 @@ if ! verify_autofix_quality_gates; then
   exit 0
 fi
 
+echo "::notice::Homeboy autofix is committing a fix for PR #${PR_NUMBER}. The bot commit will be pushed to ${TARGET_REPO}:${TARGET_BRANCH} and will supersede in-flight CI runs on the previous HEAD."
 commit_autofix_changes
 
 if push_autofix_commit; then
+  echo "::notice::Homeboy autofix pushed ${AUTOFIX_FILE_COUNT} file(s) (${AUTOFIX_FIX_TYPES}) to ${TARGET_REPO}:${TARGET_BRANCH}. The new commit supersedes in-flight CI runs — any 'cancelled' run on the previous HEAD was replaced by this push, not a failure."
   echo "committed=true" >> "${GITHUB_OUTPUT}"
   echo "status=pushed" >> "${GITHUB_OUTPUT}"
   echo "target-repo=${TARGET_REPO}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary

Fixes the two CI friction points from Extra-Chill/homeboy#3819. The root cause for both lives here in **homeboy-action** (the binary-path check, the artifact download step, and the autofix push script) — not in the homeboy Rust binary.

### 1. Missing build artifact read as a code finding
When the upstream `Build` job did not hand off the homeboy binary (failed, skipped, or the `actions: read` permission was missing — the original trigger for #3819), Lint/Test failed with a bare:
```
::error::binary-path '.homeboy-bin/homeboy' does not exist
```
which looks like a lint finding and sent the operator chasing a non-existent code issue.

**Fix:**
- The reusable workflow now **verifies the download landed** (`.github/workflows/ci.yml`) and fails fast with a message that names it a CI plumbing problem + the concrete checks (Build succeeded? artifact uploaded? `actions: read` granted?).
- The composite action's `binary-path` error (`action.yml`) now carries the same context instead of the bare `does not exist`.

### 2. Autofix pushed to the PR branch mid-review without a visible signal
The bot commit superseded in-flight CI runs, so a run showed `cancelled` — reading as a spurious failure. There was no obvious signal that the autofix bot had churned the branch.

**Fix:**
- `apply-autofix-commit.sh` now emits `::notice::` annotations **before committing** and **after pushing**, explicitly stating that the new commit supersedes in-flight runs so a `cancelled` status is understood as the push replacing the run, not a failure. These surface as annotations in the GitHub Actions run view.

### Why homeboy-action (not the homeboy Rust repo)
The issue was filed against `Extra-Chill/homeboy`, but the actual broken code is here:
- `action.yml` owns the `binary-path ... does not exist` error.
- `.github/workflows/ci.yml` owns the `gh run download` artifact handoff.
- `scripts/autofix/apply-autofix-commit.sh` owns the push-to-PR-branch logic.

The homeboy repo's `ci.yml` just calls this reusable workflow. (A companion hardening makes autofix explicit-off there: see homeboy PR.)

Fixes Extra-Chill/homeboy#3819