### PR TITLE
Migrate action placement across Homeboy CLI generations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -384,6 +384,10 @@ runs:
         SOURCE_BUILT: ${{ steps.source-build.outputs.built }}
       run: bash ${{ github.action_path }}/scripts/setup/resolve-binary-source.sh
 
+    - name: Detect Homeboy placement support
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/setup/detect-homeboy-placement.sh
+
     - name: Install extension
       if: steps.read-config.outputs.portable-extension != ''
       shell: bash

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -861,7 +861,11 @@ homeboy_global_flags() {
   local flags=""
 
   if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-    flags="${flags}--force-hot --allow-local-hot "
+    if homeboy_supports_placement; then
+      flags="${flags}--placement local "
+    else
+      flags="${flags}--force-hot --allow-local-hot "
+    fi
   fi
 
   # --output is a global flag and must appear before the subcommand
@@ -871,6 +875,20 @@ homeboy_global_flags() {
   fi
 
   printf '%s' "${flags}"
+}
+
+# The action preflights this after selecting the binary. Keep this fallback for
+# direct script consumers and cache the probe within a shell process.
+homeboy_supports_placement() {
+  if [ -z "${HOMEBOY_ACTION_SUPPORTS_PLACEMENT+x}" ]; then
+    if homeboy --help 2>&1 | grep -E '^[[:space:]]+--placement([[:space:]]|<)' >/dev/null; then
+      HOMEBOY_ACTION_SUPPORTS_PLACEMENT=true
+    else
+      HOMEBOY_ACTION_SUPPORTS_PLACEMENT=false
+    fi
+  fi
+
+  [ "${HOMEBOY_ACTION_SUPPORTS_PLACEMENT}" = "true" ]
 }
 
 build_run_command() {

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -92,54 +92,55 @@ assert_equals \
   "review lint keeps path with changed-since"
 
 GITHUB_ACTIONS="true"
+HOMEBOY_ACTION_SUPPORTS_PLACEMENT="true"
 assert_equals \
-  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review audit data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --placement local --output /tmp/workspace/out.json review audit data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review audit" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
-  "GitHub Actions initial audit opts into hot-runner execution"
+  "GitHub Actions initial audit selects local placement"
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --placement local --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
-  "GitHub Actions lint opts into hot-runner execution"
+  "GitHub Actions lint selects local placement"
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot review test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --placement local review test data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "test" "${COMPONENT}" "${WORKSPACE}")" \
-  "GitHub Actions test opts into hot-runner execution"
+  "GitHub Actions test selects local placement"
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --placement local --output /tmp/workspace/out.json review lint data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review lint" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
-  "GitHub Actions review lint opts into hot-runner execution"
+  "GitHub Actions review lint selects local placement"
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot review test data-machine --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --placement local review test data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review test" "${COMPONENT}" "${WORKSPACE}")" \
-  "GitHub Actions review test opts into hot-runner execution"
+  "GitHub Actions review test selects local placement"
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review build data-machine --path /tmp/workspace" \
+  "homeboy --placement local --output /tmp/workspace/out.json review build data-machine --path /tmp/workspace" \
   "$(build_run_command "review build" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
-  "GitHub Actions build opts into hot-runner execution"
+  "GitHub Actions build selects local placement"
 
 HOMEBOY_DIFFERENTIAL_GATING="true"
 assert_equals \
-  "homeboy --force-hot --allow-local-hot --output /tmp/workspace/out.json review test data-machine --path /tmp/workspace" \
+  "homeboy --placement local --output /tmp/workspace/out.json review test data-machine --path /tmp/workspace" \
   "$(build_run_command "review test" "${COMPONENT}" "${WORKSPACE}" "${OUTPUT_JSON}")" \
-  "GitHub Actions differential baseline test opts into hot-runner execution"
+  "GitHub Actions differential baseline test selects local placement"
 unset HOMEBOY_DIFFERENTIAL_GATING
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot review audit data-machine --baseline --path /tmp/workspace --changed-since origin/main" \
+  "homeboy --placement local review audit data-machine --baseline --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review audit --baseline" "${COMPONENT}" "${WORKSPACE}")" \
-  "GitHub Actions autofix baseline update opts into hot-runner execution"
+  "GitHub Actions autofix baseline update selects local placement"
 
 assert_equals \
-  "homeboy --force-hot --allow-local-hot review data-machine --path /tmp/workspace --report=pr-comment --changed-since origin/main" \
+  "homeboy --placement local review data-machine --path /tmp/workspace --report=pr-comment --changed-since origin/main" \
   "$(build_review_report_command "${COMPONENT}" "${WORKSPACE}")" \
-  "GitHub Actions report retry opts into hot-runner execution"
+  "GitHub Actions report retry selects local placement"
 
-unset GITHUB_ACTIONS
+unset GITHUB_ACTIONS HOMEBOY_ACTION_SUPPORTS_PLACEMENT
 
 assert_equals \
   "homeboy review test data-machine --path /tmp/workspace --changed-since origin/main" \

--- a/scripts/core/test-placement-compatibility.sh
+++ b/scripts/core/test-placement-compatibility.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAKE_BIN="$(mktemp -d)"
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -f "${FAKE_BIN}/homeboy"
+  rmdir "${FAKE_BIN}" 2>/dev/null || true
+  rm -f "${TMPDIR}/github-env-current" "${TMPDIR}/github-env-legacy" "${TMPDIR}/github-env" "${TMPDIR}/github-output"
+  rmdir "${TMPDIR}/homeboy-ci-results" 2>/dev/null || true
+  rmdir "${TMPDIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+assert_equals() {
+  local expected="$1" actual="$2" label="$3"
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_contains() {
+  local value="$1" expected="$2" label="$3"
+  case "${value}" in
+    *"${expected}"*) printf 'PASS: %s\n' "${label}" ;;
+    *)
+      printf 'FAIL: %s\nmissing: %s\nactual: %s\n' "${label}" "${expected}" "${value}"
+      exit 1
+      ;;
+  esac
+}
+
+cat > "${FAKE_BIN}/homeboy" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--help" ]; then
+  printf 'help\n' >> "${HOMEBOY_HELP_LOG}"
+  if [ "${HOMEBOY_FAKE_GENERATION}" = "current" ]; then
+    printf '  --placement <auto|local|lab>\n'
+  fi
+  exit 0
+fi
+
+printf '%s\n' "$*" >> "${HOMEBOY_CALL_LOG}"
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    output="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+[ -z "${output}" ] || printf '{"success":true}\n' > "${output}"
+SH
+chmod +x "${FAKE_BIN}/homeboy"
+
+export PATH="${FAKE_BIN}:${PATH}"
+export GITHUB_ACTIONS=true
+export SCOPE_MODE=full
+export SCOPE_BASE_REF=
+unset HOMEBOY_SETTINGS_JSON
+export HOMEBOY_HELP_LOG="${TMPDIR}/help.log"
+export HOMEBOY_CALL_LOG="${TMPDIR}/calls.log"
+source "${ROOT}/scripts/core/lib.sh"
+
+test_generation() {
+  local generation="$1" placement_flags="$2"
+  : > "${HOMEBOY_HELP_LOG}"
+  : > "${HOMEBOY_CALL_LOG}"
+  export HOMEBOY_FAKE_GENERATION="${generation}"
+  unset HOMEBOY_ACTION_SUPPORTS_PLACEMENT
+
+  export GITHUB_ENV="${TMPDIR}/github-env-${generation}"
+  : > "${GITHUB_ENV}"
+  bash "${ROOT}/scripts/setup/detect-homeboy-placement.sh"
+  IFS='=' read -r _ HOMEBOY_ACTION_SUPPORTS_PLACEMENT < "${GITHUB_ENV}"
+  export HOMEBOY_ACTION_SUPPORTS_PLACEMENT
+
+  assert_equals "homeboy ${placement_flags}--output /tmp/out.json review lint component --path /tmp/workspace" "$(build_run_command 'review lint' component /tmp/workspace /tmp/out.json)" "${generation} review builder preserves output ordering"
+  assert_equals "homeboy ${placement_flags}--output /tmp/out.json bench component --path /tmp/workspace" "$(build_run_command bench component /tmp/workspace /tmp/out.json)" "${generation} bench builder"
+  assert_equals "homeboy ${placement_flags}refactor component --all --path /tmp/workspace" "$(build_run_command 'refactor --all' component /tmp/workspace)" "${generation} refactor builder"
+  assert_equals "homeboy ${placement_flags}refactor component --from lint --write --path /tmp/workspace" "$(build_autofix_command 'refactor --from lint --write' component /tmp/workspace)" "${generation} autofix builder"
+  assert_equals "homeboy ${placement_flags}review component --path /tmp/workspace --report=pr-comment" "$(build_review_report_command component /tmp/workspace)" "${generation} report builder"
+  assert_equals 1 "$(wc -l < "${HOMEBOY_HELP_LOG}" | xargs)" "${generation} capability is detected once"
+}
+
+test_generation current '--placement local '
+test_generation legacy '--force-hot --allow-local-hot '
+
+# Exercise the action execution script with a current-generation binary.
+: > "${HOMEBOY_HELP_LOG}"
+: > "${HOMEBOY_CALL_LOG}"
+export HOMEBOY_FAKE_GENERATION=current
+unset HOMEBOY_ACTION_SUPPORTS_PLACEMENT
+export GITHUB_ACTION_PATH="${ROOT}"
+export GITHUB_WORKSPACE="${TMPDIR}"
+export GITHUB_OUTPUT="${TMPDIR}/github-output"
+export GITHUB_ENV="${TMPDIR}/github-env"
+export RESOLVED_COMMANDS='review audit'
+export COMPONENT_NAME=component
+bash "${ROOT}/scripts/setup/detect-homeboy-placement.sh"
+IFS='=' read -r _ HOMEBOY_ACTION_SUPPORTS_PLACEMENT < "${GITHUB_ENV}"
+export HOMEBOY_ACTION_SUPPORTS_PLACEMENT
+bash "${ROOT}/scripts/core/run-homeboy-commands.sh"
+assert_contains "$(< "${HOMEBOY_CALL_LOG}")" '--placement local --output ' 'current binary runs through action command execution with local placement'
+assert_equals 1 "$(wc -l < "${HOMEBOY_HELP_LOG}" | xargs)" 'current execution detects placement once'
+
+printf 'All placement compatibility checks passed.\n'

