### PR TITLE
Bound action finalization and capability probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Use these outputs to gate downstream jobs:
 | `baseline-commands` | No | `auto` | Commands to rerun at the PR base when `differential-gating` is true. `auto` reruns requested `review audit`/`review lint`/`review test` commands; use a comma-separated subset such as `review audit` or `none` to skip baseline reruns. |
 | `observation-window` | No | `24h` | Duration window passed to best-effort `homeboy runs export --since` for the separate matrix-safe observations artifact. |
 | `execution-timeout-seconds` | No | `1800` | Per-phase command and non-PR autofix wall-clock budget. The action writes liveness notices and returns timeout evidence when the budget expires. |
+| `cleanup-timeout-seconds` | No | `15` | Process-group teardown budget after a command finishes or times out. The action retains command logs and fails with diagnostics if cleanup cannot finish. |
 | `import-observations` | No | `false` | Download and best-effort import earlier `homeboy-observations-*` artifacts from the same workflow run before command execution. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |
 | `node-version` | No | | Node.js version (sets up via `actions/setup-node`) |

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,10 @@ inputs:
     description: 'Maximum wall-clock time for a Homeboy command or autofix phase. Emits liveness notices and exits with actionable timeout evidence.'
     required: false
     default: '1800'
+  cleanup-timeout-seconds:
+    description: 'Maximum wall-clock time to terminate and verify a Homeboy command process group after command completion or timeout. Emits retained-log diagnostics and fails when cleanup cannot finish.'
+    required: false
+    default: '15'
   import-observations:
     description: 'Download and import earlier homeboy-observations artifacts from the same workflow run before command execution. Import is best-effort and non-fatal.'
     required: false
@@ -506,6 +510,7 @@ runs:
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
         RUN_GROUP_PREFIX: homeboy
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
+        HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
       run: bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
 
     - name: Resolve artifact names
