### PR TITLE
fix(ci): prevent disruptive PR-branch autofix + handle missing homeboy-bin artifact (#3819)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,15 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh run download "${GITHUB_RUN_ID}" --name homeboy-binary --dir .homeboy-bin
+        run: |
+          # The Build job uploads `homeboy-binary` from this same workflow run.
+          # If the download fails the quality job cannot run; surface that as a
+          # build-artifact-handoff problem rather than a bare missing-binary
+          # error later in the action (see #3819).
+          if ! gh run download "${GITHUB_RUN_ID}" --name homeboy-binary --dir .homeboy-bin; then
+            echo "::error::Build artifact 'homeboy-binary' missing from upstream Build job (run ${GITHUB_RUN_ID}); the Lint/Test precondition cannot be met. This is a CI build-artifact handoff failure, not a code finding — check that the Build job succeeded and uploaded the binary."
+            exit 1
+          fi
 
       - name: Resolve Homeboy binary path
         id: binary-path
@@ -326,6 +334,17 @@ jobs:
         run: |
           if [ -n "${BUILD_COMMAND}" ]; then
             path=".homeboy-bin/${BUILD_ARTIFACT_FILE}"
+            # The binary is produced by the upstream Build job and downloaded
+            # above. A missing file here means the artifact handoff failed
+            # (wrong build-artifact-file name, empty/failed upload, etc.) — not
+            # a code problem in the PR. Fail with an actionable message instead
+            # of letting the bare "binary-path does not exist" error surface
+            # deep in the action (see #3819).
+            if [ ! -f "${path}" ]; then
+              echo "::error::Built Homeboy binary missing at '${path}' after downloading the 'homeboy-binary' artifact. This is a CI build-artifact handoff failure, not a code finding. Verify the Build job's build-artifact-path produced a file and that build-artifact-file ('${BUILD_ARTIFACT_FILE}') matches its basename. Contents of .homeboy-bin:"
+              ls -la .homeboy-bin 2>/dev/null || echo "  (.homeboy-bin directory not present)"
+              exit 1
+            fi
             chmod +x "${path}"
             echo "value=${path}" >> "${GITHUB_OUTPUT}"
           else

--- a/action.yml
+++ b/action.yml
@@ -294,7 +294,7 @@ runs:
       run: |
         BINARY="${{ inputs.binary-path }}"
         if [ ! -f "${BINARY}" ]; then
-          echo "::error::binary-path '${BINARY}' does not exist"
+          echo "::error::binary-path '${BINARY}' does not exist. If this path points at a downloaded build artifact (e.g. '.homeboy-bin/...'), the upstream build-artifact handoff failed — this is a CI plumbing problem, not a code finding in the PR."
           exit 1
         fi
         chmod +x "${BINARY}"


### PR DESCRIPTION
Closes Extra-Chill/homeboy#3819

## Summary
Addresses the two CI papercuts reported in homeboy#3819. The real fix lives here in **homeboy-action** (the reusable CI workflow), not in homeboy core.

### 1. lint-autofix pushing to the PR branch mid-review — already addressed, verified
PR-branch autofix (`Apply autofix commit` in `action.yml`) is gated behind `inputs.autofix == 'true'`, which **defaults to `'false'`** (and homeboy core's `.github/workflows/ci.yml` explicitly sets `autofix: 'false'` citing #3819, following #4877/#4795). So a default CI run no longer pushes bot commits to the PR branch or supersedes in-flight runs. No change needed for (1); confirmed current state is correct.

### 2. Lint/Test failing on a missing `.homeboy-bin/homeboy` with a bare, misleading error — fixed here
Root cause: the quality job downloads the `homeboy-binary` artifact uploaded by the Build job, then `chmod +x .homeboy-bin/<file>` **without verifying the file exists**. When the artifact handoff fails (failed/empty upload, mismatched `build-artifact-file`, etc.), the failure surfaced deep in `action.yml` as a bare `binary-path '.homeboy-bin/homeboy' does not exist`, which reads like a code finding and sends authors chasing a non-existent issue.

This PR:
- **Download step** (`reusable ci.yml`): checks `gh run download` succeeded and emits a clear *"build artifact missing from upstream Build job ... not a code finding"* error if not.
- **Resolve binary path step**: verifies the downloaded binary exists before `chmod +x`, and on failure prints an actionable message (mentions `build-artifact-path`/`build-artifact-file`) plus a `ls -la .homeboy-bin` listing — instead of letting the bare error fire later.
- **`action.yml` install-prebuilt step**: hardened the fallback `binary-path does not exist` message to note that a `.homeboy-bin/...` path means a CI build-artifact handoff failure, not a PR code finding.

## Validation
- `yaml.safe_load` passes for both `.github/workflows/ci.yml` and `action.yml`.
- No homeboy-core code change required; do not touch docs/changelog.md (homeboy owns changelogs).

## Note on (3) "cancelled vs failed" status distinction
The issue's third ask — distinguishing *"run cancelled because a newer commit superseded it"* from *"run failed"* — is a GitHub Actions concurrency/UI surface behavior (`cancel-in-progress: true`) and is not addressable in this workflow definition. Left out of scope.