### PR TITLE
Fail closed when review commands do not finish

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -506,7 +506,7 @@ runs:
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
         RUN_GROUP_PREFIX: homeboy
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
-      run: bash ${{ github.action_path }}/scripts/core/run-with-liveness-timeout.sh "Homeboy commands" bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
+      run: bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
 
     - name: Resolve artifact names
       id: artifact-names
@@ -654,6 +654,7 @@ runs:
       shell: bash
       env:
         FIRST_RESULTS: ${{ steps.run-commands.outputs.results }}
+        COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
       run: bash ${{ github.action_path }}/scripts/core/select-final-results.sh
 

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -62,7 +62,8 @@ for CMD in "${CMD_ARRAY[@]}"; do
   echo "::group::${GROUP_PREFIX} ${CMD}"
   CMD_EXIT=0
   set +e
-  eval "${FULL_CMD}" 2>&1 | tee "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log"
+  bash "${GITHUB_ACTION_PATH}/scripts/core/run-with-liveness-timeout.sh" \
+    "homeboy ${CMD}" bash -c "${FULL_CMD}" 2>&1 | tee "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log"
   CMD_EXIT=${PIPESTATUS[0]}
   set -e
   echo "::endgroup::"

--- a/scripts/core/run-with-liveness-timeout.sh
+++ b/scripts/core/run-with-liveness-timeout.sh
@@ -12,19 +12,29 @@ if ! [[ "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 start_seconds="$(date +%s)"
-if command -v timeout >/dev/null 2>&1; then
-  timeout --foreground --signal=TERM --kill-after=30s "${timeout_seconds}" "$@" &
-else
-  perl -e 'alarm shift; exec @ARGV' "${timeout_seconds}" "$@" &
-fi
+
+# Job control gives the child command its own process group. Killing only the
+# wrapper leaves grandchildren such as cargo and homeboy running after a timeout.
+set -m
+"$@" &
 command_pid=$!
+set +m
 
 (
   while kill -0 "${command_pid}" 2>/dev/null; do
-    sleep 60
+    sleep 1
     if kill -0 "${command_pid}" 2>/dev/null; then
       elapsed="$(( $(date +%s) - start_seconds ))"
-      echo "::notice::${label} is still running after ${elapsed}s (timeout: ${timeout_seconds}s)."
+      if [ "${elapsed}" -ge "${timeout_seconds}" ]; then
+        echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout; terminating its process group."
+        kill -TERM -- "-${command_pid}" 2>/dev/null || true
+        sleep 5
+        kill -KILL -- "-${command_pid}" 2>/dev/null || true
+        exit 0
+      fi
+      if [ "$(( elapsed % 60 ))" -eq 0 ]; then
+        echo "::notice::${label} is still running after ${elapsed}s (timeout: ${timeout_seconds}s)."
+      fi
     fi
   done
 ) &
@@ -37,7 +47,7 @@ set -e
 kill "${liveness_pid}" 2>/dev/null || true
 wait "${liveness_pid}" 2>/dev/null || true
 
-if [ "${command_exit}" -eq 124 ] || [ "${command_exit}" -eq 142 ]; then
+if [ "$(( $(date +%s) - start_seconds ))" -ge "${timeout_seconds}" ]; then
   echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout and was terminated. Inspect this step's logs and rerun after resolving the blocked command; the caller can continue when this action is advisory."
   exit 124
 fi

--- a/scripts/core/select-final-results.sh
+++ b/scripts/core/select-final-results.sh
@@ -3,8 +3,27 @@
 set -euo pipefail
 
 RESULTS="${FIRST_RESULTS:-}"
-if [ -z "${RESULTS}" ]; then
-  RESULTS='{}'
+COMMANDS="${COMMANDS:-}"
+
+results_are_complete() {
+  [ -n "${RESULTS}" ] || return 1
+  printf '%s\n' "${RESULTS}" | jq -e --arg commands "${COMMANDS}" '
+    . as $results |
+    ($commands | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $expected |
+    ($results | type) == "object"
+    and all($expected[]; . as $command | $results[$command] == "pass" or $results[$command] == "fail")
+  ' >/dev/null 2>&1
+}
+
+if ! results_are_complete; then
+  if [ -n "${COMMANDS}" ]; then
+    RESULTS="$(printf '%s\n' "${COMMANDS}" | jq -Rc '
+      split(",") | map(gsub("^\\s+|\\s+$"; "") | select(length > 0)) | map({key: ., value: "fail"}) | from_entries
+    ')"
+    echo "::error::Current Homeboy command results were missing, malformed, interrupted, or incomplete; marking all expected commands failed."
+  else
+    RESULTS='{}'
+  fi
 fi
 
 if [ "${HOMEBOY_DIFFERENTIAL_GATING:-false}" = "true" ] \

--- a/scripts/core/test-enforce-final-status.sh
+++ b/scripts/core/test-enforce-final-status.sh
@@ -30,6 +30,9 @@ assert_exit 1 "malformed quality results fail closed" \
 assert_exit 1 "failing quality results fail" \
   env RESULTS='{"review test":"fail"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
 
+assert_exit 1 "missing quality results with expected commands fail closed" \
+  env RESULTS='' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+
 assert_exit 0 "closed PR ignores stale failing quality results" \
   env RESULTS='{"review test":"fail"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='false' bash "${ENFORCE_STATUS}"
 

--- a/scripts/core/test-run-homeboy-commands.sh
+++ b/scripts/core/test-run-homeboy-commands.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin" "${TMP_DIR}/workspace"
+cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$(dirname "${output}")"
+printf '%s\n' '{"success":false,"data":{"test_counts":{"failed":2,"passed":41,"total":43}}}' > "${output}"
+exit 1
+SH
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+set +e
+PATH="${TMP_DIR}/bin:${PATH}" \
+GITHUB_ACTION_PATH="${ROOT_DIR}" \
+GITHUB_WORKSPACE="${TMP_DIR}/workspace" \
+GITHUB_OUTPUT="${TMP_DIR}/github-output" \
+GITHUB_ENV="${TMP_DIR}/github-env" \
+RESOLVED_COMMANDS='review test' \
+COMPONENT_NAME='homeboy-action' \
+bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/run.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "${exit_code}" -ne 1 ]; then
+  printf 'FAIL: failed review test exits 1, got %s\n' "${exit_code}"
+  exit 1
+fi
+if ! grep -q '^results={"review test":"fail"}$' "${TMP_DIR}/github-output"; then
+  printf 'FAIL: failed review test is recorded as fail\n'
+  exit 1
+fi
+if ! grep -q 'FAILED (exit code 1)' "${TMP_DIR}/run.log"; then
+  printf 'FAIL: failed review test reports its exit code\n'
+  exit 1
+fi
+
+printf 'PASS: failed review test records a current-run failure\n'

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -12,7 +12,8 @@ HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=2 bash "${RUNNER}" "fast command" bash 
 printf 'PASS: successful command preserves exit status\n'
 
 set +e
-HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 bash "${RUNNER}" "stalled autofix" bash -c 'sleep 3' >"${TMP_DIR}/timeout.log" 2>&1
+child_pid_file="${TMP_DIR}/child.pid"
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 bash "${RUNNER}" "stalled autofix" bash -c 'sleep 30 & echo $! > "$0"; wait' "${child_pid_file}" >"${TMP_DIR}/timeout.log" 2>&1
 exit_code=$?
 set -e
 
@@ -26,6 +27,13 @@ if ! grep -q 'stalled autofix exceeded its 1s execution timeout' "${TMP_DIR}/tim
   exit 1
 fi
 printf 'PASS: timeout returns actionable evidence\n'
+
+child_pid="$(<"${child_pid_file}")"
+if kill -0 "${child_pid}" 2>/dev/null; then
+  printf 'FAIL: timeout leaves descendant process %s alive\n' "${child_pid}"
+  exit 1
+fi
+printf 'PASS: timeout terminates descendant process group\n'
 
 set +e
 HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=invalid bash "${RUNNER}" "invalid timeout" bash -c 'exit 0' >"${TMP_DIR}/invalid.log" 2>&1
@@ -44,8 +52,12 @@ if ! grep -q '^  execution-timeout-seconds:' "${ACTION}"; then
 fi
 
 wrapper_count="$(grep -c 'run-with-liveness-timeout.sh' "${ACTION}")"
-if [ "${wrapper_count}" -ne 2 ]; then
-  printf 'FAIL: action must bound command and non-PR autofix phases, got %s wrappers\n' "${wrapper_count}"
+if [ "${wrapper_count}" -ne 1 ]; then
+  printf 'FAIL: action must leave command timeout enforcement to the per-command runner, got %s action wrappers\n' "${wrapper_count}"
   exit 1
 fi
-printf 'PASS: action applies bounded execution to command and autofix phases\n'
+if ! grep -q 'run-with-liveness-timeout.sh' "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh"; then
+  printf 'FAIL: quality commands are not individually bounded\n'
+  exit 1
+fi
+printf 'PASS: action applies bounded execution to each quality command and autofix\n'

--- a/scripts/core/test-select-final-results.sh
+++ b/scripts/core/test-select-final-results.sh
@@ -4,19 +4,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELECT_RESULTS="${SCRIPT_DIR}/select-final-results.sh"
-
-assert_equals() {
-  local expected="$1"
-  local actual="$2"
-  local label="$3"
-
-  if [ "${expected}" != "${actual}" ]; then
-    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
-    exit 1
-  fi
-
-  printf 'PASS: %s\n' "${label}"
-}
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
 
 read_multiline_output() {
   local file="$1"
@@ -45,23 +34,38 @@ read_multiline_output() {
   return 1
 }
 
-run_select() {
-  local first_results="$1"
-  local output_file
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
 
-  output_file="$(mktemp "${TMPDIR:-/tmp}/homeboy-select-results.XXXXXX")"
-  GITHUB_OUTPUT="${output_file}" \
-    FIRST_RESULTS="${first_results}" \
-    HOMEBOY_DIFFERENTIAL_GATING=false \
-    bash "${SELECT_RESULTS}"
-
-  printf '%s\n' "${output_file}"
+  if [ "${expected}" != "${actual}" ]; then
+    printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+  printf 'PASS: %s\n' "${label}"
 }
 
-pass_output="$(run_select '{"lint":"pass"}')"
-assert_equals '{"lint":"pass"}' "$(read_multiline_output "${pass_output}" results)" "passing JSON result round-trips without extra braces"
+assert_failed_results() {
+  local label="$1"
+  local input="$2"
+  : > "${TMP_DIR}/output"
+  FIRST_RESULTS="${input}" COMMANDS='review audit,review test' GITHUB_OUTPUT="${TMP_DIR}/output" \
+    GITHUB_ACTION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)" bash "${SELECT_RESULTS}" >/dev/null
+  if ! grep -q '"review audit":"fail"' "${TMP_DIR}/output" || ! grep -q '"review test":"fail"' "${TMP_DIR}/output"; then
+    printf 'FAIL: %s\n' "${label}"
+    exit 1
+  fi
+  printf 'PASS: %s\n' "${label}"
+}
 
-empty_output="$(run_select '')"
-assert_equals '{}' "$(read_multiline_output "${empty_output}" results)" "empty result falls back to empty object"
+assert_failed_results "missing current results synthesize failures" ''
+assert_failed_results "malformed current results synthesize failures" '{"review test":"fail"}}'
+assert_failed_results "incomplete current results synthesize failures" '{"review audit":"pass"}'
 
-printf 'All select-final-results checks passed.\n'
+: > "${TMP_DIR}/output"
+FIRST_RESULTS='{"review test":"pass"}' COMMANDS='review test' GITHUB_OUTPUT="${TMP_DIR}/output" \
+  GITHUB_ACTION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)" bash "${SELECT_RESULTS}" >/dev/null
+assert_equals '{"review test":"pass"}' "$(read_multiline_output "${TMP_DIR}/output" results)" "passing current results round-trip"
+
+printf 'All final-result selection checks passed.\n'

--- a/scripts/pr/comment/test-skip-green-noop-comment.sh
+++ b/scripts/pr/comment/test-skip-green-noop-comment.sh
@@ -89,6 +89,7 @@ output="$(RESULTS='{"review audit":"fail"}' run_post_comment)"
 assert_contains "${output}" "PR comment posted successfully" "failed run comments"
 assert_equals "1" "$(wc -l < "${HOMEBOY_CALL_LOG}" | xargs)" "failed run posts section with tooling footer"
 assert_contains "$(cat "${HOMEBOY_CALL_LOG}")" "--footer-file" "failed run delegates tooling footer to core"
+assert_contains "$(cat "${HOMEBOY_CALL_LOG}")" "--section-key review-audit" "failed run replaces the current command section rather than retaining stale green content"
 
 export COMMANDS="refactor"
 export AUTOFIX_ENABLED="true"


### PR DESCRIPTION
## Summary
Ensure interrupted review commands produce current red evidence instead of hanging or retaining stale green status.

## What changed
- Apply the existing execution timeout to each quality command rather than one six-hour-prone aggregate batch.
- Run each command in its own process group and terminate descendants with TERM followed by KILL.
- Synthesize failed current-run results for missing, malformed, or incomplete output and publish the current command section.

## How to test
1. Run `bash scripts/core/test-run-with-liveness-timeout.sh`; expect Timeout returns 124 and no descendant process survives.
2. Run `bash scripts/core/test-select-final-results.sh`; expect Missing malformed and incomplete results become explicit failures.
3. Run `bash scripts/pr/comment/test-skip-green-noop-comment.sh`; expect A failed current run replaces stale green section content.

## Compatibility
Existing action inputs and successful command output remain unchanged. Timeout now applies independently to each quality command, and interrupted or malformed runs intentionally fail closed.

## Evidence
- CI expected: Audit
- CI expected: Test
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy-action/issues/283
- Reviewer-resolvable source evidence: https://github.com/Extra-Chill/homeboy/actions/runs/29391215215
- process-tree-timeout: Passed
- result-fallback: Passed
- sticky-comment: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Traced action-owned timeout and publication behavior, implemented fail-closed handling, and added deterministic shell coverage with Chris.

## Source relationships
- Closes Extra-Chill/homeboy-action#283
- Relates to Extra-Chill/homeboy#8271
