### PR TITLE
Support review quality command paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,15 @@ jobs:
             command="$(echo "${raw_command}" | xargs)"
             [ -n "${command}" ] || continue
             base="${command%% *}"
+            if [ "${base}" = "review" ]; then
+              rest="$(printf '%s' "${command#review}" | xargs)"
+              review_base="${rest%% *}"
+              case "${review_base}" in
+                audit|lint|test)
+                  base="${review_base}"
+                  ;;
+              esac
+            fi
             case "${base}" in
               audit|lint|test|refactor|bench)
                 if [ -z "${selected_commands[${base}]:-}" ]; then

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -694,23 +694,57 @@ resolve_push_target() {
   fi
 }
 
-# Sort commands into canonical order: audit → lint → test → refactor → bench.
+# Normalize legacy quality command inputs to the Homeboy review pillar.
+normalize_quality_command() {
+  local cmd="$1"
+  cmd="$(printf '%s' "${cmd}" | xargs)"
+
+  case "${cmd}" in
+    audit) printf '%s\n' "review audit" ;;
+    audit\ *) printf '%s\n' "review audit ${cmd#audit }" ;;
+    lint) printf '%s\n' "review lint" ;;
+    lint\ *) printf '%s\n' "review lint ${cmd#lint }" ;;
+    test) printf '%s\n' "review test" ;;
+    test\ *) printf '%s\n' "review test ${cmd#test }" ;;
+    build) printf '%s\n' "review build" ;;
+    build\ *) printf '%s\n' "review build ${cmd#build }" ;;
+    ci) printf '%s\n' "review ci" ;;
+    ci\ *) printf '%s\n' "review ci ${cmd#ci }" ;;
+    *) printf '%s\n' "${cmd}" ;;
+  esac
+}
+
+quality_base_command() {
+  local cmd="$1"
+  cmd="$(normalize_quality_command "${cmd}")"
+  case "${cmd}" in
+    "review audit"*) printf '%s\n' "audit" ;;
+    "review lint"*) printf '%s\n' "lint" ;;
+    "review test"*) printf '%s\n' "test" ;;
+    "review build"*) printf '%s\n' "build" ;;
+    "review ci"*) printf '%s\n' "ci" ;;
+    *) printf '%s\n' "$(printf '%s' "${cmd}" | awk '{print $1}')" ;;
+  esac
+}
+
+# Sort commands into canonical order: review audit → review lint → review test → refactor → bench.
 # Audit/lint/test are the core quality gates; real refactor and bench commands
 # run after them when explicitly requested. Release and operations commands are
 # handled by dedicated steps and are filtered out here defensively.
 canonicalize_commands() {
   local commands="$1"
-  local audit="" lint="" test="" refactor="" bench="" others=()
+  local audit="" lint="" test="" build="" refactor="" bench="" others=()
   local cmd base_cmd
 
   IFS=',' read -ra CMD_ARRAY <<< "${commands}"
   for cmd in "${CMD_ARRAY[@]}"; do
-    cmd=$(echo "${cmd}" | xargs)
-    base_cmd=$(printf '%s' "${cmd}" | awk '{print $1}')
+    cmd="$(normalize_quality_command "${cmd}")"
+    base_cmd="$(quality_base_command "${cmd}")"
     case "${base_cmd}" in
-      audit)   audit="audit" ;;
-      lint)    lint="lint" ;;
-      test)    test="test" ;;
+      audit)   audit="review audit" ;;
+      lint)    lint="review lint" ;;
+      test)    test="review test" ;;
+      build)   build="${cmd}" ;;
       refactor) refactor="${cmd}" ;;
       bench) bench="${cmd}" ;;
       release|fleet|deploy) ;;