@@ -627,6 +632,7 @@ runs:
         AUTOFIX_MAX_COMMITS: ${{ inputs.autofix-max-commits }}
         APP_TOKEN: ${{ inputs.app-token }}
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
+        HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
       run: bash ${{ github.action_path }}/scripts/core/run-with-liveness-timeout.sh "Non-PR autofix" bash ${{ github.action_path }}/scripts/autofix/prepare-autofix-branch.sh
 
     - name: Open non-PR autofix PR

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -884,11 +884,75 @@ homeboy_global_flags() {
 
 # The action preflights this after selecting the binary. Keep this fallback for
 # direct script consumers and cache the probe within a shell process.
+homeboy_help_supports_placement() {
+  local output_file command_pid timeout_seconds cleanup_timeout_seconds deadline
+  local label="homeboy $* --help placement capability probe"
+
+  timeout_seconds="${HOMEBOY_ACTION_PLACEMENT_PROBE_TIMEOUT_SECONDS:-10}"
+  cleanup_timeout_seconds="${HOMEBOY_ACTION_PLACEMENT_PROBE_CLEANUP_TIMEOUT_SECONDS:-5}"
+  for value_name in timeout_seconds cleanup_timeout_seconds; do
+    if ! [[ "${!value_name}" =~ ^[1-9][0-9]*$ ]]; then
+      printf '::warning::%s %s must be a positive number of seconds; using the default.\n' "${label}" "${value_name//_/ }" >&2
+      if [ "${value_name}" = "timeout_seconds" ]; then
+        timeout_seconds=10
+      else
+        cleanup_timeout_seconds=5
+      fi
+    fi
+  done
+
+  output_file="$(mktemp)"
+  # Job control gives the probe and any child it leaves behind a dedicated
+  # process group, so a stalled help command cannot retain this shell's pipe.
+  set -m
+  homeboy "$@" --help >"${output_file}" 2>&1 &
+  command_pid=$!
+  set +m
+
+  deadline="$(( $(date +%s) + timeout_seconds ))"
+  while kill -0 "${command_pid}" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+      printf '::warning::%s exceeded its %ss timeout; terminating process group %s.\n' "${label}" "${timeout_seconds}" "${command_pid}" >&2
+      kill -TERM -- "-${command_pid}" 2>/dev/null || true
+      break
+    fi
+    sleep 0.1
+  done
+
+  if kill -0 -- "-${command_pid}" 2>/dev/null; then
+    deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
+    while kill -0 -- "-${command_pid}" 2>/dev/null && [ "$(date +%s)" -lt "${deadline}" ]; do
+      sleep 0.1
+    done
+  fi
+
+  if kill -0 -- "-${command_pid}" 2>/dev/null; then
+    printf '::warning::%s did not exit after %ss cleanup; sending SIGKILL to process group %s.\n' "${label}" "${cleanup_timeout_seconds}" "${command_pid}" >&2
+    kill -KILL -- "-${command_pid}" 2>/dev/null || true
+  fi
+
+  wait "${command_pid}" 2>/dev/null || true
+
+  if kill -0 -- "-${command_pid}" 2>/dev/null; then
+    printf '::warning::%s retained process group %s after bounded cleanup.\n' "${label}" "${command_pid}" >&2
+    rm -f "${output_file}"
+    return 1
+  fi
+
+  if grep -E '^[[:space:]]+--placement([[:space:]]|<)' "${output_file}" >/dev/null; then
+    rm -f "${output_file}"
+    return 0
+  fi
+
+  rm -f "${output_file}"
+  return 1
+}
+
 homeboy_placement_mode() {
   if [ -z "${HOMEBOY_ACTION_PLACEMENT_MODE+x}" ]; then
-    if homeboy --help 2>&1 | grep -E '^[[:space:]]+--placement([[:space:]]|<)' >/dev/null; then
+    if homeboy_help_supports_placement; then
       HOMEBOY_ACTION_PLACEMENT_MODE=global
-    elif homeboy review audit --help 2>&1 | grep -E '^[[:space:]]+--placement([[:space:]]|<)' >/dev/null; then
+    elif homeboy_help_supports_placement review audit; then
       HOMEBOY_ACTION_PLACEMENT_MODE=scoped
     else
       HOMEBOY_ACTION_PLACEMENT_MODE=legacy

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -63,8 +63,10 @@ for CMD in "${CMD_ARRAY[@]}"; do
   CMD_EXIT=0
   set +e
   bash "${GITHUB_ACTION_PATH}/scripts/core/run-with-liveness-timeout.sh" \
-    "homeboy ${CMD}" bash -c "${FULL_CMD}" 2>&1 | tee "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log"
-  CMD_EXIT=${PIPESTATUS[0]}
+    --log-file "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log" \
+    "homeboy ${CMD}" bash -c "${FULL_CMD}"
+  CMD_EXIT=$?
+  cat "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log"
   set -e
   echo "::endgroup::"
 

--- a/scripts/core/run-with-liveness-timeout.sh
+++ b/scripts/core/run-with-liveness-timeout.sh
@@ -2,21 +2,36 @@
 
 set -euo pipefail
 
+log_file=""
+if [ "${1:-}" = "--log-file" ]; then
+  log_file="${2:-}"
+  shift 2
+fi
+
 label="$1"
 shift
 timeout_seconds="${HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS:-1800}"
+cleanup_timeout_seconds="${HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS:-15}"
 
-if ! [[ "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
-  echo "::error::${label} timeout must be a positive number of seconds; received '${timeout_seconds}'."
-  exit 2
-fi
+for value_name in timeout_seconds cleanup_timeout_seconds; do
+  value="${!value_name}"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::${label} ${value_name//_/ } must be a positive number of seconds; received '${value}'."
+    exit 2
+  fi
+done
 
 start_seconds="$(date +%s)"
 
-# Job control gives the child command its own process group. Killing only the
-# wrapper leaves grandchildren such as cargo and homeboy running after a timeout.
+# Job control gives the child command its own process group. Capturing its output
+# directly in a file prevents a descendant-held stdout pipe from wedging `tee`
+# after the command parent exits.
 set -m
-"$@" &
+if [ -n "${log_file}" ]; then
+  "$@" >"${log_file}" 2>&1 &
+else
+  "$@" &
+fi
 command_pid=$!
 set +m
 
@@ -28,8 +43,6 @@ set +m
       if [ "${elapsed}" -ge "${timeout_seconds}" ]; then
         echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout; terminating its process group."
         kill -TERM -- "-${command_pid}" 2>/dev/null || true
-        sleep 5
-        kill -KILL -- "-${command_pid}" 2>/dev/null || true
         exit 0
       fi
       if [ "$(( elapsed % 60 ))" -eq 0 ]; then
@@ -46,6 +59,31 @@ command_exit=$?
 set -e
 kill "${liveness_pid}" 2>/dev/null || true
 wait "${liveness_pid}" 2>/dev/null || true
+
+if kill -0 -- "-${command_pid}" 2>/dev/null; then
+  echo "::warning::${label} finalization found a live process group after the command parent exited; terminating it within ${cleanup_timeout_seconds}s."
+  kill -TERM -- "-${command_pid}" 2>/dev/null || true
+  cleanup_deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
+  while kill -0 -- "-${command_pid}" 2>/dev/null && [ "$(date +%s)" -lt "${cleanup_deadline}" ]; do
+    sleep 1
+  done
+
+  if kill -0 -- "-${command_pid}" 2>/dev/null; then
+    echo "::warning::${label} finalization grace expired; sending SIGKILL to process group ${command_pid}."
+    kill -KILL -- "-${command_pid}" 2>/dev/null || true
+    cleanup_deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
+    while kill -0 -- "-${command_pid}" 2>/dev/null && [ "$(date +%s)" -lt "${cleanup_deadline}" ]; do
+      sleep 1
+    done
+  fi
+
+  if kill -0 -- "-${command_pid}" 2>/dev/null; then
+    echo "::error::${label} finalization could not terminate process group ${command_pid} within ${cleanup_timeout_seconds}s. Retained command output: ${log_file:-standard output}."
+    exit 125
+  fi
+
+  echo "::notice::${label} finalization terminated surviving process group ${command_pid}; retained command output: ${log_file:-standard output}."
+fi
 
 if [ "$(( $(date +%s) - start_seconds ))" -ge "${timeout_seconds}" ]; then
   echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout and was terminated. Inspect this step's logs and rerun after resolving the blocked command; the caller can continue when this action is advisory."

--- a/scripts/core/test-baseline-change-detection.sh
+++ b/scripts/core/test-baseline-change-detection.sh
@@ -184,7 +184,12 @@ git -C "${ABSENT_REPO}" add .
 git -C "${ABSENT_REPO}" commit -q -m initial
 
 mv "${FAKE_BIN}/homeboy" "${FAKE_BIN}/homeboy.bak"
+original_path="${PATH}"
+# Removing the fake alone exposes a host-installed Homeboy, defeating this
+# fixture and allowing its real component resolver to block the shell suite.
+PATH="${FAKE_BIN}:/usr/bin:/bin"
 assert_equals "homeboy.json" "$(drift_file_paths "${ABSENT_REPO}")" "no homeboy on PATH falls back to baseline only"
+PATH="${original_path}"
 mv "${FAKE_BIN}/homeboy.bak" "${FAKE_BIN}/homeboy"
 
 printf 'All baseline change detection checks passed.\n'

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -3,6 +3,29 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+FAKE_BIN="${TMP_DIR}/bin"
+mkdir -p "${FAKE_BIN}"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+cat > "${FAKE_BIN}/homeboy" <<'SH'
+#!/usr/bin/env bash
+
+if [ "${1:-}" = "--help" ] && [ "${HOMEBOY_FAKE_STALLED_HELP:-false}" = "true" ]; then
+  sleep 30 &
+  printf '%s\n' "$!" > "${HOMEBOY_FAKE_CHILD_PID_FILE}"
+  wait
+fi
+
+if [ "${*: -1}" = "--help" ]; then
+  printf '  --placement <auto|local|lab>\n'
+fi
+SH
+chmod +x "${FAKE_BIN}/homeboy"
+export PATH="${FAKE_BIN}:${PATH}"
 source "${SCRIPT_DIR}/lib.sh"
 
 assert_equals() {
@@ -53,6 +76,33 @@ assert_not_contains() {
 WORKSPACE="/tmp/workspace"
 COMPONENT="data-machine"
 OUTPUT_JSON="/tmp/workspace/out.json"
+
+# The placement fallback executes Homeboy help commands. Verify a stalled probe
+# cannot retain a child or block command construction indefinitely.
+child_pid_file="${TMP_DIR}/stalled-help-child.pid"
+placement_probe_log="${TMP_DIR}/placement-probe.log"
+unset HOMEBOY_ACTION_PLACEMENT_MODE
+export HOMEBOY_FAKE_STALLED_HELP=true
+export HOMEBOY_FAKE_CHILD_PID_FILE="${child_pid_file}"
+export HOMEBOY_ACTION_PLACEMENT_PROBE_TIMEOUT_SECONDS=1
+export HOMEBOY_ACTION_PLACEMENT_PROBE_CLEANUP_TIMEOUT_SECONDS=1
+homeboy_placement_mode 2>"${placement_probe_log}"
+if [ "${HOMEBOY_ACTION_PLACEMENT_MODE}" != "scoped" ]; then
+  printf 'FAIL: stalled global placement probe does not recover through scoped placement\n'
+  exit 1
+fi
+if ! grep -q 'placement capability probe exceeded its 1s timeout' "${placement_probe_log}"; then
+  printf 'FAIL: stalled placement probe does not report timeout diagnostics\n'
+  exit 1
+fi
+child_pid="$(<"${child_pid_file}")"
+if kill -0 "${child_pid}" 2>/dev/null; then
+  printf 'FAIL: stalled placement probe leaves child process %s alive\n' "${child_pid}"
+  exit 1
+fi
+printf 'PASS: stalled placement probe is bounded and cleans its child\n'
+unset HOMEBOY_ACTION_PLACEMENT_MODE HOMEBOY_FAKE_STALLED_HELP HOMEBOY_FAKE_CHILD_PID_FILE
+unset HOMEBOY_ACTION_PLACEMENT_PROBE_TIMEOUT_SECONDS HOMEBOY_ACTION_PLACEMENT_PROBE_CLEANUP_TIMEOUT_SECONDS
 
 # ── Unscoped (full mode) ──
 unset GITHUB_ACTIONS SCOPE_MODE SCOPE_BASE_REF EXTRA_ARGS || true

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -8,12 +8,17 @@ ACTION="${ROOT_DIR}/action.yml"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
-HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=2 bash "${RUNNER}" "fast command" bash -c 'exit 0'
-printf 'PASS: successful command preserves exit status\n'
+success_log="${TMP_DIR}/success.log"
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=2 bash "${RUNNER}" --log-file "${success_log}" "fast command" bash -c 'printf success'
+if [ "$(<"${success_log}")" != "success" ]; then
+  printf 'FAIL: successful command log was not retained\n'
+  exit 1
+fi
+printf 'PASS: successful command preserves its retained output\n'
 
 set +e
 child_pid_file="${TMP_DIR}/child.pid"
-HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 bash "${RUNNER}" "stalled autofix" bash -c 'sleep 30 & echo $! > "$0"; wait' "${child_pid_file}" >"${TMP_DIR}/timeout.log" 2>&1
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 bash "${RUNNER}" --log-file "${TMP_DIR}/timeout-command.log" "stalled autofix" bash -c 'sleep 30 & echo $! > "$0"; wait' "${child_pid_file}" >"${TMP_DIR}/timeout.log" 2>&1
 exit_code=$?
 set -e
 
@@ -35,6 +40,23 @@ if kill -0 "${child_pid}" 2>/dev/null; then
 fi
 printf 'PASS: timeout terminates descendant process group\n'
 
+leaked_pid_file="${TMP_DIR}/leaked.pid"
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=5 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 bash "${RUNNER}" --log-file "${TMP_DIR}/leaked-command.log" "leaked child" bash -c 'sleep 30 & echo $! > "$0"; printf retained' "${leaked_pid_file}" >"${TMP_DIR}/cleanup.log" 2>&1
+leaked_pid="$(<"${leaked_pid_file}")"
+if kill -0 "${leaked_pid}" 2>/dev/null; then
+  printf 'FAIL: finalization leaves child process %s alive\n' "${leaked_pid}"
+  exit 1
+fi
+if ! grep -q 'finalization terminated surviving process group' "${TMP_DIR}/cleanup.log"; then
+  printf 'FAIL: finalization does not report child-process cleanup\n'
+  exit 1
+fi
+if [ "$(<"${TMP_DIR}/leaked-command.log")" != "retained" ]; then
+  printf 'FAIL: child cleanup did not preserve command output\n'
+  exit 1
+fi
+printf 'PASS: finalization cleans children and reports retained output\n'
+
 set +e
 HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=invalid bash "${RUNNER}" "invalid timeout" bash -c 'exit 0' >"${TMP_DIR}/invalid.log" 2>&1
 exit_code=$?
@@ -50,6 +72,10 @@ if ! grep -q '^  execution-timeout-seconds:' "${ACTION}"; then
   printf 'FAIL: action does not expose execution timeout input\n'
   exit 1
 fi
+if ! grep -q '^  cleanup-timeout-seconds:' "${ACTION}"; then
+  printf 'FAIL: action does not expose cleanup timeout input\n'
+  exit 1
+fi
 
 wrapper_count="$(grep -c 'run-with-liveness-timeout.sh' "${ACTION}")"
 if [ "${wrapper_count}" -ne 1 ]; then
@@ -58,6 +84,10 @@ if [ "${wrapper_count}" -ne 1 ]; then
 fi
 if ! grep -q 'run-with-liveness-timeout.sh' "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh"; then
   printf 'FAIL: quality commands are not individually bounded\n'
+  exit 1
+fi
+if grep -q 'run-with-liveness-timeout.sh.*| tee' "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh"; then
+  printf 'FAIL: quality command finalization still depends on an unbounded tee pipeline\n'
   exit 1
 fi
 printf 'PASS: action applies bounded execution to each quality command and autofix\n'


### PR DESCRIPTION
## Summary

Prevent Homeboy Action Test jobs and command-builder verification from hanging indefinitely when descendants retain output pipes or capability probes stop responding.

## What changed

- Replace `tee` pipelines with file-backed logs and bounded process-group teardown.
- Add configurable cleanup timeout diagnostics.
- Bound Homeboy capability probes and correct absence fixtures so host binaries cannot leak into tests.

## How to test

1. Run `bash scripts/core/test-run-homeboy-commands.sh`; command execution and retained-log tests pass.
2. Run `bash scripts/core/test-run-with-liveness-timeout.sh`; success, timeout, descendant cleanup, and diagnostics tests pass.
3. Run `timeout 240 bash -c 'while IFS= read -r test; do bash "$test" || exit 1; done < <(find scripts -name "test-*.sh" -type f | sort)'`; every tracked shell test reaches a passing terminal result.\n4. Run `ruby -e "require 'yaml'; YAML.load_file('action.yml')"`; the action manifest remains valid YAML.\n\n## Compatibility\n\nExisting action inputs remain compatible. The new optional `cleanup-timeout-seconds` input defaults to 15 seconds and only bounds post-command descendant cleanup that previously could hang indefinitely.\n\n## Evidence\n\n- Source: https://github.com/Extra-Chill/homeboy/issues/6859\n- Source: https://github.com/Extra-Chill/homeboy-action/issues/285\n- Full tracked shell suite passed under a 240-second outer timeout.\n- `git diff --check` passed.\n\n## AI assistance\n- **AI assistance:** Yes\n- **Tool(s):** OpenCode general coding task via Homeboy\n- **Model:** openai/gpt-5.6-sol\n- **Used for:** Diagnosed the action process and pipe leaks, implemented bounded teardown and probes, and verified the full shell suite.\n\n## Source relationships\n\n- Closes Extra-Chill/homeboy#6859\n- Closes #285