### PR TITLE
fix: route quality gates through review umbrella

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Use these outputs to gate downstream jobs:
 | `release-skip-github-release` | No | `false` | Skip GitHub Release creation |
 | `release-verify-github-release` | No | `true` | Verify that a successful release has a GitHub Release |
 
+Quality command inputs `audit`, `lint`, `test`, `build`, and `audit-baseline` are action-level shorthand. Homeboy Action runs them through Homeboy's review umbrella, for example `commands: test` emits `homeboy review test <component> --path <workspace>`. Commands that remain top-level in Homeboy, including `bench` and `refactor`, are emitted as top-level commands.
+
 ## Outputs
 
 | Output | Description |

--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -131,7 +131,7 @@ maybe_update_baseline() {
   if [ "$(scope_context)" != "pr" ]; then
     echo "Updating audit baseline (non-PR context)..."
     set +e
-    BASELINE_CMD="homeboy audit ${COMP_ID} --baseline --path ${WORKSPACE}"
+    BASELINE_CMD="homeboy review audit ${COMP_ID} --baseline --path ${WORKSPACE}"
     eval "${BASELINE_CMD}"
     BASELINE_EXIT=$?
     set -e

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -199,7 +199,7 @@ fi
 if changes_are_only_drift "${WORKSPACE}" || (git diff --quiet && git diff --cached --quiet); then
   echo "Updating audit baseline..."
   set +e
-  homeboy audit "${COMP_ID}" --baseline --path "${WORKSPACE}"
+  homeboy review audit "${COMP_ID}" --baseline --path "${WORKSPACE}"
   BASELINE_EXIT=$?
   set -e
   if [ "${BASELINE_EXIT}" -ne 0 ]; then

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -699,17 +699,23 @@ quality_base_command() {
   cmd="$(printf '%s' "${cmd}" | xargs)"
   case "${cmd}" in
     "review audit"*) printf '%s\n' "audit" ;;
+    "review audit-baseline"*) printf '%s\n' "audit-baseline" ;;
     "review lint"*) printf '%s\n' "lint" ;;
     "review test"*) printf '%s\n' "test" ;;
     "review build"*) printf '%s\n' "build" ;;
     "review ci"*) printf '%s\n' "ci" ;;
-    audit|audit\ *|lint|lint\ *|test|test\ *|build|build\ *|ci|ci\ *) printf '%s\n' "" ;;
+    audit|audit\ *) printf '%s\n' "audit" ;;
+    audit-baseline|audit-baseline\ *) printf '%s\n' "audit-baseline" ;;
+    lint|lint\ *) printf '%s\n' "lint" ;;
+    test|test\ *) printf '%s\n' "test" ;;
+    build|build\ *) printf '%s\n' "build" ;;
+    ci|ci\ *) printf '%s\n' "ci" ;;
     *) printf '%s\n' "$(printf '%s' "${cmd}" | awk '{print $1}')" ;;
   esac
 }
 