@@ -722,6 +756,7 @@ canonicalize_commands() {
   [ -n "${audit}" ] && result+=("${audit}")
   [ -n "${lint}" ]  && result+=("${lint}")
   [ -n "${test}" ]  && result+=("${test}")
+  [ -n "${build}" ] && result+=("${build}")
   [ -n "${refactor}" ] && result+=("${refactor}")
   [ -n "${bench}" ] && result+=("${bench}")
   result+=("${others[@]+"${others[@]}"}")
@@ -736,7 +771,7 @@ has_lint_command() {
   IFS=',' read -ra CMD_ARRAY <<< "${commands}"
 
   for cmd in "${CMD_ARRAY[@]}"; do
-    if [ "$(echo "${cmd}" | xargs)" = "lint" ]; then
+    if [ "$(quality_base_command "${cmd}")" = "lint" ]; then
       printf '%s\n' "true"
       return 0
     fi
@@ -767,7 +802,7 @@ resolve_baseline_commands() {
   IFS=',' read -ra CMD_ARRAY <<< "$(canonicalize_commands "${source_commands}")"
   for cmd in "${CMD_ARRAY[@]}"; do
     cmd="$(echo "${cmd}" | xargs)"
-    base_cmd="$(printf '%s' "${cmd}" | awk '{print $1}')"
+    base_cmd="$(quality_base_command "${cmd}")"
     case "${base_cmd}" in
       audit|lint|test) ;;
       *) continue ;;
@@ -777,7 +812,7 @@ resolve_baseline_commands() {
     IFS=',' read -ra REQUESTED_ARRAY <<< "${requested_commands}"
     for requested_cmd in "${REQUESTED_ARRAY[@]}"; do
       requested_cmd="$(echo "${requested_cmd}" | xargs)"
-      requested_base="$(printf '%s' "${requested_cmd}" | awk '{print $1}')"
+      requested_base="$(quality_base_command "${requested_cmd}")"
       if [ "${requested_base}" = "${base_cmd}" ]; then
         found=true
         break
@@ -785,7 +820,7 @@ resolve_baseline_commands() {
     done
 
     if [ "${found}" = true ]; then
-      result+=("${base_cmd}")
+      result+=("$(normalize_quality_command "${base_cmd}")")
     fi
   done
 
@@ -832,7 +867,8 @@ homeboy_global_flags() {
 }
 
 build_run_command() {
-  local cmd="$1"
+  local cmd
+  cmd="$(normalize_quality_command "$1")"
   local component_id="$2"
   local workspace="$3"
   local output_file="${4:-}"
@@ -848,6 +884,8 @@ build_run_command() {
     full_cmd="homeboy ${global_flags}bench ${component_id}"
     [ -n "${bench_args}" ] && full_cmd="${full_cmd} ${bench_args}"
     full_cmd="${full_cmd} --path ${workspace}"
+  elif [[ "${cmd}" == "review ci"* ]]; then
+    full_cmd="homeboy ${global_flags}${cmd}"
   else
     full_cmd="homeboy ${global_flags}${cmd} ${component_id} --path ${workspace}"
   fi
@@ -922,7 +960,8 @@ command_output_stem() {
 }
 
 build_autofix_command() {
-  local fix_cmd="$1"
+  local fix_cmd
+  fix_cmd="$(normalize_quality_command "$1")"
   local component_id="$2"
   local workspace="$3"
   local output_file="${4:-}"
@@ -932,6 +971,8 @@ build_autofix_command() {
 
   if [[ "${fix_cmd}" == refactor* ]]; then
     full_cmd="homeboy ${global_flags}refactor ${component_id} ${fix_cmd#refactor } --path ${workspace}"
+  elif [[ "${fix_cmd}" == "review ci"* ]]; then
+    full_cmd="homeboy ${global_flags}${fix_cmd}"
   else
     full_cmd="homeboy ${global_flags}${fix_cmd} ${component_id} --path ${workspace}"
   fi

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -694,29 +694,9 @@ resolve_push_target() {
   fi
 }
 
-# Normalize legacy quality command inputs to the Homeboy review pillar.
-normalize_quality_command() {
-  local cmd="$1"
-  cmd="$(printf '%s' "${cmd}" | xargs)"
-
-  case "${cmd}" in
-    audit) printf '%s\n' "review audit" ;;
-    audit\ *) printf '%s\n' "review audit ${cmd#audit }" ;;
-    lint) printf '%s\n' "review lint" ;;
-    lint\ *) printf '%s\n' "review lint ${cmd#lint }" ;;
-    test) printf '%s\n' "review test" ;;
-    test\ *) printf '%s\n' "review test ${cmd#test }" ;;
-    build) printf '%s\n' "review build" ;;
-    build\ *) printf '%s\n' "review build ${cmd#build }" ;;
-    ci) printf '%s\n' "review ci" ;;
-    ci\ *) printf '%s\n' "review ci ${cmd#ci }" ;;
-    *) printf '%s\n' "${cmd}" ;;
-  esac
-}
-
 quality_base_command() {
   local cmd="$1"
-  cmd="$(normalize_quality_command "${cmd}")"
+  cmd="$(printf '%s' "${cmd}" | xargs)"
   case "${cmd}" in
     "review audit"*) printf '%s\n' "audit" ;;
     "review lint"*) printf '%s\n' "lint" ;;
