### PR TITLE
fix: honor changed-scope differential counts

### DIFF
--- a/scripts/core/apply-differential-gate.py
+++ b/scripts/core/apply-differential-gate.py
@@ -78,12 +78,26 @@ def test_count(payload: dict[str, Any] | None) -> int | None:
     return None
 
 
+def changed_scope_introduced_count(command: str, payload: dict[str, Any] | None) -> int | None:
+    data = unwrap(payload)
+    changed_since = data.get("changed_since", {}) if isinstance(data, dict) else {}
+    if not isinstance(changed_since, dict):
+        return None
+
+    key = "introduced_findings" if command == "audit" else "introduced_failures"
+    value = changed_since.get(key)
+    return int(value) if isinstance(value, int) else None
+
+
 def output_stem(command: str) -> str:
     return "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in command).strip("-") or "homeboy-output"
 
 
 def metric_for(command: str, directory: str) -> int | None:
     payload = read_json(os.path.join(directory, f"{output_stem(command)}.json"))
+    scoped_count = changed_scope_introduced_count(command, payload)
+    if scoped_count is not None:
+        return scoped_count
     if command == "audit":
         return audit_count(payload)
     if command == "test":

--- a/scripts/core/test-differential-gate.py
+++ b/scripts/core/test-differential-gate.py
@@ -55,6 +55,22 @@ def main() -> None:
             "audit failure remains when outliers increase",
         )
 
+        write_json(
+            current / "audit.json",
+            {
+                "success": False,
+                "data": {
+                    "summary": {"outliers_found": 6},
+                    "changed_since": {"introduced_findings": 0, "contextual_findings": 6},
+                },
+            },
+        )
+        assert_equal(
+            {"audit": "pass"},
+            run_gate({"audit": "fail"}, current, base),
+            "changed-scope audit failure passes when no findings were introduced",
+        )
+
         write_json(base / "test.json", {"success": False, "data": {"test_counts": {"failed": 2, "errors": 1}}})
         write_json(current / "test.json", {"success": False, "data": {"test_counts": {"failed": 2, "errors": 1}}})
         assert_equal(
@@ -68,6 +84,22 @@ def main() -> None:
             {"test": "fail"},
             run_gate({"test": "fail"}, current, base),
             "test failure remains when failures increase",
+        )
+
+        write_json(
+            current / "test.json",
+            {
+                "success": False,
+                "data": {
+                    "test_counts": {"failed": 3, "errors": 1},
+                    "changed_since": {"introduced_failures": 0},
+                },
+            },
+        )
+        assert_equal(
+            {"test": "pass"},
+            run_gate({"test": "fail"}, current, base),
+            "changed-scope test failure passes when no failures were introduced",
         )
 
         assert_equal(


### PR DESCRIPTION
## Summary
- Prefer Homeboy changed-scope introduced counts when applying the action differential gate.
- Keep aggregate current/base comparison as the fallback for outputs without scoped counts.
- Add regression coverage for scoped audit/test outputs.

## Testing
- `python3 scripts/core/test-differential-gate.py`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the CI gate mismatch, drafted the small action fix and regression tests, and ran local verification. Chris remains responsible for review and merge.