### PR TITLE
Support finishing artifact releases at HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The release command:
 6. Finalizes changelog (`[Next]` → `[VERSION] - DATE`)
 7. Commits, creates an annotated tag, pushes, and creates a GitHub Release
 
-After the tag push, downstream build/publish jobs can pick it up (e.g. cargo-dist, npm publish).
+After the tag push, downstream build jobs can produce artifacts and then call Homeboy Action again with `release-head: 'true'` and `release-from-artifacts: <path>` to publish those artifacts through the native Homeboy release pipeline.
 
 ### Benchmarks
 
@@ -196,6 +196,11 @@ Use these outputs to gate downstream jobs:
 | `pr-policy-merge-method` | No | `squash` | Merge method for `pr-policy-merge`: `merge`, `squash`, or `rebase` |
 | `release-dry-run` | No | `false` | Preview the release without making changes |
 | `release-branch` | No | `main` | Branch that releases are allowed from |
+| `release-head` | No | `false` | Finish a release at the current HEAD/tag with `--head` |
+| `release-from-artifacts` | No | | Publish existing artifacts with `--from-artifacts <path>` |
+| `release-skip-publish` | No | `false` | Skip package and publish steps |
+| `release-skip-github-release` | No | `false` | Skip GitHub Release creation |
+| `release-verify-github-release` | No | `true` | Verify that a successful release has a GitHub Release |
 
 ## Outputs
 
@@ -455,11 +460,34 @@ jobs:
           extension: rust
           commands: release
 
-  # Build + publish (only if released)
+  # Build artifacts (only if released)
   build:
     needs: prepare
     if: needs.prepare.outputs.released == 'true'
