### PR TITLE
fix: authorize CI review execution on warm runners

### DIFF
--- a/scripts/autofix/apply-autofix-commit.sh
+++ b/scripts/autofix/apply-autofix-commit.sh
@@ -131,7 +131,7 @@ maybe_update_baseline() {
   if [ "$(scope_context)" != "pr" ]; then
     echo "Updating audit baseline (non-PR context)..."
     set +e
-    BASELINE_CMD="homeboy review audit ${COMP_ID} --baseline --path ${WORKSPACE}"
+    BASELINE_CMD="$(build_run_command "review audit --baseline" "${COMP_ID}" "${WORKSPACE}")"
     eval "${BASELINE_CMD}"
     BASELINE_EXIT=$?
     set -e

--- a/scripts/autofix/prepare-autofix-branch.sh
+++ b/scripts/autofix/prepare-autofix-branch.sh
@@ -199,7 +199,8 @@ fi
 if changes_are_only_drift "${WORKSPACE}" || (git diff --quiet && git diff --cached --quiet); then
   echo "Updating audit baseline..."
   set +e
-  homeboy review audit "${COMP_ID}" --baseline --path "${WORKSPACE}"
+  BASELINE_CMD="$(build_run_command "review audit --baseline" "${COMP_ID}" "${WORKSPACE}")"
+  eval "${BASELINE_CMD}"
   BASELINE_EXIT=$?
   set -e
   if [ "${BASELINE_EXIT}" -ne 0 ]; then

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -935,8 +935,11 @@ build_review_report_command() {
   local component_id="$1"
   local workspace="$2"
   local full_cmd
+  local global_flags
 
-  full_cmd="homeboy review ${component_id} --path ${workspace} --report=pr-comment"
+  global_flags="$(homeboy_global_flags)"
+
+  full_cmd="homeboy ${global_flags}review ${component_id} --path ${workspace} --report=pr-comment"
 
   local scope
   scope="$(scope_flags_for "review")"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -93,6 +93,11 @@ assert_equals \
 
 GITHUB_ACTIONS="true"
 assert_equals \
+  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review audit data-machine --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "review audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "GitHub Actions initial audit opts into hot-runner execution"
+
+assert_equals \
   "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
   "GitHub Actions lint opts into hot-runner execution"
@@ -111,6 +116,28 @@ assert_equals \
   "homeboy --force-hot --allow-local-hot review test data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review test" "${COMPONENT}" "${WORKSPACE}")" \
   "GitHub Actions review test opts into hot-runner execution"
+
+assert_equals \
+  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review build data-machine --path /tmp/workspace" \
+  "$(build_run_command "review build" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "GitHub Actions build opts into hot-runner execution"
+
+HOMEBOY_DIFFERENTIAL_GATING="true"
+assert_equals \
+  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review test data-machine --path /tmp/workspace" \
+  "$(build_run_command "review test" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
+  "GitHub Actions differential baseline test opts into hot-runner execution"
+unset HOMEBOY_DIFFERENTIAL_GATING
+
+assert_equals \
+  "homeboy --force-hot --allow-local-hot review audit data-machine --baseline --path /tmp/workspace --changed-since origin/main" \
+  "$(build_run_command "review audit --baseline" "${COMPONENT}" "${WORKSPACE}")" \
+  "GitHub Actions autofix baseline update opts into hot-runner execution"
+
+assert_equals \
+  "homeboy --force-hot --allow-local-hot review data-machine --path /tmp/workspace --report=pr-comment --changed-since origin/main" \
+  "$(build_review_report_command "${COMPONENT}" "${WORKSPACE}")" \
+  "GitHub Actions report retry opts into hot-runner execution"
 
 unset GITHUB_ACTIONS
 

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -46,15 +46,12 @@ append_review_report_section() {
     return 0
   fi
 
-  local review_md review_exit scope_flags
+  local review_md review_exit review_cmd
   local -a REVIEW_CMD
-  REVIEW_CMD=(homeboy review "${COMP_ID}" --path "${WORKSPACE}" --report=pr-comment)
-
-  scope_flags="$(scope_flags_for "review")"
-  if [ -n "${scope_flags}" ]; then
-    # shellcheck disable=SC2206
-    REVIEW_CMD+=(${scope_flags})
-  fi
+  review_cmd="$(build_review_report_command "${COMP_ID}" "${WORKSPACE}")"
+  # Command fragments are generated internally from action inputs.
+  # shellcheck disable=SC2206
+  REVIEW_CMD=(${review_cmd})
 
   append_review_banner_args
 

--- a/scripts/pr/comment/test-review-report-section.sh
+++ b/scripts/pr/comment/test-review-report-section.sh
@@ -65,6 +65,7 @@ export BINARY_SOURCE="fallback"
 export HOMEBOY_CI_RESULTS_ARTIFACT="homeboy-ci-results-data-machine-audit"
 export HOMEBOY_OBSERVATIONS_ARTIFACT="homeboy-observations-data-machine-audit"
 export GITHUB_RUN_URL="https://github.com/Extra-Chill/homeboy-action/actions/runs/123"
+export GITHUB_ACTIONS="true"
 export SCOPE_MODE="changed"
 export SCOPE_BASE_REF="origin/main"
 export DIGEST_FILE=""
@@ -85,6 +86,7 @@ assert_contains "${SECTION_BODY}" "https://github.com/Extra-Chill/homeboy-action
 assert_not_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "legacy per-command audit block skipped"
 assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner autofix=applied — 2 file(s) fixed via lint" "autofix banner passed to core"
 assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner binary-source=fallback release binary (source build failed)" "binary-source banner passed to core"
+assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--force-hot --allow-local-hot review data-machine" "review report opts into hot-runner execution in GitHub Actions"
 
 export HOMEBOY_REVIEW_OUTPUT_MODE="custom"
 build_section_body


### PR DESCRIPTION
## Summary
- Route PR-comment report and autofix baseline-update review commands through the shared CI command builder.
- Explicitly pass `--force-hot --allow-local-hot` before `review` on GitHub Actions for initial gates, differential baselines, autofix verification, report retries, and baseline updates.
- Add regression coverage for every path while preserving flag-free interactive/local command generation.

GitHub-hosted CI is an explicit, operator-configured non-interactive execution environment. The flags authorize its intentional local execution when transient load triggers Homeboy warm-machine policy; they do not change the policy for interactive or local users.

## Testing
- `bash scripts/core/test-command-builders.sh`
- `bash scripts/pr/comment/test-review-report-section.sh`
- `bash -n scripts/core/lib.sh scripts/pr/comment/sections.sh scripts/autofix/apply-autofix-commit.sh scripts/autofix/prepare-autofix-branch.sh scripts/core/test-command-builders.sh`
- `shellcheck scripts/core/lib.sh scripts/pr/comment/sections.sh scripts/autofix/apply-autofix-commit.sh scripts/autofix/prepare-autofix-branch.sh scripts/core/test-command-builders.sh scripts/pr/comment/test-review-report-section.sh`
- Full `scripts/**/test-*.sh` sweep: relevant paths passed; unrelated existing failure tracked in #271 (`scripts/autofix/test-open-autofix-pr-report.sh`).

No Rust/Cargo build was run on the VPS.

Fixes #270