### PR TITLE
fix: use published CI action majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
     if: inputs.build-command != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -316,7 +316,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -352,7 +352,7 @@ jobs:
           fi
 
       - name: Check out Homeboy Action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ inputs.action-ref }}
@@ -360,7 +360,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v2
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       should-release: ${{ steps.check.outputs.should-release }}
       tooling-identity: ${{ steps.release-check.outputs.tooling-identity }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -102,13 +102,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v2
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -131,7 +131,7 @@ jobs:
     if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.release.result == 'failure' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Save failed SHA
         run: git rev-parse HEAD > "${RUNNER_TEMP}/homeboy-release-last-failed"

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKFLOW="${ROOT_DIR}/.github/workflows/release.yml"
+CI_WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
 RUN_RELEASE="${ROOT_DIR}/scripts/release/run-release.sh"
 README="${ROOT_DIR}/README.md"
 COMMENT_SECTIONS="${ROOT_DIR}/scripts/pr/comment/sections.sh"
@@ -55,6 +56,16 @@ assert_count() {
 assert_not_contains '^  create-release:' "${WORKFLOW}" "release workflow has no duplicate GitHub Release job"
 assert_not_contains 'gh release create' "${WORKFLOW}" "release workflow does not shell out to gh release create"
 assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not parse changelog notes"
+
+# GitHub-hosted workflow dependencies must use published action majors (#275).
+assert_count 'actions/checkout@v4' '3' "${CI_WORKFLOW}" "reusable CI workflow uses checkout v4 for every checkout"
+assert_count 'actions/create-github-app-token@v2' '1' "${CI_WORKFLOW}" "reusable CI workflow uses app-token v2"
+assert_not_contains 'actions/checkout@v6' "${CI_WORKFLOW}" "reusable CI workflow does not use unavailable checkout v6"
+assert_not_contains 'actions/create-github-app-token@v3' "${CI_WORKFLOW}" "reusable CI workflow does not use unavailable app-token v3"
+assert_count 'actions/checkout@v4' '3' "${WORKFLOW}" "release workflow uses checkout v4 for every checkout"
+assert_count 'actions/create-github-app-token@v2' '1' "${WORKFLOW}" "release workflow uses app-token v2"
+assert_not_contains 'actions/checkout@v6' "${WORKFLOW}" "release workflow does not use unavailable checkout v6"
+assert_not_contains 'actions/create-github-app-token@v3' "${WORKFLOW}" "release workflow does not use unavailable app-token v3"
 
 assert_contains 'uses: ./' "${WORKFLOW}" "release workflow uses checked-out action code for self-release"
 assert_not_contains 'Extra-Chill/homeboy-action@v2' "${WORKFLOW}" "release workflow is not bootstrapped from the stale floating v2 channel"


### PR DESCRIPTION
## Summary
- replace unavailable `actions/checkout@v6` uses with published `v4` in reusable CI and release workflows
- replace unavailable `actions/create-github-app-token@v3` uses with published `v2`
- extend the existing workflow contract test with exact action-major counts and regression guards

## Evidence
- Source relationship: directly resolves the initialization failure reported in #275 and the linked consumer run.
- Change kind: workflow dependency correction plus contract-test coverage.
- Verification capability: GitHub API resolved both published floating tags; local contract, shell syntax, and Action workflow validation pass.
- Scope: runtime changes are limited to the eight action references carrying the unavailable majors; inputs, permissions, job logic, and all unrelated dependencies remain unchanged.

## Verification
- `bash scripts/release/test-release-workflow.sh`
- `bash -n scripts/release/test-release-workflow.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check origin/main...HEAD`
- `gh api repos/actions/checkout/git/ref/tags/v4`
- `gh api repos/actions/create-github-app-token/git/ref/tags/v2`

Closes #275

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-terra
- **Used for:** Investigated the CI initialization failure, drafted the workflow pin correction and contract coverage, and ran focused verification. Chris remains responsible for every line.