-    # ... cargo-dist, crates.io, Homebrew
+    # ... cargo-dist, upload artifacts
+
+  # Publish prebuilt artifacts through Homeboy release.publish
+  publish:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release-tag }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-*
+          path: artifacts
+          merge-multiple: true
+      - uses: Extra-Chill/homeboy-action@v2
+        with:
+          source: '.'
+          extension: rust
+          commands: release
+          release-head: 'true'
+          release-from-artifacts: artifacts
 ```
 
 ### Recommended CI Profile

--- a/action.yml
+++ b/action.yml
@@ -206,6 +206,14 @@ inputs:
     description: 'Pass --no-github-release to homeboy release. Skips the github.release step that runs `gh release create`. Set true for components that create their GitHub Release through a separate workflow step (typically pairs with release-skip-publish=true). Defaults to false so components with a github.com remote get a GitHub Release on every tag.'
     required: false
     default: 'false'
+  release-head:
+    description: 'Pass --head to homeboy release. Use for finishing a release at an existing tag or release commit, often with release-from-artifacts.'
+    required: false
+    default: 'false'
+  release-from-artifacts:
+    description: 'Pass --from-artifacts <path> to homeboy release. Use to publish artifacts produced by an earlier build job through the native Homeboy release pipeline.'
+    required: false
+    default: ''
 
 outputs:
   results:
@@ -656,6 +664,8 @@ runs:
         RELEASE_BRANCH: ${{ inputs.release-branch }}
         RELEASE_SKIP_PUBLISH: ${{ inputs.release-skip-publish }}
         RELEASE_SKIP_GITHUB_RELEASE: ${{ inputs.release-skip-github-release }}
+        RELEASE_HEAD: ${{ inputs.release-head }}
+        RELEASE_FROM_ARTIFACTS: ${{ inputs.release-from-artifacts }}
         HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}
         COMPONENT_NAME: ${{ inputs.component }}
       run: bash ${{ github.action_path }}/scripts/release/run-release.sh

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -10,6 +10,8 @@
 #   RELEASE_BRANCH      - branch to release from (default: main)
 #   COMPONENT_NAME      - component ID override
 #   RELEASE_DRY_RUN     - if "true", preview without making changes
+#   RELEASE_HEAD        - if "true", finish release at existing HEAD/tag
+#   RELEASE_FROM_ARTIFACTS - artifact directory passed to --from-artifacts
 #
 # Outputs (GITHUB_OUTPUT):
 #   released:        true|false
@@ -25,6 +27,8 @@ source "${SCRIPT_DIR}/github-release.sh"
 
 RELEASE_BRANCH="${RELEASE_BRANCH:-main}"
 DRY_RUN="${RELEASE_DRY_RUN:-false}"
+RELEASE_HEAD="${RELEASE_HEAD:-false}"
+RELEASE_FROM_ARTIFACTS="${RELEASE_FROM_ARTIFACTS:-}"
 
 COMPONENT_DIR="${COMPONENT_DIR:-.}"
 if [ -n "${COMPONENT_DIR}" ] && [ "${COMPONENT_DIR}" != "." ]; then
@@ -112,7 +116,7 @@ COMP_ID="$(resolve_component_id)"
 configure_git_push_auth
 
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [ "${CURRENT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
+if [ "${RELEASE_HEAD}" != "true" ] && [ "${CURRENT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
   echo "::notice::Not on ${RELEASE_BRANCH} (current: ${CURRENT_BRANCH}) - skipping release"
   write_output "released" "false"
   write_output "skipped-reason" "wrong-branch"
@@ -124,7 +128,7 @@ if [ -z "${DEFAULT_BRANCH}" ]; then
   DEFAULT_BRANCH="main"
 fi
 
-if [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
+if [ "${RELEASE_HEAD}" != "true" ] && [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
   echo "::error::Refusing to release from non-default branch '${CURRENT_BRANCH}' (default: '${DEFAULT_BRANCH}')"
   write_output "released" "false"
   write_output "skipped-reason" "wrong-default-branch"
@@ -164,6 +168,14 @@ fi
 
 if [ "${RELEASE_SKIP_GITHUB_RELEASE}" = "true" ]; then
   RELEASE_ARGS+=(--no-github-release)
+fi
+
+if [ "${RELEASE_HEAD}" = "true" ]; then
+  RELEASE_ARGS+=(--head)
+fi
+
+if [ -n "${RELEASE_FROM_ARTIFACTS}" ]; then
+  RELEASE_ARGS+=(--from-artifacts "${RELEASE_FROM_ARTIFACTS}")
 fi
 
 if [ "${DRY_RUN}" = "true" ]; then

--- a/scripts/release/test-run-release-wrapper.sh
+++ b/scripts/release/test-run-release-wrapper.sh
@@ -163,6 +163,9 @@ run_wrapper() {
   RELEASE_DRY_RUN="${RELEASE_DRY_RUN:-false}" \
   RELEASE_SKIP_PUBLISH="${RELEASE_SKIP_PUBLISH:-false}" \
   RELEASE_SKIP_GITHUB_RELEASE="${RELEASE_SKIP_GITHUB_RELEASE:-false}" \
+  RELEASE_HEAD="${RELEASE_HEAD:-false}" \
+  RELEASE_FROM_ARTIFACTS="${RELEASE_FROM_ARTIFACTS:-}" \
+  MOCK_BRANCH="${MOCK_BRANCH:-main}" \
   GH_TOKEN="${GH_TOKEN:-}" \
   bash "${RUN_RELEASE}"
 }
@@ -218,6 +221,20 @@ ARGS="$(cat "${HOMEBOY_ARGS_FILE}")"
 assert_contains '--skip-publish' "${ARGS}" "release can opt out of package/publish steps"
 assert_contains '--no-github-release' "${ARGS}" "release can opt out of GitHub Release creation"
 unset RELEASE_SKIP_PUBLISH RELEASE_SKIP_GITHUB_RELEASE
+
+setup_fixture
+HOMEBOY_MOCK_SCENARIO="released"
+RELEASE_HEAD="true"
+RELEASE_FROM_ARTIFACTS="artifacts"
+MOCK_BRANCH="HEAD"
+GH_TOKEN="secret123"
+run_wrapper
+ARGS="$(cat "${HOMEBOY_ARGS_FILE}")"
+assert_contains '--head' "${ARGS}" "head release passes --head"
+assert_contains '--from-artifacts' "${ARGS}" "head release passes --from-artifacts"
+assert_contains 'artifacts' "${ARGS}" "head release passes artifact directory"
+assert_output_line 'released=true' "${OUTPUT_FILE}" "head release can run from detached HEAD"
+unset RELEASE_HEAD RELEASE_FROM_ARTIFACTS MOCK_BRANCH
 
 setup_fixture
 HOMEBOY_MOCK_SCENARIO="released"


### PR DESCRIPTION
## Summary
- add `release-head` and `release-from-artifacts` inputs
- forward `--head --from-artifacts <path>` to `homeboy release`
- allow detached HEAD release completion for tag/artifact publishing
- document the two-phase release flow

## Testing
- `bash -n scripts/release/run-release.sh scripts/release/test-run-release-wrapper.sh`
- `bash scripts/release/test-run-release-wrapper.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing release wrapper inputs, tests, and documentation.