### PR TITLE
Reduce differential CI latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ on:
         description: 'Enable PR differential gating for audit/lint/test.'
         type: string
         default: 'false'
+      baseline-commands:
+        description: 'Commands to rerun at the PR base when differential-gating is true. Use auto, a comma-separated subset, or none.'
+        type: string
+        default: 'auto'
       observation-window:
         description: 'Duration window for best-effort observation export.'
         type: string
@@ -301,7 +305,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
@@ -376,6 +379,7 @@ jobs:
           php-version: ${{ inputs.php-version }}
           node-version: ${{ inputs.node-version }}
           differential-gating: ${{ inputs.differential-gating }}
+          baseline-commands: ${{ inputs.baseline-commands }}
           observation-window: ${{ inputs.observation-window }}
           autofix: ${{ inputs.autofix }}
           autofix-mode: ${{ inputs.autofix-mode }}

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Use these outputs to gate downstream jobs:
 | `iterations` | No | | Bench iteration count passed to `homeboy bench --iterations` |
 | `regression-threshold` | No | | Bench regression threshold passed to `homeboy bench --regression-threshold` |
 | `differential-gating` | No | `false` | On PRs, compare `audit`/`test` counts against the base SHA and fail only when the PR is worse. Opt-in; `lint` still gates on exit code. PR autofix is skipped while enabled. |
+| `baseline-commands` | No | `auto` | Commands to rerun at the PR base when `differential-gating` is true. `auto` preserves existing behavior by rerunning requested `audit`/`lint`/`test` commands; use a comma-separated subset such as `audit` or `none` to skip baseline reruns. |
 | `observation-window` | No | `24h` | Duration window passed to best-effort `homeboy runs export --since` for the separate matrix-safe observations artifact. |
 | `import-observations` | No | `false` | Download and best-effort import earlier `homeboy-observations-*` artifacts from the same workflow run before command execution. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,10 @@ inputs:
     description: 'On PRs, compare audit/lint/test failure counts against the base SHA and fail only when the PR is worse. Opt-in; PR autofix is skipped while enabled.'
     required: false
     default: 'false'
+  baseline-commands:
+    description: 'Commands to rerun at the PR base when differential-gating is true. Use auto to rerun requested audit/lint/test commands, a comma-separated subset such as audit,test, or none to skip baseline reruns.'
+    required: false
+    default: 'auto'
   observation-window:
     description: 'Duration window to export Homeboy observations after command execution (e.g. "24h", "7d", "30m"). Export is best-effort and non-fatal.'
     required: false
@@ -562,6 +566,7 @@ runs:
         COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
+        BASELINE_COMMANDS: ${{ inputs.baseline-commands }}
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
         RUN_GROUP_PREFIX: homeboy baseline
       run: bash ${{ github.action_path }}/scripts/core/run-baseline-commands.sh

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -745,6 +745,54 @@ has_lint_command() {
   printf '%s\n' "false"
 }
 
