### PR TITLE
fix: give the release failed-SHA marker manual + tooling-aware escape hatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,19 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
+      tooling-identity: ${{ steps.release-check.outputs.tooling-identity }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Restore failure cache
-        id: failure-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ${{ runner.temp }}/homeboy-release-last-failed
-          key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            release-last-failed-${{ github.ref_name }}-
 
       - name: Dry-run release check
         id: release-check
@@ -60,15 +52,31 @@ jobs:
           release-skip-publish: 'true'
           release-skip-github-release: 'true'
 
+      # The failed-SHA marker is keyed by the resolved tooling identity, not
+      # just the SHA, so a CI-side fix (new homeboy binary / extension) that
+      # changes the resolved tooling produces a fresh key and self-heals a
+      # previously-blocked SHA. See homeboy-action#257.
+      - name: Restore failure cache
+        id: failure-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}/homeboy-release-last-failed
+          key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}-${{ steps.release-check.outputs.tooling-identity }}
+
       - name: Decide whether to release
         id: check
+        env:
+          # A manual dispatch is an explicit human "retry this now" — it must
+          # never be silently skipped by a stale failed-SHA marker. The marker
+          # only guards the unattended push path against retry loops.
+          IS_MANUAL_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           HEAD_SHA="$(git rev-parse HEAD)"
           FAILURE_MARKER="${RUNNER_TEMP}/homeboy-release-last-failed"
-          if [ -f "${FAILURE_MARKER}" ]; then
+          if [ "${IS_MANUAL_DISPATCH}" != "true" ] && [ -f "${FAILURE_MARKER}" ]; then
             LAST_FAILED="$(tr -d '[:space:]' < "${FAILURE_MARKER}")"
             if [ "${HEAD_SHA}" = "${LAST_FAILED}" ]; then
-              echo "::notice::HEAD ${HEAD_SHA:0:8} matches last failed release attempt — skipping until new commits"
+              echo "::notice::HEAD ${HEAD_SHA:0:8} matches last failed release attempt with the same tooling — skipping until new commits or new tooling (dispatch manually to force)"
               echo "should-release=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -133,7 +141,9 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/homeboy-release-last-failed
-          key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}
+          # Keyed by tooling identity so a later tooling fix produces a new
+          # key and the prior failure no longer matches (homeboy-action#257).
+          key: release-last-failed-${{ github.ref_name }}-${{ github.sha }}-${{ needs.check.outputs.tooling-identity }}
 
   # ── Clear failure cache on success ──
   clear-failure:

--- a/action.yml
+++ b/action.yml
@@ -241,6 +241,12 @@ outputs:
   skipped-reason:
     description: 'Why release was skipped when released is false'
     value: ${{ steps.release.outputs.skipped-reason }}
+  homeboy-version:
+    description: 'Resolved Homeboy CLI version string that actually ran (e.g. "homeboy 0.74.1")'
+    value: ${{ steps.tooling-metadata.outputs.homeboy-version }}
+  tooling-identity:
+    description: 'Cache-key-safe token identifying the resolved release tooling (homeboy CLI version + extension revision). Use to key per-SHA CI state so a tooling fix self-heals.'
+    value: ${{ steps.tooling-metadata.outputs.tooling-identity }}
   pr-policy-safe:
     description: 'Whether the PR policy marked this pull request safe for auto-merge (true/false)'
     value: ${{ steps.pr-policy.outputs.safe }}
@@ -374,6 +380,7 @@ runs:
       run: bash ${{ github.action_path }}/scripts/setup/install-extension.sh
 
     - name: Capture tooling metadata
+      id: tooling-metadata
       shell: bash
       env:
         EXTENSION_SOURCE: ${{ inputs.extension-source }}

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -72,6 +72,16 @@ assert_not_contains 'name: homeboy-ci-results$' "${ROOT_DIR}/action.yml" "CI res
 assert_not_contains 'name: homeboy-observations$' "${ROOT_DIR}/action.yml" "observation artifacts do not use a shared static name"
 assert_contains 'release-bump-type:' "${ROOT_DIR}/action.yml" "action exposes release bump type output"
 assert_contains 'skipped-reason:' "${ROOT_DIR}/action.yml" "action exposes skipped release reason output"
