### PR TITLE
Gate review quality commands differentially

### DIFF
--- a/scripts/core/apply-differential-gate.py
+++ b/scripts/core/apply-differential-gate.py
@@ -98,6 +98,13 @@ def lint_count(payload: dict[str, Any] | None) -> int | None:
     return None
 
 
+def quality_base_command(command: str) -> str:
+    parts = command.split()
+    if len(parts) >= 2 and parts[0] == "review" and parts[1] in {"audit", "lint", "test"}:
+        return parts[1]
+    return parts[0] if parts else command
+
+
 def changed_scope_introduced_count(command: str, payload: dict[str, Any] | None) -> int | None:
     data = unwrap(payload)
     changed_since = data.get("changed_since", {}) if isinstance(data, dict) else {}
@@ -114,15 +121,16 @@ def output_stem(command: str) -> str:
 
 
 def metric_for(command: str, directory: str) -> int | None:
+    base_command = quality_base_command(command)
     payload = read_json(os.path.join(directory, f"{output_stem(command)}.json"))
-    scoped_count = changed_scope_introduced_count(command, payload)
+    scoped_count = changed_scope_introduced_count(base_command, payload)
     if scoped_count is not None:
         return scoped_count
-    if command == "audit":
+    if base_command == "audit":
         return audit_count(payload)
-    if command == "lint":
+    if base_command == "lint":
         return lint_count(payload)
-    if command == "test":
+    if base_command == "test":
         return test_count(payload)
     return None
 
@@ -165,8 +173,11 @@ def main() -> int:
         return 0
 
     adjusted = dict(results)
-    for command in ("audit", "lint", "test"):
-        if adjusted.get(command) != "fail":
+    for command, status in list(adjusted.items()):
+        base_command = quality_base_command(command)
+        if base_command not in {"audit", "lint", "test"}:
+            continue
+        if status != "fail":
             continue
 
         current = metric_for(command, current_dir)

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -28,7 +28,7 @@ ORDERED_COMMANDS="$(resolve_baseline_commands "${EFFECTIVE_COMMANDS}" "${BASELIN
 IFS=',' read -ra CMD_ARRAY <<< "${ORDERED_COMMANDS}"
 for CMD in "${CMD_ARRAY[@]}"; do
   CMD="$(echo "${CMD}" | xargs)"
-  case "${CMD}" in
+  case "$(quality_base_command "${CMD}")" in
     audit|lint|test)
       BASELINE_RUN_COMMANDS+=("${CMD}")
       ;;

--- a/scripts/core/test-apply-differential-gate.sh
+++ b/scripts/core/test-apply-differential-gate.sh
@@ -40,7 +40,14 @@ printf '{"test":{"status":"fail","exit_code":1,"command":"homeboy test sample --
 result="$(python3 "${APPLY_GATE}" '{"test":"fail"}' "${current_dir}" "${base_dir}")"
 assert_equals '{"test":"pass"}' "${result}" "matching baseline failure count is accepted"
 
+printf '{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}\n' > "${current_dir}/review-test.json"
+printf '{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}\n' > "${base_dir}/review-test.json"
+printf '{"review test":{"status":"fail","exit_code":1,"command":"homeboy review test sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"review test":"fail"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"review test":"pass"}' "${result}" "matching review test baseline failure count is accepted"
+
 printf '{"success":false,"data":{"test_counts":{"failed":2,"errors":0}}}\n' > "${current_dir}/test.json"
+printf '{"test":{"status":"fail","exit_code":1,"command":"homeboy test sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
 result="$(python3 "${APPLY_GATE}" '{"test":"fail"}' "${current_dir}" "${base_dir}")"
 assert_equals '{"test":"fail"}' "${result}" "candidate regression still fails"
 


### PR DESCRIPTION
## Summary
- Recognize `review audit|lint|test` when selecting differential baseline commands.
- Apply differential gate comparisons to nested review command result keys while preserving bare command behavior.
- Add coverage for `review test` differential acceptance.

## Testing
- `bash scripts/core/test-apply-differential-gate.sh`
- `bash scripts/core/test-command-builders.sh`
- `for test_script in scripts/**/*test*.sh; do bash ""; done`

## Related
- Follow-up to #265 for Extra-Chill/homeboy#7590.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** GPT-5.5 via OpenCode
- **Used for:** Diagnosed the nested review differential-gating gap from CI logs, patched the action, and ran the local shell gate.
