### PR TITLE
ci: use review quality command defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       commands:
         description: 'Homeboy quality commands to run.'
         type: string
-        default: 'audit,lint,test'
+        default: 'review audit,review lint,review test'
       expected-commands:
         description: 'Full command set expected across the workflow.'
         type: string

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
 
   # ── Commands ──
   commands:
-    description: 'Override commands to run. If empty, inferred from event context: PR/push/manual → audit,lint,test; cron → release.'
+    description: 'Override commands to run. If empty, inferred from event context: PR/push/manual → review audit,review lint,review test; cron → release.'
     required: false
     default: ''
   expected-commands:


### PR DESCRIPTION
Part of the review-pillar vocabulary cut (Extra-Chill/homeboy#7456, homeboy#7590).

Updates the reusable workflow default quality commands to the review-nested Homeboy vocabulary while keeping non-quality commands unchanged.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Applied the workflow vocabulary update and prepared this PR.