### PR TITLE
fix(release): confirm CI creates GitHub Release when skipping it

### DIFF
--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -167,7 +167,7 @@ if [ "${RELEASE_SKIP_PUBLISH}" = "true" ]; then
 fi
 
 if [ "${RELEASE_SKIP_GITHUB_RELEASE}" = "true" ]; then
-  RELEASE_ARGS+=(--no-github-release)
+  RELEASE_ARGS+=(--no-github-release --i-know-ci-creates-the-github-release)
 fi
 
 if [ "${RELEASE_HEAD}" = "true" ]; then

--- a/scripts/release/test-run-release-wrapper.sh
+++ b/scripts/release/test-run-release-wrapper.sh
@@ -220,6 +220,7 @@ run_wrapper
 ARGS="$(cat "${HOMEBOY_ARGS_FILE}")"
 assert_contains '--skip-publish' "${ARGS}" "release can opt out of package/publish steps"
 assert_contains '--no-github-release' "${ARGS}" "release can opt out of GitHub Release creation"
+assert_contains '--i-know-ci-creates-the-github-release' "${ARGS}" "CI opt-out also confirms CI creates the GitHub Release"
 unset RELEASE_SKIP_PUBLISH RELEASE_SKIP_GITHUB_RELEASE
 
 setup_fixture


### PR DESCRIPTION
When RELEASE_SKIP_GITHUB_RELEASE=true, run-release.sh passed --no-github-release WITHOUT the --i-know-ci-creates-the-github-release confirmation that homeboy core requires (issue #6137 guard). This makes the Prepare Release job in multi-job release pipelines (where a downstream job creates the GitHub Release) fail with: "Invalid argument no-github-release ... this is gated. Confirm only if CI creates the GitHub Release." Setting RELEASE_SKIP_GITHUB_RELEASE=true IS the explicit CI opt-in, so we now pass both flags. Updated wrapper test to assert the confirmation flag is present in the skip=true case. Root-caused from homeboy main Release runs where every code gate (Build/Test/Lint/Audit) passed but Prepare Release went red on this guard.