### PR TITLE
Classify red baselines in differential CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ on:
         type: string
         default: ''
       differential-gating:
-        description: 'Enable PR differential gating for audit/test.'
+        description: 'Enable PR differential gating for audit/lint/test.'
         type: string
         default: 'false'
       observation-window:

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ inputs:
     required: false
     default: ''
   differential-gating:
-    description: 'On PRs, compare audit/test failure counts against the base SHA and fail only when the PR is worse. Opt-in; lint remains normal exit-code gating. PR autofix is skipped while enabled.'
+    description: 'On PRs, compare audit/lint/test failure counts against the base SHA and fail only when the PR is worse. Opt-in; PR autofix is skipped while enabled.'
     required: false
     default: 'false'
   observation-window:
@@ -643,7 +643,14 @@ runs:
       run: bash ${{ github.action_path }}/scripts/core/select-final-results.sh
 
     - name: Generate failure digest
-      if: always() && steps.select-results.outputs.results != '' && contains(steps.select-results.outputs.results, '"fail"')
+      if: |
+        always()
+        && steps.select-results.outputs.results != ''
+        && (
+          contains(steps.select-results.outputs.results, '"fail"')
+          || contains(steps.select-results.outputs.results, '"baseline_red"')
+          || contains(steps.select-results.outputs.results, '"inconclusive"')
+        )
       shell: bash
       env:
         RESULTS: ${{ steps.select-results.outputs.results }}

--- a/scripts/core/apply-differential-gate.py
+++ b/scripts/core/apply-differential-gate.py
@@ -78,6 +78,26 @@ def test_count(payload: dict[str, Any] | None) -> int | None:
     return None
 
 
+def lint_count(payload: dict[str, Any] | None) -> int | None:
+    data = unwrap(payload)
+    if not isinstance(data, dict):
+        return None
+
+    for key in ("lint_findings", "findings", "violations", "top_violations"):
+        items = data.get(key)
+        if isinstance(items, list):
+            return len(items)
+
+    summary = data.get("summary")
+    if isinstance(summary, dict):
+        for key in ("findings", "failures", "errors"):
+            value = summary.get(key)
+            if isinstance(value, int):
+                return int(value)
+
+    return None
+
+
 def changed_scope_introduced_count(command: str, payload: dict[str, Any] | None) -> int | None:
     data = unwrap(payload)
     changed_since = data.get("changed_since", {}) if isinstance(data, dict) else {}
@@ -100,9 +120,35 @@ def metric_for(command: str, directory: str) -> int | None:
         return scoped_count
     if command == "audit":
         return audit_count(payload)
+    if command == "lint":
+        return lint_count(payload)
     if command == "test":
         return test_count(payload)
     return None
+
+
+def base_command_status(command: str, base_dir: str) -> dict[str, Any]:
+    status = read_json(os.path.join(base_dir, "baseline-status.json"))
+    if not isinstance(status, dict):
+        return {}
+    value = status.get(command)
+    return value if isinstance(value, dict) else {}
+
+
+def command_label(command: str, metadata: dict[str, Any]) -> str:
+    full = metadata.get("command")
+    if isinstance(full, str) and full:
+        return full
+    return f"homeboy {command}"
+
+
+def command_failed(metadata: dict[str, Any]) -> bool:
+    if metadata.get("status") == "fail":
+        return True
+    try:
+        return int(metadata.get("exit_code") or 0) != 0
+    except (TypeError, ValueError):
+        return False
 
 
 def main() -> int:
@@ -119,15 +165,28 @@ def main() -> int:
         return 0
 
     adjusted = dict(results)
-    for command in ("audit", "test"):
+    for command in ("audit", "lint", "test"):
         if adjusted.get(command) != "fail":
             continue
 
         current = metric_for(command, current_dir)
         base = metric_for(command, base_dir)