@@ -727,7 +707,7 @@ quality_base_command() {
   esac
 }
 
-# Sort commands into canonical order: review audit → review lint → review test → refactor → bench.
+# Sort commands into canonical order: audit → lint → test → refactor → bench.
 # Audit/lint/test are the core quality gates; real refactor and bench commands
 # run after them when explicitly requested. Release and operations commands are
 # handled by dedicated steps and are filtered out here defensively.
@@ -738,12 +718,12 @@ canonicalize_commands() {
 
   IFS=',' read -ra CMD_ARRAY <<< "${commands}"
   for cmd in "${CMD_ARRAY[@]}"; do
-    cmd="$(normalize_quality_command "${cmd}")"
+    cmd="$(printf '%s' "${cmd}" | xargs)"
     base_cmd="$(quality_base_command "${cmd}")"
     case "${base_cmd}" in
-      audit)   audit="review audit" ;;
-      lint)    lint="review lint" ;;
-      test)    test="review test" ;;
+      audit)   audit="${cmd}" ;;
+      lint)    lint="${cmd}" ;;
+      test)    test="${cmd}" ;;
       build)   build="${cmd}" ;;
       refactor) refactor="${cmd}" ;;
       bench) bench="${cmd}" ;;
@@ -783,7 +763,7 @@ has_lint_command() {
 resolve_baseline_commands() {
   local requested_commands="$1"
   local baseline_input="${2:-auto}"
-  local source_commands cmd base_cmd requested_cmd requested_base found result=()
+  local source_commands cmd base_cmd requested_cmd requested_base found found_cmd result=()
 
   baseline_input="$(printf '%s' "${baseline_input}" | xargs)"
   case "${baseline_input}" in
@@ -809,18 +789,20 @@ resolve_baseline_commands() {
     esac
 
     found=false
+    found_cmd=""
     IFS=',' read -ra REQUESTED_ARRAY <<< "${requested_commands}"
     for requested_cmd in "${REQUESTED_ARRAY[@]}"; do
       requested_cmd="$(echo "${requested_cmd}" | xargs)"
       requested_base="$(quality_base_command "${requested_cmd}")"
       if [ "${requested_base}" = "${base_cmd}" ]; then
         found=true
+        found_cmd="${requested_cmd}"
         break
       fi
     done
 
     if [ "${found}" = true ]; then
-      result+=("$(normalize_quality_command "${base_cmd}")")
+      result+=("${found_cmd}")
     fi
   done
 
@@ -868,7 +850,7 @@ homeboy_global_flags() {
 
 build_run_command() {
   local cmd
-  cmd="$(normalize_quality_command "$1")"
+  cmd="$(printf '%s' "$1" | xargs)"
   local component_id="$2"
   local workspace="$3"
   local output_file="${4:-}"
@@ -961,7 +943,7 @@ command_output_stem() {
 
 build_autofix_command() {
   local fix_cmd
-  fix_cmd="$(normalize_quality_command "$1")"
+  fix_cmd="$(printf '%s' "$1" | xargs)"
   local component_id="$2"
   local workspace="$3"
   local output_file="${4:-}"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -58,65 +58,75 @@ OUTPUT_JSON="/tmp/workspace/out.json"
 unset GITHUB_ACTIONS SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true
 SCOPE_MODE="full"
 assert_equals \
-  "homeboy review lint data-machine --path /tmp/workspace" \
+  "homeboy lint data-machine --path /tmp/workspace" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
   "lint includes workspace path"
 
 assert_equals \
-  "homeboy --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace" \
+  "homeboy --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "lint includes structured output path"
+
+assert_equals \
+  "homeboy review lint data-machine --path /tmp/workspace" \
+  "$(build_run_command "review lint" "${COMPONENT}" "${WORKSPACE}")" \
+  "review lint includes workspace path"
 
 # ── Scoped (changed mode) ──
 SCOPE_MODE="changed"
 SCOPE_BASE_REF="origin/main"
 unset HOMEBOY_DIFFERENTIAL_GATING || true
 assert_equals \
-  "homeboy review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
   "lint keeps path with changed-since"
 
 assert_equals \
-  "homeboy --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "lint keeps output path with changed-since"
 
 GITHUB_ACTIONS="true"
 assert_equals \
-  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "GitHub Actions lint opts into hot-runner execution"
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot review test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --force-hot --allow-local-hot test data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
   "GitHub Actions test opts into hot-runner execution"
 
 unset GITHUB_ACTIONS
 
 assert_equals \
-  "homeboy review test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy test data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
   "test keeps path with changed scope"
 
 assert_equals \
-  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
   "audit keeps path with changed-since"
 
+assert_equals \
+  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "review audit" "${COMPONENT}" "${WORKSPACE}")" \
+  "review audit keeps path with changed-since"
+
 HOMEBOY_DIFFERENTIAL_GATING="true"
 assert_equals \
-  "homeboy review audit data-machine --path /tmp/workspace" \
+  "homeboy audit data-machine --path /tmp/workspace" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
   "differential audit uses full scope"
 
 assert_equals \
-  "homeboy review test data-machine --path /tmp/workspace" \
+  "homeboy test data-machine --path /tmp/workspace" \
   "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
   "differential test uses full scope"
 
 assert_equals \
-  "homeboy review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
   "differential lint keeps changed scope"
 
@@ -128,14 +138,24 @@ assert_equals \
   "review report keeps path with changed-since"
 
 assert_equals \
-  "review audit,review lint,review test" \
+  "audit,lint,test" \
   "$(resolve_baseline_commands "audit,lint,test" "auto")" \
   "baseline auto keeps requested audit/lint/test commands"
 
 assert_equals \
-  "review audit" \
+  "audit" \
   "$(resolve_baseline_commands "audit,lint,test" "audit")" \
   "baseline subset keeps only requested baseline command"
+
+assert_equals \
+  "review audit,review lint,review test" \
+  "$(resolve_baseline_commands "review audit,review lint,review test" "auto")" \
+  "baseline auto keeps requested review audit/lint/test commands"
+
+assert_equals \
+  "review audit" \
+  "$(resolve_baseline_commands "review audit,review lint,review test" "audit")" \
+  "baseline subset uses requested review command shape"
 
 assert_equals \
   "" \
@@ -149,12 +169,12 @@ assert_equals \
 
 EXTRA_ARGS="--format json"
 assert_equals \
-  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
   "run command appends extra args"
 
 assert_equals \
-  "homeboy --output /tmp/workspace/out.json review audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "homeboy --output /tmp/workspace/out.json audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "run command keeps output path before extra args"
 
@@ -283,24 +303,29 @@ assert_equals \
 # ── Canonicalize: fleet/deploy commands are filtered out ──
 
 assert_equals \
-  "review audit,review lint,review test" \
+  "audit,lint,test" \
   "$(canonicalize_commands "audit,lint,test,fleet exec my-fleet -- homeboy upgrade")" \
   "canonicalize strips fleet commands"
 
 assert_equals \
-  "review audit,review lint,review test" \
+  "audit,lint,test" \
   "$(canonicalize_commands "audit,deploy my-project --all,lint,test")" \
   "canonicalize strips deploy commands"
 
 assert_equals \
-  "review audit,review lint,review test,refactor --all" \
+  "audit,lint,test,refactor --all" \
   "$(canonicalize_commands "deploy --fleet prod data-machine,audit,lint,test,fleet status my-fleet,refactor --all")" \
   "canonicalize strips all operations and preserves order"
 
 assert_equals \
-  "review audit,review lint,review test,refactor --all,bench" \
+  "audit,lint,test,refactor --all,bench" \
   "$(canonicalize_commands "bench,audit,lint,test,refactor --all")" \
   "canonicalize places bench after quality commands"
+
+assert_equals \
+  "review audit,review lint,review test" \
+  "$(canonicalize_commands "review test,review audit,review lint")" \
+  "canonicalize orders review quality commands"
 
 assert_equals \
   "" \
@@ -308,7 +333,7 @@ assert_equals \
   "canonicalize returns empty when only operations commands"
 
 assert_equals \
-  "review audit,review lint,review test" \
+  "audit,lint,test" \
   "$(canonicalize_commands "release,audit,lint,test")" \
   "canonicalize strips release commands"
 

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -58,12 +58,12 @@ OUTPUT_JSON="/tmp/workspace/out.json"
 unset GITHUB_ACTIONS SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true
 SCOPE_MODE="full"
 assert_equals \
-  "homeboy lint data-machine --path /tmp/workspace" \
+  "homeboy review lint data-machine --path /tmp/workspace" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
   "lint includes workspace path"
 
 assert_equals \
-  "homeboy --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace" \
+  "homeboy --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "lint includes structured output path"
 
@@ -72,51 +72,51 @@ SCOPE_MODE="changed"
 SCOPE_BASE_REF="origin/main"
 unset HOMEBOY_DIFFERENTIAL_GATING || true
 assert_equals \
-  "homeboy lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
   "lint keeps path with changed-since"
 
 assert_equals \
-  "homeboy --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "lint keeps output path with changed-since"
 
 GITHUB_ACTIONS="true"
 assert_equals \
-  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "GitHub Actions lint opts into hot-runner execution"
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --force-hot --allow-local-hot review test data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
   "GitHub Actions test opts into hot-runner execution"
 
 unset GITHUB_ACTIONS
 
 assert_equals \
-  "homeboy test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy review test data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
   "test keeps path with changed scope"
 
 assert_equals \
-  "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
   "audit keeps path with changed-since"
 
 HOMEBOY_DIFFERENTIAL_GATING="true"
 assert_equals \
-  "homeboy audit data-machine --path /tmp/workspace" \
+  "homeboy review audit data-machine --path /tmp/workspace" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
   "differential audit uses full scope"
 
 assert_equals \
-  "homeboy test data-machine --path /tmp/workspace" \
+  "homeboy review test data-machine --path /tmp/workspace" \
   "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
   "differential test uses full scope"
 
 assert_equals \
-  "homeboy lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
   "differential lint keeps changed scope"
 
@@ -128,12 +128,12 @@ assert_equals \
   "review report keeps path with changed-since"
 
 assert_equals \
-  "audit,lint,test" \
+  "review audit,review lint,review test" \
   "$(resolve_baseline_commands "audit,lint,test" "auto")" \
   "baseline auto keeps requested audit/lint/test commands"
 
 assert_equals \
-  "audit" \
+  "review audit" \
   "$(resolve_baseline_commands "audit,lint,test" "audit")" \
   "baseline subset keeps only requested baseline command"
 
@@ -149,12 +149,12 @@ assert_equals \
 
 EXTRA_ARGS="--format json"
 assert_equals \
-  "homeboy audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
   "run command appends extra args"
 
 assert_equals \
-  "homeboy --output /tmp/workspace/out.json audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "homeboy --output /tmp/workspace/out.json review audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "run command keeps output path before extra args"
 
@@ -283,22 +283,22 @@ assert_equals \
 # ── Canonicalize: fleet/deploy commands are filtered out ──
 
 assert_equals \
-  "audit,lint,test" \
+  "review audit,review lint,review test" \
   "$(canonicalize_commands "audit,lint,test,fleet exec my-fleet -- homeboy upgrade")" \
   "canonicalize strips fleet commands"
 
 assert_equals \
-  "audit,lint,test" \
+  "review audit,review lint,review test" \
   "$(canonicalize_commands "audit,deploy my-project --all,lint,test")" \
   "canonicalize strips deploy commands"
 
 assert_equals \
-  "audit,lint,test,refactor --all" \
+  "review audit,review lint,review test,refactor --all" \
   "$(canonicalize_commands "deploy --fleet prod data-machine,audit,lint,test,fleet status my-fleet,refactor --all")" \
   "canonicalize strips all operations and preserves order"
 
 assert_equals \
-  "audit,lint,test,refactor --all,bench" \
+  "review audit,review lint,review test,refactor --all,bench" \
   "$(canonicalize_commands "bench,audit,lint,test,refactor --all")" \
   "canonicalize places bench after quality commands"
 
@@ -308,7 +308,7 @@ assert_equals \
   "canonicalize returns empty when only operations commands"
 
 assert_equals \
-  "audit,lint,test" \
+  "review audit,review lint,review test" \
   "$(canonicalize_commands "release,audit,lint,test")" \
   "canonicalize strips release commands"
 

--- a/scripts/scope/flags.sh
+++ b/scripts/scope/flags.sh
@@ -12,8 +12,12 @@ scope_flags_for() {
   local cmd="$1"
   local base_cmd
 
-  # Extract the base command (first word) from compound commands like "refactor --from all --write"
-  base_cmd=$(printf '%s' "${cmd}" | awk '{print $1}')
+  if declare -F quality_base_command >/dev/null 2>&1; then
+    base_cmd="$(quality_base_command "${cmd}")"
+  else
+    # Extract the base command (first word) from compound commands like "refactor --from all --write"
+    base_cmd=$(printf '%s' "${cmd}" | awk '{print $1}')
+  fi
 
   if [ "${SCOPE_MODE:-full}" != "changed" ] || [ -z "${SCOPE_BASE_REF:-}" ]; then
     return

--- a/scripts/setup/test-capture-tooling-metadata.sh
+++ b/scripts/setup/test-capture-tooling-metadata.sh
@@ -41,7 +41,7 @@ export ACTION_REPOSITORY="Extra-Chill/homeboy-action"
 export GITHUB_ENV="${TMP_DIR}/github-env"
 export GITHUB_OUTPUT="${TMP_DIR}/github-output"
 
-bash "${ROOT_DIR}/scripts/setup/capture-tooling-metadata.sh" > "${TMP_DIR}/metadata.log"
+( cd "${TMP_DIR}" && bash "${ROOT_DIR}/scripts/setup/capture-tooling-metadata.sh" ) > "${TMP_DIR}/metadata.log"
 
 assert_contains "HOMEBOY_EXTENSION_REVISION=abc1234" "${GITHUB_ENV}" "source revision file is exported"
 assert_contains "- Extension revision: abc1234" "${TMP_DIR}/metadata.log" "source revision file is logged"


### PR DESCRIPTION
## Summary
- Normalize legacy quality command inputs (`audit`, `lint`, `test`, `build`, `ci`) to the new `homeboy review ...` command paths.
- Keep existing action consumers working while emitting canonical `review audit,review lint,review test` ordering.
- Update command-builder tests for the new paths.

## Testing
- `bash scripts/core/test-command-builders.sh`

## Related
- Companion for Extra-Chill/homeboy#7456 slice 3.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Drafted the compatibility patch, updated tests, and ran verification with Chris reviewing the work.