--- a/scripts/pr/comment/test-review-report-section.sh
+++ b/scripts/pr/comment/test-review-report-section.sh
@@ -66,6 +66,7 @@ export HOMEBOY_CI_RESULTS_ARTIFACT="homeboy-ci-results-data-machine-audit"
 export HOMEBOY_OBSERVATIONS_ARTIFACT="homeboy-observations-data-machine-audit"
 export GITHUB_RUN_URL="https://github.com/Extra-Chill/homeboy-action/actions/runs/123"
 export GITHUB_ACTIONS="true"
+export HOMEBOY_ACTION_SUPPORTS_PLACEMENT="true"
 export SCOPE_MODE="changed"
 export SCOPE_BASE_REF="origin/main"
 export DIGEST_FILE=""
@@ -86,7 +87,7 @@ assert_contains "${SECTION_BODY}" "https://github.com/Extra-Chill/homeboy-action
 assert_not_contains "${SECTION_BODY}" ":x: **audit** _(changed files only)_" "legacy per-command audit block skipped"
 assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner autofix=applied — 2 file(s) fixed via lint" "autofix banner passed to core"
 assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--banner binary-source=fallback release binary (source build failed)" "binary-source banner passed to core"
-assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--force-hot --allow-local-hot review data-machine" "review report opts into hot-runner execution in GitHub Actions"
+assert_contains "$(cat "${HOMEBOY_REVIEW_CALL_LOG}")" "--placement local review data-machine" "review report opts into local placement in GitHub Actions"
 
 export HOMEBOY_REVIEW_OUTPUT_MODE="custom"
 build_section_body