+
+# Failed-SHA marker escape hatches (homeboy-action#257):
+# 1. A manual dispatch must never be blocked by a stale marker.
+# 2. The marker is keyed by tooling identity so a CI-side fix self-heals.
+assert_contains 'tooling-identity:' "${ROOT_DIR}/action.yml" "action exposes resolved tooling identity output"
+assert_contains "github.event_name == 'workflow_dispatch'" "${WORKFLOW}" "release workflow detects manual dispatch for the marker bypass"
+assert_contains 'IS_MANUAL_DISPATCH' "${WORKFLOW}" "release workflow gates the failed-SHA skip on non-dispatch runs"
+assert_contains 'release-last-failed-${{ github.ref_name }}-${{ github.sha }}-${{ steps.release-check.outputs.tooling-identity }}' "${WORKFLOW}" "failure-cache restore key includes tooling identity"
+assert_contains 'release-last-failed-${{ github.ref_name }}-${{ github.sha }}-${{ needs.check.outputs.tooling-identity }}' "${WORKFLOW}" "failure-cache save key includes tooling identity"
+assert_not_contains 'restore-keys:' "${WORKFLOW}" "failure cache no longer falls back to a stale-tooling marker via restore-keys"
 assert_contains 'git/ref/tags/v${release_version}' "${HOMEBOY_CONFIG}" "post-release hook reads the pushed release tag ref"
 assert_contains 'release_sha' "${HOMEBOY_CONFIG}" "post-release hook points v2 at the pushed release tag target"
 assert_not_contains 'sha=$(git rev-parse HEAD)' "${HOMEBOY_CONFIG}" "post-release hook does not point v2 at an unpushed local release commit"

--- a/scripts/setup/capture-tooling-metadata.sh
+++ b/scripts/setup/capture-tooling-metadata.sh
@@ -48,6 +48,18 @@ echo "HOMEBOY_EXTENSION_REVISION=${EXTENSION_REVISION}" >> "${GITHUB_ENV}"
 echo "HOMEBOY_ACTION_REF=${ACTION_REF_USED}" >> "${GITHUB_ENV}"
 echo "HOMEBOY_ACTION_REPOSITORY=${ACTION_REPOSITORY_USED}" >> "${GITHUB_ENV}"
 
+# Expose the resolved tooling identity as a step output so workflows can key
+# caches/markers on "which release tooling actually ran" — a CI-side fix that
+# changes the resolved homeboy binary or extension naturally produces a new
+# value, so stale per-SHA state self-heals instead of blocking forever
+# (homeboy-action#257). Sanitized to a GitHub cache-key-safe token.
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  TOOLING_IDENTITY="${HOMEBOY_CLI_VERSION}-${EXTENSION_REVISION}"
+  TOOLING_IDENTITY="$(printf '%s' "${TOOLING_IDENTITY}" | tr -c 'A-Za-z0-9._-' '-')"
+  echo "homeboy-version=${HOMEBOY_CLI_VERSION}" >> "${GITHUB_OUTPUT}"
+  echo "tooling-identity=${TOOLING_IDENTITY}" >> "${GITHUB_OUTPUT}"
+fi
+
 echo "Tooling metadata captured"
 echo "- Homeboy CLI: ${HOMEBOY_CLI_VERSION}"
 echo "- Extension: ${EXTENSION_ID_EFFECTIVE} (${EXTENSION_SOURCE_EFFECTIVE})"

--- a/scripts/setup/test-capture-tooling-metadata.sh
+++ b/scripts/setup/test-capture-tooling-metadata.sh
@@ -39,10 +39,19 @@ export EXTENSION_SOURCE="https://github.com/Extra-Chill/homeboy-extensions"
 export ACTION_REF="v2"
 export ACTION_REPOSITORY="Extra-Chill/homeboy-action"
 export GITHUB_ENV="${TMP_DIR}/github-env"