-        if current is None or base is None:
+        base_metadata = base_command_status(command, base_dir)
+        base_failed = command_failed(base_metadata)
+        base_structured = base_metadata.get("structured_output") is True
+
+        if base_failed and (base is None or not base_structured):
+            adjusted[command] = "baseline_red"
             print(
-                f"::warning::Differential gate could not parse {command} counts; preserving failure",
+                f"::warning::Differential gate marked {command} baseline_red: baseline command `{command_label(command, base_metadata)}` exited {base_metadata.get('exit_code', 'unknown')} before comparable counts were available",
+                file=sys.stderr,
+            )
+            continue
+
+        if current is None or base is None:
+            adjusted[command] = "inconclusive"
+            print(
+                f"::warning::Differential gate marked {command} inconclusive: current={current if current is not None else 'unavailable'} base={base if base is not None else 'unavailable'}",
                 file=sys.stderr,
             )
             continue

--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -55,6 +55,12 @@ if [ "${HAS_QUALITY_COMMANDS}" = true ]; then
     echo "::error::One or more quality commands failed"
     FAILED=true
   fi
+  if printf '%s\n' "${RESULTS}" | jq -e 'to_entries | any(.value == "baseline_red")' > /dev/null; then
+    echo "::warning::One or more quality commands were inconclusive because the baseline is already red"
+  fi
+  if printf '%s\n' "${RESULTS}" | jq -e 'to_entries | any(.value == "inconclusive")' > /dev/null; then
+    echo "::warning::One or more quality commands were inconclusive; preserving evidence without failing the PR"
+  fi
 fi
 
 # Check operations command results

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -28,20 +28,22 @@ IFS=',' read -ra CMD_ARRAY <<< "${ORDERED_COMMANDS}"
 for CMD in "${CMD_ARRAY[@]}"; do
   CMD="$(echo "${CMD}" | xargs)"
   case "${CMD}" in
-    audit|test)
+    audit|lint|test)
       BASELINE_COMMANDS+=("${CMD}")
       ;;
   esac
 done
 
 if [ "${#BASELINE_COMMANDS[@]}" -eq 0 ]; then
-  echo "No audit/test commands requested; skipping differential baseline run"
+  echo "No audit/lint/test commands requested; skipping differential baseline run"
   exit 0
 fi
 
 ORIGINAL_REF="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse HEAD)"
 BASE_OUTPUT_DIR="$(mktemp -d)"
 echo "HOMEBOY_BASE_OUTPUT_DIR=${BASE_OUTPUT_DIR}" >> "${GITHUB_ENV}"