+resolve_baseline_commands() {
+  local requested_commands="$1"
+  local baseline_input="${2:-auto}"
+  local source_commands cmd base_cmd requested_cmd requested_base found result=()
+
+  baseline_input="$(printf '%s' "${baseline_input}" | xargs)"
+  case "${baseline_input}" in
+    ""|auto)
+      source_commands="${requested_commands}"
+      ;;
+    none|false|off)
+      printf '\n'
+      return 0
+      ;;
+    *)
+      source_commands="${baseline_input}"
+      ;;
+  esac
+
+  IFS=',' read -ra CMD_ARRAY <<< "$(canonicalize_commands "${source_commands}")"
+  for cmd in "${CMD_ARRAY[@]}"; do
+    cmd="$(echo "${cmd}" | xargs)"
+    base_cmd="$(printf '%s' "${cmd}" | awk '{print $1}')"
+    case "${base_cmd}" in
+      audit|lint|test) ;;
+      *) continue ;;
+    esac
+
+    found=false
+    IFS=',' read -ra REQUESTED_ARRAY <<< "${requested_commands}"
+    for requested_cmd in "${REQUESTED_ARRAY[@]}"; do
+      requested_cmd="$(echo "${requested_cmd}" | xargs)"
+      requested_base="$(printf '%s' "${requested_cmd}" | awk '{print $1}')"
+      if [ "${requested_base}" = "${base_cmd}" ]; then
+        found=true
+        break
+      fi
+    done
+
+    if [ "${found}" = true ]; then
+      result+=("${base_cmd}")
+    fi
+  done
+
+  local IFS=','
+  printf '%s\n' "${result[*]}"
+}
+
 settings_json_flags() {
   local raw="${HOMEBOY_SETTINGS_JSON:-}"
   if [ -z "${raw}" ] || [ "${raw}" = "{}" ]; then

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
 
 EFFECTIVE_COMMANDS="${COMMANDS:-audit,lint,test}"
+BASELINE_COMMANDS_INPUT="${BASELINE_COMMANDS:-auto}"
 
 if [ "${HOMEBOY_DIFFERENTIAL_GATING:-false}" != "true" ]; then
   echo "Differential gating disabled; skipping baseline run"
@@ -22,19 +23,19 @@ if [ -n "${TRACKED_DIRTY}" ]; then
   exit 0
 fi
 
-BASELINE_COMMANDS=()
-ORDERED_COMMANDS="$(canonicalize_commands "${EFFECTIVE_COMMANDS}")"
+BASELINE_RUN_COMMANDS=()
+ORDERED_COMMANDS="$(resolve_baseline_commands "${EFFECTIVE_COMMANDS}" "${BASELINE_COMMANDS_INPUT}")"
 IFS=',' read -ra CMD_ARRAY <<< "${ORDERED_COMMANDS}"
 for CMD in "${CMD_ARRAY[@]}"; do
   CMD="$(echo "${CMD}" | xargs)"
   case "${CMD}" in
     audit|lint|test)
-      BASELINE_COMMANDS+=("${CMD}")
+      BASELINE_RUN_COMMANDS+=("${CMD}")
       ;;
   esac
 done
 
-if [ "${#BASELINE_COMMANDS[@]}" -eq 0 ]; then
+if [ "${#BASELINE_RUN_COMMANDS[@]}" -eq 0 ]; then
   echo "No audit/lint/test commands requested; skipping differential baseline run"
   exit 0
 fi
@@ -57,7 +58,7 @@ COMP_ID="$(resolve_component_id)"
 WORKSPACE="$(resolve_workspace)"
 GROUP_PREFIX="${RUN_GROUP_PREFIX:-homeboy baseline}"
 
-for CMD in "${BASELINE_COMMANDS[@]}"; do
+for CMD in "${BASELINE_RUN_COMMANDS[@]}"; do
   OUTPUT_STEM="$(command_output_stem "${CMD}")"
   OUTPUT_JSON="${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.json"
   FULL_CMD="$(build_run_command "${CMD}" "${COMP_ID}" "${WORKSPACE}" "${OUTPUT_JSON}")"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -127,6 +127,26 @@ assert_equals \
   "$(build_review_report_command "${COMPONENT}" "${WORKSPACE}")" \
   "review report keeps path with changed-since"
 
+assert_equals \
+  "audit,lint,test" \
+  "$(resolve_baseline_commands "audit,lint,test" "auto")" \
+  "baseline auto keeps requested audit/lint/test commands"
+
+assert_equals \
+  "audit" \
+  "$(resolve_baseline_commands "audit,lint,test" "audit")" \
+  "baseline subset keeps only requested baseline command"
+
+assert_equals \
+  "" \
+  "$(resolve_baseline_commands "test" "audit")" \
+  "baseline subset intersects with matrix command"
+
+assert_equals \
+  "" \
+  "$(resolve_baseline_commands "audit,lint,test" "none")" \
+  "baseline none disables differential reruns"
+
 EXTRA_ARGS="--format json"
 assert_equals \
   "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \


### PR DESCRIPTION
## Summary
- Let reusable CI quality matrix jobs run concurrently instead of forcing Audit, Lint, and Test through `max-parallel: 1`.
- Add a `baseline-commands` input so differential baseline reruns can be narrowed or disabled explicitly while preserving the existing `auto` default.
- Add shell coverage for baseline command selection and matrix intersection behavior.

## Testing
- bash scripts/core/test-command-builders.sh && bash scripts/core/test-command-resolution.sh && bash scripts/core/test-select-final-results.sh && bash scripts/core/test-apply-differential-gate.sh && bash scripts/core/test-enforce-final-status.sh && bash scripts/core/test-bench-command.sh && bash scripts/core/test-import-observations.sh && bash scripts/core/test-baseline-change-detection.sh

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing CI latency, implementing the reusable workflow/action inputs, adding shell tests, and PR preparation.