-# Sort commands into canonical order: audit → lint → test → refactor → bench.
-# Audit/lint/test are the core quality gates; real refactor and bench commands
+# Sort commands into canonical order: audit → lint → test → build → refactor → bench.
+# Review-backed audit/lint/test/build are core quality gates; real refactor and bench commands
 # run after them when explicitly requested. Release and operations commands are
 # handled by dedicated steps and are filtered out here defensively.
 canonicalize_commands() {
@@ -832,6 +838,24 @@ settings_json_flags() {
   done < <(printf '%s' "${raw}" | jq -r 'to_entries[] | [.key, (.value | tojson)] | @tsv')
 }
 
+review_subcommand_run_command() {
+  local cmd="$1"
+  local component_id="$2"
+  local workspace="$3"
+  local global_flags="$4"
+  local review_cmd base_cmd rest
+
+  review_cmd="${cmd#review }"
+  base_cmd="$(printf '%s' "${review_cmd}" | awk '{print $1}')"
+  rest="$(printf '%s' "${review_cmd#${base_cmd}}" | xargs)"
+
+  if [ -n "${rest}" ]; then
+    printf 'homeboy %sreview %s %s %s --path %s\n' "${global_flags}" "${base_cmd}" "${component_id}" "${rest}" "${workspace}"
+  else
+    printf 'homeboy %sreview %s %s --path %s\n' "${global_flags}" "${base_cmd}" "${component_id}" "${workspace}"
+  fi
+}
+
 homeboy_global_flags() {
   local output_file="${1:-}"
   local flags=""
@@ -869,6 +893,10 @@ build_run_command() {
     full_cmd="${full_cmd} --path ${workspace}"
   elif [[ "${cmd}" == "review ci"* ]]; then
     full_cmd="homeboy ${global_flags}${cmd}"
+  elif [[ "${cmd}" == "review "* ]]; then
+    full_cmd="$(review_subcommand_run_command "${cmd}" "${component_id}" "${workspace}" "${global_flags}")"
+  elif [[ "$(quality_base_command "${cmd}")" =~ ^(audit|audit-baseline|lint|test|build)$ ]]; then
+    full_cmd="$(review_subcommand_run_command "review ${cmd}" "${component_id}" "${workspace}" "${global_flags}")"
   else
     full_cmd="homeboy ${global_flags}${cmd} ${component_id} --path ${workspace}"
   fi
@@ -956,6 +984,10 @@ build_autofix_command() {
     full_cmd="homeboy ${global_flags}refactor ${component_id} ${fix_cmd#refactor } --path ${workspace}"
   elif [[ "${fix_cmd}" == "review ci"* ]]; then
     full_cmd="homeboy ${global_flags}${fix_cmd}"
+  elif [[ "${fix_cmd}" == "review "* ]]; then
+    full_cmd="$(review_subcommand_run_command "${fix_cmd}" "${component_id}" "${workspace}" "${global_flags}")"
+  elif [[ "$(quality_base_command "${fix_cmd}")" =~ ^(audit|audit-baseline|lint|test|build)$ ]]; then
+    full_cmd="$(review_subcommand_run_command "review ${fix_cmd}" "${component_id}" "${workspace}" "${global_flags}")"
   else
     full_cmd="homeboy ${global_flags}${fix_cmd} ${component_id} --path ${workspace}"
   fi

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -59,6 +59,16 @@ unset GITHUB_ACTIONS SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true
 SCOPE_MODE="full"
 assert_equals \
   "homeboy review lint data-machine --path /tmp/workspace" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
+  "lint routes through review and includes workspace path"
+
+assert_equals \
+  "homeboy --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "lint routes through review and includes structured output path"
+
+assert_equals \
+  "homeboy review lint data-machine --path /tmp/workspace" \
   "$(build_run_command "review lint" "${COMPONENT}" "${WORKSPACE}")" \
   "review lint includes workspace path"
 
@@ -68,10 +78,30 @@ SCOPE_BASE_REF="origin/main"
 unset HOMEBOY_DIFFERENTIAL_GATING || true
 assert_equals \
   "homeboy review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
+  "lint keeps path with changed-since"
+
+assert_equals \
+  "homeboy --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "lint keeps output path with changed-since"
+
+assert_equals \
+  "homeboy review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review lint" "${COMPONENT}" "${WORKSPACE}")" \
   "review lint keeps path with changed-since"
 
 GITHUB_ACTIONS="true"
+assert_equals \
+  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "GitHub Actions lint opts into hot-runner execution"
+
+assert_equals \
+  "homeboy --force-hot --allow-local-hot review test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
+  "GitHub Actions test opts into hot-runner execution"
+
 assert_equals \
   "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
@@ -85,11 +115,46 @@ assert_equals \
 unset GITHUB_ACTIONS
 
 assert_equals \
+  "homeboy review test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
+  "test keeps path with changed scope"
+
+assert_equals \
+  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
+  "audit keeps path with changed-since"
+
+assert_equals \
   "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review audit" "${COMPONENT}" "${WORKSPACE}")" \
   "review audit keeps path with changed-since"
 
+assert_equals \
+  "homeboy review build data-machine --path /tmp/workspace" \
+  "$(build_run_command "build" "${COMPONENT}" "${WORKSPACE}")" \
+  "build routes through review"
+
+assert_equals \
+  "homeboy review audit data-machine --baseline --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "audit --baseline" "${COMPONENT}" "${WORKSPACE}")" \
+  "audit flags route after component through review"
+
 HOMEBOY_DIFFERENTIAL_GATING="true"
+assert_equals \
+  "homeboy review audit data-machine --path /tmp/workspace" \
+  "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
+  "differential audit uses full scope"
+
+assert_equals \
+  "homeboy review test data-machine --path /tmp/workspace" \
+  "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
+  "differential test uses full scope"
+
+assert_equals \
+  "homeboy review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}")" \
+  "differential lint keeps changed scope"
+
 assert_equals \
   "homeboy review audit data-machine --path /tmp/workspace" \
   "$(build_run_command "review audit" "${COMPONENT}" "${WORKSPACE}")" \
@@ -139,9 +204,19 @@ assert_equals \
   "run command appends extra args"
 
 assert_equals \
+  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
+  "bare audit command appends extra args through review"
+
+assert_equals \
   "homeboy --output /tmp/workspace/out.json review audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
   "$(build_run_command "review audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "run command keeps output path before extra args"
+
+assert_equals \
+  "homeboy --output /tmp/workspace/out.json review audit data-machine --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "bare audit command keeps output path before extra args"
 
 unset EXTRA_ARGS
 BENCH_RIG="main,pr"

--- a/scripts/digest/generate-failure-digest.sh
+++ b/scripts/digest/generate-failure-digest.sh
@@ -47,10 +47,17 @@ append_local_reproduction_commands() {
     printf '\n```bash\n'
     while IFS= read -r command; do
       [ -n "${command}" ] || continue
-      printf 'homeboy %s %s --path .%s\n' "${command}" "${COMPONENT_NAME}" "${scope_args}"
+      case "${command}" in
+        "review "*) printf 'homeboy %s %s --path .%s\n' "${command}" "${COMPONENT_NAME}" "${scope_args}" ;;
+        lint|test) printf 'homeboy review %s %s --path .%s\n' "${command}" "${COMPONENT_NAME}" "${scope_args}" ;;
+      esac
     done <<< "${failed_commands}"
     printf '```\n'
   } >> "${digest_file}"