+BASELINE_STATUS_JSON="${BASE_OUTPUT_DIR}/baseline-status.json"
+printf '{}\n' > "${BASELINE_STATUS_JSON}"
 
 restore_original_ref() {
   git checkout -q "${ORIGINAL_REF}" || true
@@ -76,6 +78,29 @@ for CMD in "${BASELINE_COMMANDS[@]}"; do
   if [ ! -s "${OUTPUT_JSON}" ]; then
     echo "::warning::baseline homeboy ${CMD} did not write structured output to ${OUTPUT_JSON}"
   fi
+
+  STRUCTURED_OUTPUT=false
+  if [ -s "${OUTPUT_JSON}" ]; then
+    STRUCTURED_OUTPUT=true
+  fi
+
+  STATUS="pass"
+  if [ "${CMD_EXIT}" -ne 0 ]; then
+    STATUS="fail"
+  fi
+
+  tmp_status="$(mktemp)"
+  jq -c \
+    --arg cmd "${CMD}" \
+    --arg status "${STATUS}" \
+    --arg command "${FULL_CMD}" \
+    --arg output_json "${OUTPUT_JSON}" \
+    --arg log_path "${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.log" \
+    --argjson exit_code "${CMD_EXIT}" \
+    --argjson structured_output "${STRUCTURED_OUTPUT}" \
+    '. + {($cmd): {status: $status, exit_code: $exit_code, command: $command, output_json: $output_json, log_path: $log_path, structured_output: $structured_output}}' \
+    "${BASELINE_STATUS_JSON}" > "${tmp_status}"
+  mv "${tmp_status}" "${BASELINE_STATUS_JSON}"
 
   echo "Baseline homeboy ${CMD} exited ${CMD_EXIT}"
 done

--- a/scripts/core/select-final-results.sh
+++ b/scripts/core/select-final-results.sh
@@ -12,6 +12,20 @@ if [ "${HOMEBOY_DIFFERENTIAL_GATING:-false}" = "true" ] \
   && [ -d "${HOMEBOY_OUTPUT_DIR:-}" ] \
   && [ -n "${HOMEBOY_BASE_OUTPUT_DIR:-}" ] \
   && [ -d "${HOMEBOY_BASE_OUTPUT_DIR:-}" ]; then
+  for baseline_file in "${HOMEBOY_BASE_OUTPUT_DIR}"/*.json; do
+    [ -f "${baseline_file}" ] || continue
+    name="$(basename "${baseline_file}")"
+    if [ "${name}" = "baseline-status.json" ]; then
+      cp "${baseline_file}" "${HOMEBOY_OUTPUT_DIR}/${name}"
+    else
+      cp "${baseline_file}" "${HOMEBOY_OUTPUT_DIR}/baseline-${name}"
+    fi
+  done
+  for baseline_log in "${HOMEBOY_BASE_OUTPUT_DIR}"/*.log; do
+    [ -f "${baseline_log}" ] || continue
+    cp "${baseline_log}" "${HOMEBOY_OUTPUT_DIR}/baseline-$(basename "${baseline_log}")"
+  done
+
   RESULTS="$(python3 "${GITHUB_ACTION_PATH}/scripts/core/apply-differential-gate.py" \
     "${RESULTS}" \
     "${HOMEBOY_OUTPUT_DIR}" \

--- a/scripts/core/test-apply-differential-gate.sh
+++ b/scripts/core/test-apply-differential-gate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APPLY_GATE="${SCRIPT_DIR}/apply-differential-gate.py"
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/homeboy-differential-gate.XXXXXX")"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+current_dir="${tmp_dir}/current"
+base_dir="${tmp_dir}/base"
+mkdir -p "${current_dir}" "${base_dir}"
+
+printf '{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}\n' > "${current_dir}/test.json"
+printf '{}\n' > "${base_dir}/baseline-status.json"
+
+result="$(python3 "${APPLY_GATE}" '{"test":"fail"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"test":"inconclusive"}' "${result}" "missing baseline counts become inconclusive"
+
+printf '{"test":{"status":"fail","exit_code":1,"command":"homeboy test sample --path .","structured_output":false}}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"test":"fail"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"test":"baseline_red"}' "${result}" "red baseline without structured counts does not fail candidate"
+
+printf '{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}\n' > "${base_dir}/test.json"
+printf '{"test":{"status":"fail","exit_code":1,"command":"homeboy test sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"test":"fail"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"test":"pass"}' "${result}" "matching baseline failure count is accepted"
+
+printf '{"success":false,"data":{"test_counts":{"failed":2,"errors":0}}}\n' > "${current_dir}/test.json"
+result="$(python3 "${APPLY_GATE}" '{"test":"fail"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"test":"fail"}' "${result}" "candidate regression still fails"
+
+printf '{"success":false,"data":{"lint_findings":[{},{}]}}\n' > "${current_dir}/lint.json"
+printf '{"success":false,"data":{"lint_findings":[{},{}]}}\n' > "${base_dir}/lint.json"
+printf '{"lint":{"status":"fail","exit_code":1,"command":"homeboy lint sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"lint":"fail"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"lint":"pass"}' "${result}" "lint baseline count is compared"
+
+printf 'All differential gate checks passed.\n'

--- a/scripts/core/test-enforce-final-status.sh
+++ b/scripts/core/test-enforce-final-status.sh
@@ -39,4 +39,10 @@ assert_exit 0 "closed PR ignores malformed stale results" \
 assert_exit 0 "passing quality results pass" \
   env RESULTS='{"test":"pass"}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
 
+assert_exit 0 "baseline red quality results do not fail PR" \
+  env RESULTS='{"test":"baseline_red"}' COMMANDS='test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+
+assert_exit 0 "inconclusive quality results do not fail PR" \
+  env RESULTS='{"lint":"inconclusive"}' COMMANDS='lint' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+
 printf 'All final status enforcement checks passed.\n'

--- a/scripts/digest/generate-failure-digest.sh
+++ b/scripts/digest/generate-failure-digest.sh
@@ -53,6 +53,47 @@ append_local_reproduction_commands() {
   } >> "${digest_file}"
 }
 
+append_differential_evidence() {
+  local digest_file="$1"
+  local baseline_status_file="${OUTPUT_DIR}/baseline-status.json"
+  local rows
+
+  rows="$(jq -r '
+    to_entries[]
+    | select(.value == "baseline_red" or .value == "inconclusive")
+    | [.key, .value] | @tsv
+  ' <<< "${RESULTS_JSON}" 2>/dev/null || true)"
+
+  [ -n "${rows}" ] || return 0
+
+  {
+    printf '\n### Differential baseline evidence\n'
+    printf -- '- Classification: baseline failures or missing comparable counts prevented candidate regression enforcement.\n'
+    if [ -f "${baseline_status_file}" ]; then
+      printf -- '- Baseline status artifact: `baseline-status.json`\n'
+    fi
+  } >> "${digest_file}"
+
+  while IFS=$'\t' read -r command status; do
+    [ -n "${command}" ] || continue
+    local baseline_command baseline_exit baseline_result candidate_result baseline_json baseline_log
+    baseline_command="$(jq -r --arg cmd "${command}" '.[$cmd].command // ("homeboy " + $cmd)' "${baseline_status_file}" 2>/dev/null || printf 'homeboy %s' "${command}")"
+    baseline_exit="$(jq -r --arg cmd "${command}" '.[$cmd].exit_code // "unknown"' "${baseline_status_file}" 2>/dev/null || printf 'unknown')"
+    baseline_result="$(jq -r --arg cmd "${command}" '.[$cmd].status // "unknown"' "${baseline_status_file}" 2>/dev/null || printf 'unknown')"
+    candidate_result="$(jq -r --arg cmd "${command}" '.[$cmd] // "unknown"' <<< "${RESULTS_JSON}" 2>/dev/null || printf 'unknown')"
+    baseline_json="baseline-${command}.json"
+    baseline_log="baseline-${command}.log"
+
+    {
+      printf -- '- `%s`: **%s**\n' "${command}" "${status}"
+      printf '  - Baseline command: `%s`\n' "${baseline_command}"
+      printf '  - Baseline result: `%s` (exit `%s`)\n' "${baseline_result}" "${baseline_exit}"
+      printf '  - Candidate result: `%s`\n' "${candidate_result}"
+      printf '  - Artifact refs: `%s`, `%s`, `%s`\n' "${command}.json" "${baseline_json}" "${baseline_log}"
+    } >> "${digest_file}"
+  done <<< "${rows}"
+}
+
 if [ -z "${OUTPUT_DIR}" ] || [ ! -d "${OUTPUT_DIR}" ]; then
   echo "No output directory available; skipping failure digest"
   exit 0
@@ -111,6 +152,7 @@ if [ ! -s "${DIGEST_FILE}" ]; then
 fi
 
 append_local_reproduction_commands "${DIGEST_FILE}"
+append_differential_evidence "${DIGEST_FILE}"
 
 if [ -n "${GITHUB_ENV:-}" ]; then
   echo "HOMEBOY_FAILURE_DIGEST_FILE=${DIGEST_FILE}" >> "${GITHUB_ENV}"

--- a/scripts/digest/test-generate-failure-digest.sh
+++ b/scripts/digest/test-generate-failure-digest.sh
@@ -94,4 +94,25 @@ jq -e \
    .action_ref == "v2"' \
   "${TOOLING_JSON}" >/dev/null
 
+export RESULTS='{"test":"baseline_red"}'
+cat > "${OUTPUT_DIR}/baseline-status.json" <<'JSON'
+{
+  "test": {
+    "status": "fail",
+    "exit_code": 1,
+    "command": "homeboy test wordpress --path /work --changed-since abc123base",
+    "structured_output": false
+  }
+}
+JSON
+
+bash "${ROOT}/scripts/digest/generate-failure-digest.sh"
+
+grep -F "### Differential baseline evidence" "${DIGEST_FILE}" >/dev/null
+grep -F -- '- `test`: **baseline_red**' "${DIGEST_FILE}" >/dev/null
+grep -F -- '- Baseline command: `homeboy test wordpress --path /work --changed-since abc123base`' "${DIGEST_FILE}" >/dev/null
+grep -F -- '- Baseline result: `fail` (exit `1`)' "${DIGEST_FILE}" >/dev/null
+grep -F -- '- Candidate result: `baseline_red`' "${DIGEST_FILE}" >/dev/null
+grep -F -- '- Artifact refs: `test.json`, `baseline-test.json`, `baseline-test.log`' "${DIGEST_FILE}" >/dev/null
+
 echo "generate failure digest wrapper checks passed"

--- a/scripts/pr/comment/lib.sh
+++ b/scripts/pr/comment/lib.sh
@@ -83,7 +83,7 @@ summary_json_for_command() {
 
 command_status() {
   local command="$1"
-  echo "${RESULTS}" | jq -r --arg cmd "${command}" 'if .[$cmd] == "pass" or .[$cmd] == "fail" then .[$cmd] else "unknown" end' 2>/dev/null || echo "unknown"
+  echo "${RESULTS}" | jq -r --arg cmd "${command}" 'if .[$cmd] == "pass" or .[$cmd] == "fail" or .[$cmd] == "baseline_red" or .[$cmd] == "inconclusive" then .[$cmd] else "unknown" end' 2>/dev/null || echo "unknown"
 }
 
 is_refactor_owning_section() {

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -84,6 +84,7 @@ status_icon() {
   case "$1" in
     pass|passed) printf '%s\n' ':white_check_mark:' ;;
     fail|failed) printf '%s\n' ':x:' ;;
+    baseline_red|inconclusive) printf '%s\n' ':warning:' ;;
     skipped) printf '%s\n' ':fast_forward:' ;;
     *) printf '%s\n' ':warning:' ;;
   esac
@@ -93,6 +94,8 @@ status_label() {
   case "$1" in
     pass|passed) printf '%s\n' 'passed' ;;
     fail|failed) printf '%s\n' 'failed' ;;
+    baseline_red) printf '%s\n' 'baseline red' ;;
+    inconclusive) printf '%s\n' 'inconclusive' ;;
     skipped) printf '%s\n' 'skipped' ;;
     *) printf '%s\n' 'unknown' ;;
   esac


### PR DESCRIPTION
## Summary
- Run differential baselines for lint as well as audit/test and capture per-command baseline status metadata.
- Classify failed or unparseable baselines as `baseline_red`/`inconclusive` instead of preserving candidate failure.
- Keep true candidate regressions failing when comparable baseline counts exist, and add digest/comment evidence for baseline-red outcomes.

Fixes Extra-Chill/homeboy#5788

## Verification
- `bash scripts/core/test-apply-differential-gate.sh`
- `bash scripts/core/test-enforce-final-status.sh`
- `bash scripts/core/test-select-final-results.sh`
- `bash scripts/pr/comment/test-unknown-status-rendering.sh`
- `bash scripts/digest/test-generate-failure-digest.sh`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the differential CI scripts, implementing the baseline-red classification change, and adding focused shell test coverage.