### PR TITLE
fix: bound action command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Use these outputs to gate downstream jobs:
 | `differential-gating` | No | `false` | On PRs, compare `review audit`/`review test` counts against the base SHA and fail only when the PR is worse. Opt-in; `review lint` still gates on exit code. PR autofix is skipped while enabled. |
 | `baseline-commands` | No | `auto` | Commands to rerun at the PR base when `differential-gating` is true. `auto` reruns requested `review audit`/`review lint`/`review test` commands; use a comma-separated subset such as `review audit` or `none` to skip baseline reruns. |
 | `observation-window` | No | `24h` | Duration window passed to best-effort `homeboy runs export --since` for the separate matrix-safe observations artifact. |
+| `execution-timeout-seconds` | No | `1800` | Per-phase command and non-PR autofix wall-clock budget. The action writes liveness notices and returns timeout evidence when the budget expires. |
 | `import-observations` | No | `false` | Download and best-effort import earlier `homeboy-observations-*` artifacts from the same workflow run before command execution. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |
 | `node-version` | No | | Node.js version (sets up via `actions/setup-node`) |

--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,10 @@ inputs:
     description: 'Duration window to export Homeboy observations after command execution (e.g. "24h", "7d", "30m"). Export is best-effort and non-fatal.'
     required: false
     default: '24h'
+  execution-timeout-seconds:
+    description: 'Maximum wall-clock time for a Homeboy command or autofix phase. Emits liveness notices and exits with actionable timeout evidence.'
+    required: false
+    default: '1800'
   import-observations:
     description: 'Download and import earlier homeboy-observations artifacts from the same workflow run before command execution. Import is best-effort and non-fatal.'
     required: false
@@ -497,7 +501,8 @@ runs:
         BENCH_REGRESSION_THRESHOLD: ${{ inputs.regression-threshold }}
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
         RUN_GROUP_PREFIX: homeboy
-      run: bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
+        HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
+      run: bash ${{ github.action_path }}/scripts/core/run-with-liveness-timeout.sh "Homeboy commands" bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
 
     - name: Resolve artifact names
       id: artifact-names
@@ -617,7 +622,8 @@ runs:
         AUTOFIX_COMMANDS: ${{ inputs.autofix-commands }}
         AUTOFIX_MAX_COMMITS: ${{ inputs.autofix-max-commits }}
         APP_TOKEN: ${{ inputs.app-token }}
-      run: bash ${{ github.action_path }}/scripts/autofix/prepare-autofix-branch.sh
+        HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
+      run: bash ${{ github.action_path }}/scripts/core/run-with-liveness-timeout.sh "Non-PR autofix" bash ${{ github.action_path }}/scripts/autofix/prepare-autofix-branch.sh
 
     - name: Open non-PR autofix PR
       id: autofix-open-pr

--- a/scripts/core/run-with-liveness-timeout.sh
+++ b/scripts/core/run-with-liveness-timeout.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+label="$1"
+shift
+timeout_seconds="${HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS:-1800}"
+
+if ! [[ "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::${label} timeout must be a positive number of seconds; received '${timeout_seconds}'."
+  exit 2
+fi
+
+start_seconds="$(date +%s)"
+if command -v timeout >/dev/null 2>&1; then
+  timeout --foreground --signal=TERM --kill-after=30s "${timeout_seconds}" "$@" &
+else
+  perl -e 'alarm shift; exec @ARGV' "${timeout_seconds}" "$@" &
+fi
+command_pid=$!
+
+(
+  while kill -0 "${command_pid}" 2>/dev/null; do
+    sleep 60
+    if kill -0 "${command_pid}" 2>/dev/null; then
+      elapsed="$(( $(date +%s) - start_seconds ))"
+      echo "::notice::${label} is still running after ${elapsed}s (timeout: ${timeout_seconds}s)."
+    fi
+  done
+) &
+liveness_pid=$!
+
+set +e
+wait "${command_pid}"
+command_exit=$?
+set -e
+kill "${liveness_pid}" 2>/dev/null || true
+wait "${liveness_pid}" 2>/dev/null || true
+
+if [ "${command_exit}" -eq 124 ] || [ "${command_exit}" -eq 142 ]; then
+  echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout and was terminated. Inspect this step's logs and rerun after resolving the blocked command; the caller can continue when this action is advisory."
+  exit 124
+fi
+
+exit "${command_exit}"

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="${ROOT_DIR}/scripts/core/run-with-liveness-timeout.sh"
+ACTION="${ROOT_DIR}/action.yml"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=2 bash "${RUNNER}" "fast command" bash -c 'exit 0'
+printf 'PASS: successful command preserves exit status\n'
+
+set +e
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 bash "${RUNNER}" "stalled autofix" bash -c 'sleep 3' >"${TMP_DIR}/timeout.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "${exit_code}" -ne 124 ]; then
+  printf 'FAIL: timeout exits 124, got %s\n' "${exit_code}"
+  exit 1
+fi
+
+if ! grep -q 'stalled autofix exceeded its 1s execution timeout' "${TMP_DIR}/timeout.log"; then
+  printf 'FAIL: timeout reports actionable evidence\n'
+  exit 1
+fi
+printf 'PASS: timeout returns actionable evidence\n'
+
+set +e
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=invalid bash "${RUNNER}" "invalid timeout" bash -c 'exit 0' >"${TMP_DIR}/invalid.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "${exit_code}" -ne 2 ]; then
+  printf 'FAIL: invalid timeout exits 2, got %s\n' "${exit_code}"
+  exit 1
+fi
+printf 'PASS: invalid timeout is rejected\n'
+
+if ! grep -q '^  execution-timeout-seconds:' "${ACTION}"; then
+  printf 'FAIL: action does not expose execution timeout input\n'
+  exit 1
+fi
+
+wrapper_count="$(grep -c 'run-with-liveness-timeout.sh' "${ACTION}")"
+if [ "${wrapper_count}" -ne 2 ]; then
+  printf 'FAIL: action must bound command and non-PR autofix phases, got %s wrappers\n' "${wrapper_count}"
+  exit 1
+fi
+printf 'PASS: action applies bounded execution to command and autofix phases\n'


### PR DESCRIPTION
## Summary

Closes #273.

- Adds a configurable 30-minute wall-clock budget to Homeboy command and non-PR autofix phases.
- Emits liveness notices every minute and reports an actionable GitHub Actions error on timeout.
- Preserves caller-owned failure handling, including `continue-on-error`.

## Testing

1. Run `bash scripts/core/test-run-with-liveness-timeout.sh`.
2. Run `bash scripts/core/test-bench-command.sh`.
3. Run `bash scripts/core/test-command-builders.sh`.
4. Run `ruby -e 'require "yaml"; YAML.load_file("action.yml")'`.\n\n## Consumer\n\n`Extra-Chill/homeboy` will consume `execution-timeout-seconds` in its Release Auto-refactor job and separately set a job-level cap: https://github.com/Extra-Chill/homeboy/pull/new/fix/auto-refactor-timeout-liveness\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenCode, openai/gpt-5.6-terra\n- **Used for:** Implemented the bounded action execution contract, focused tests, and PR documentation with human-directed task requirements.