+}
+
+command_artifact_stem() {
+  printf '%s' "$1" | sed -E 's/[^[:alnum:]._-]+/-/g; s/^-+//; s/-+$//'
 }
 
 append_differential_evidence() {
@@ -81,7 +88,7 @@ append_differential_evidence() {
     baseline_exit="$(jq -r --arg cmd "${command}" '.[$cmd].exit_code // "unknown"' "${baseline_status_file}" 2>/dev/null || printf 'unknown')"
     baseline_result="$(jq -r --arg cmd "${command}" '.[$cmd].status // "unknown"' "${baseline_status_file}" 2>/dev/null || printf 'unknown')"
     candidate_result="$(jq -r --arg cmd "${command}" '.[$cmd] // "unknown"' <<< "${RESULTS_JSON}" 2>/dev/null || printf 'unknown')"
-    artifact_stem="${command// /-}"
+    artifact_stem="$(command_artifact_stem "${command}")"
     baseline_json="baseline-${artifact_stem}.json"
     baseline_log="baseline-${artifact_stem}.log"
 

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -229,7 +229,14 @@ append_split_command_section() {
     SECTION_BODY+="> :warning: Structured output for \`${command}\` was not found. Check the action logs for details."$'\n'
   fi
 
-  SECTION_BODY+="> Deep dive: homeboy ${command} ${COMP_ID}${scope_suffix}"$'\n\n'
+  case "${command}" in
+    audit|lint|test|build|audit-baseline)
+      SECTION_BODY+="> Deep dive: homeboy review ${command} ${COMP_ID}${scope_suffix}"$'\n\n'
+      ;;
+    *)
+      SECTION_BODY+="> Deep dive: homeboy ${command} ${COMP_ID}${scope_suffix}"$'\n\n'
+      ;;
+  esac
 }
 
 append_split_command_sections() {


### PR DESCRIPTION
## Root cause

Homeboy 0.281.7 collapsed the standalone top-level `audit`, `lint`, `test`, and `build` commands into the `review` umbrella. At Homeboy 0.281.8, the action's runtime builder still emitted bare forms such as `homeboy test <component> --path <workspace>`, which fails with `error: unrecognized subcommand 'test'` for consumers using current Homeboy releases. This is failing consumer CI, including Static Site Importer PR #560.

## Migration scope

- Route action-level quality command inputs `audit`, `lint`, `test`, `build`, and `audit-baseline` through `homeboy review <subcommand>`.
- Keep verified top-level Homeboy commands such as `bench` and `refactor` as top-level invocations.
- Update autofix audit-baseline refresh paths to use `homeboy review audit ... --baseline`.
- Update PR comment deep links, failure-digest reproduction commands, differential-gate fixtures, and command-builder tests to match the new invocation shape.
- Document that action command inputs remain shorthand while emitted Homeboy commands use the review umbrella.

## Verification

- `bash scripts/core/test-command-builders.sh`
- `for test_script in scripts/**/test-*.sh; do bash "$test_script" || exit $?; done`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode — Claude (Fable 5) orchestrator + GPT-5.5 subagents
- **Used for:** Diagnosing the homeboy review-umbrella CLI refactor and migrating the action's command builders