--- a/scripts/setup/detect-homeboy-placement.sh
+++ b/scripts/setup/detect-homeboy-placement.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if homeboy --help 2>&1 | grep -E '^[[:space:]]+--placement([[:space:]]|<)' >/dev/null; then
+  supports_placement=true
+else
+  supports_placement=false
+fi
+
+echo "HOMEBOY_ACTION_SUPPORTS_PLACEMENT=${supports_placement}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Summary
- Finalized Homeboy agent-task cook run `runner-exec-test-placement-compatibility-sh-homeboy-lab-72825855-0f37-4c42-8305-b9aca14bdc6c` into review-ready branch `fix/277-placement-compat-final`.

## Proof provenance
- **Proof runner:** Homeboy agent-task cook loop
- **Proof ID:** `agent-task-finalization:runner-exec-test-placement-compatibility-sh-homeboy-lab-72825855-0f37-4c42-8305-b9aca14bdc6c`
- **Homeboy run ID:** `runner-exec-test-placement-compatibility-sh-homeboy-lab-72825855-0f37-4c42-8305-b9aca14bdc6c`
- **Manual proof:** none recorded by this Homeboy finalization

## Publication intent
- **Schema:** `homeboy/agent-task-publication-intent/v1`
- **Action:** `review_request`
- **Target kind:** `code_review`
- **Adapter:** `github_pull_request`
- **Base:** `main`
- **Head:** `fix/277-placement-compat-final`

## Source refs
- https://github.com/Extra-Chill/homeboy-action/issues/277
- https://github.com/Extra-Chill/homeboy/actions/runs/29281068069

## Source relationship
- **Related finding ID:** none recorded
- **Source packet ID:** none recorded
- **Change kind:** runtime-fix
- **Supersedes:** none recorded
- **Depends on:** none recorded

## Attempt summary
Homeboy Lab verified current and released Homeboy CLI generations after restoring the canonical runner control plane.

## Gate results
- placement_compatibility: passed (targeted)
- command_builders: passed (targeted)

## Verification capability
- `targeted_checks_run`: `bash scripts/core/test-placement-compatibility.sh`, `HOMEBOY_SETTINGS_JSON={} bash scripts/core/test-command-builders.sh`
- `targeted_checks_unavailable`: none recorded
- `ci_expected`: `ShellCheck`, `Tests`
- `manual_reviewer_check`: Confirm the action invokes current Homeboy with --placement local and released pre-placement Homeboy with --force-hot --allow-local-hot.

## CI-equivalent coverage
- **CI-equivalent required gate:** CI-equivalent required gate was not recorded; targeted proof must not be treated as full CI coverage

## Changed files
- action.yml
- scripts/core/lib.sh
- scripts/core/test-command-builders.sh
- scripts/core/test-placement-compatibility.sh
- scripts/pr/comment/test-review-report-section.sh
- scripts/setup/detect-homeboy-placement.sh

## Artifact refs
- none recorded

## Final status
- **Status:** review-ready
- **Base:** `main`
- **Head:** `fix/277-placement-compat-final`
- **Merge/deploy:** not performed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Diagnosed the Homeboy release regression, implemented capability-based placement selection, and added deterministic compatibility tests; Chris reviews and owns the change.