+export GITHUB_OUTPUT="${TMP_DIR}/github-output"
 
 bash "${ROOT_DIR}/scripts/setup/capture-tooling-metadata.sh" > "${TMP_DIR}/metadata.log"
 
 assert_contains "HOMEBOY_EXTENSION_REVISION=abc1234" "${GITHUB_ENV}" "source revision file is exported"
 assert_contains "- Extension revision: abc1234" "${TMP_DIR}/metadata.log" "source revision file is logged"
+
+# Tooling identity output for failed-SHA marker keying (homeboy-action#257).
+# The raw version string "homeboy 9.9.9" contains a space, which is hostile to
+# GitHub cache keys; the sanitizer must collapse it to a '-'. A dev build would
+# add a '+sha' suffix — also sanitized — so any tooling change yields a fresh,
+# cache-key-safe identity token.
+assert_contains "homeboy-version=homeboy 9.9.9" "${GITHUB_OUTPUT}" "resolved homeboy version is exposed verbatim as a step output"
+assert_contains "tooling-identity=homeboy-9.9.9-abc1234" "${GITHUB_OUTPUT}" "tooling identity combines sanitized version + extension revision into a cache-key-safe token"
 
 echo "All tooling metadata checks passed."


### PR DESCRIPTION
## Summary

Fixes the design flaw documented in #257: the Release workflow's failed-SHA marker has no escape hatch when the failure cause was the release *tooling*, not the component's code. Once a SHA was marked failed, every subsequent attempt at that SHA was skipped — including manual `workflow_dispatch` — until a new commit landed or the cache was manually deleted.

This bit us live: the `--apply` regression (#256) marked every component's HEAD as failed, and even after the action was fixed, releases stayed blocked. `data-machine v0.153.2` only shipped after manually `gh cache delete`-ing 5 stale `release-last-failed-main-*` entries.

Closes #257.

## Changes

**1. Manual dispatch bypasses the marker (escape hatch).**
`.github/workflows/release.yml` — the `Decide whether to release` step now gates the failed-SHA skip on `github.event_name != 'workflow_dispatch'`. An explicit human "retry this now" is never silently skipped; the marker still guards the unattended push path against retry loops.

**2. Marker keyed by resolved tooling identity (self-heal).**
The failure-cache key is now `release-last-failed-<branch>-<sha>-<tooling-identity>`, where `tooling-identity` = sanitized `homeboy CLI version + extension revision`. When a CI-side fix changes the resolved tooling, the key changes, so a previously-blocked SHA no longer matches and releases on its own — no manual cache delete. The stale `restore-keys` prefix fallback is removed (it would have re-matched an old-tooling marker and defeated the self-heal).

**3. New action outputs.**
`capture-tooling-metadata.sh` emits `homeboy-version` and a cache-key-safe `tooling-identity` to `GITHUB_OUTPUT`; `action.yml` surfaces both so consumer release workflows can adopt the same keying.

## Why these two together

- (1) gives an immediate, always-available human override — the dead-end I hit is gone.
- (2) makes infra fixes self-healing so the backlog never silently freezes again, even without a human noticing.

## Verification

- `bash -n scripts/setup/capture-tooling-metadata.sh` + YAML parse of `release.yml`/`action.yml` — clean.
- `scripts/release/test-release-workflow.sh` — PASS (added: dispatch-bypass detection, `IS_MANUAL_DISPATCH` gate, tooling-identity in both restore + save keys, no `restore-keys` fallback, `tooling-identity` action output).
- `scripts/setup/test-capture-tooling-metadata.sh` — PASS (added: `homeboy-version` + sanitized `tooling-identity` outputs).
- `scripts/release/test-run-release-wrapper.sh` — PASS.
- Full `test-*.sh` sweep: all green except `scripts/autofix/test-open-autofix-pr-report.sh`, which fails identically on clean `origin/main` (pre-existing, unrelated — verified via stash).

## Impact

Shared tooling — applies to every component on the `v2` channel. After this ships, a release-infra regression no longer requires hand-clearing each stuck SHA: dispatch manually for an instant retry, or just let the next tooling version self-heal the backlog.