### PR TITLE
fix(issues): categorize review-prefixed audit/lint/test commands

### DIFF
--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -106,21 +106,30 @@ IFS=',' read -ra CMD_ARRAY <<< "${COMMANDS:-}"
 for CMD in "${CMD_ARRAY[@]}"; do
   CMD=$(echo "${CMD}" | xargs)
 
-  # Only process command types we know how to normalize
+  # Normalize the invoked command to its base quality type. The action pipeline
+  # passes review-backed commands ("review audit", "review lint", "review test")
+  # as well as bare forms ("audit", "lint", "test"); both must categorize.
+  # Mirrors quality_base_command() in scripts/core/lib.sh.
   case "${CMD}" in
-    audit|lint|test) ;;
+    "review audit"*|audit|audit\ *) BASE_CMD="audit" ;;
+    "review lint"*|lint|lint\ *)    BASE_CMD="lint" ;;
+    "review test"*|test|test\ *)    BASE_CMD="test" ;;
     *) continue ;;
   esac
 
-  JSON_FILE="${OUTPUT_DIR}/${CMD}.json"
+  # Resolve the structured-output file. run-homeboy-commands.sh writes to a
+  # sanitized stem (command_output_stem() in lib.sh), so "review audit" lands in
+  # review-audit.json, not "review audit.json". Sanitize the same way here.
+  CMD_STEM="$(printf '%s' "${CMD}" | sed -E 's/[^[:alnum:]._-]+/-/g; s/^-+//; s/-+$//')"
+  JSON_FILE="${OUTPUT_DIR}/${CMD_STEM}.json"
 
   if [ ! -f "${JSON_FILE}" ] || [ ! -s "${JSON_FILE}" ]; then
-    echo "No structured ${CMD}.json found — skipping categorized issues for ${CMD}"
+    echo "No structured ${CMD_STEM}.json found — skipping categorized issues for ${CMD}"
     continue
   fi
 
   if ! jq empty "${JSON_FILE}" >/dev/null 2>&1; then
-    echo "::warning::Structured ${CMD}.json is malformed — skipping categorized issues for ${CMD}"
+    echo "::warning::Structured ${CMD_STEM}.json is malformed — skipping categorized issues for ${CMD}"
     RECONCILE_FAILURES=$((RECONCILE_FAILURES + 1))
     continue
   fi
@@ -132,8 +141,10 @@ for CMD in "${CMD_ARRAY[@]}"; do
     local_comp_id="${COMPONENT_FROM_JSON}"
   fi
 
-  # Reconcile this command's findings against the tracker
-  if reconcile_command "${CMD}" "${JSON_FILE}" "${local_comp_id}"; then
+  # Reconcile this command's findings against the tracker. Pass the normalized
+  # base type (audit/lint/test), not the raw "review …" form, so downstream
+  # grouping and issue labels use the canonical command type.
+  if reconcile_command "${BASE_CMD}" "${JSON_FILE}" "${local_comp_id}"; then
     COMMANDS_PROCESSED=$((COMMANDS_PROCESSED + 1))
   else
     RECONCILE_FAILURES=$((RECONCILE_FAILURES + 1))


### PR DESCRIPTION
## Summary
Auto-issue filing has been silently broken on **every** repo (homeboy, data-machine, …) since the reconcile-bridge refactor (191cec1) migrated the action to review-prefixed quality commands. This restores it.

## Root cause
`scripts/issues/auto-file-categorized-issues.sh` main loop:
- Matched only bare `audit`/`lint`/`test` in `COMMANDS` (`case "${CMD}" in audit|lint|test)`).
- Read `${OUTPUT_DIR}/${CMD}.json`.

But the pipeline passes **`review audit`, `review lint`, `review test`**, and `run-homeboy-commands.sh` writes output to a **sanitized stem** via `command_output_stem()` — so `review audit` lands in `review-audit.json`, not `"review audit.json"`.

Consequence for every modern run:
1. `case` matched nothing → `continue` → `COMMANDS_PROCESSED` stayed `0`.
2. The empty-input handler then saw the command marked `"fail"` in `RESULTS` — the audit **drift gate** legitimately exits non-zero when findings exceed baseline (the normal, expected state for an advisory sweep) — and bailed with:
   > `Commands failed without producing structured output for categorization`
3. Zero issues filed, **despite a fully-populated findings JSON on disk**.

### Observed evidence
- homeboy's `audit-debt.yml`: first non-aborting run logged `DRIFT INCREASED: 1058 new finding(s) since baseline` yet reported `Commands processed: 0 / Issues created: 0`.
- No `homeboy-ci` bot-authored tracking issues have been filed on any repo since 2026-07-03 (the reconcile-bridge era).

## Fix
- Normalize each command to its base quality type (`review audit` → `audit`), mirroring `quality_base_command()` in `lib.sh`. Bare `audit`/`lint`/`test` still match → no regression for older callers.
- Resolve the JSON via the same stem sanitization `run-homeboy-commands.sh`/`command_output_stem()` use (`review-audit.json`).
- Pass the canonical base type to `homeboy issues reconcile --from-output <type>=<file>` (it expects `audit`/`lint`/`test`, not the `review …` form).

## Verification
- `bash -n` passes.
- Stem sanitization confirmed: `review audit` → `review-audit`.
- Diff is limited to the main-loop command/stem resolution; reconcile plumbing unchanged.

## Note
This depends on the audit actually producing findings JSON, which on homeboy also required Extra-Chill/homeboy#9269 (stale `audit.source_policies` paths after the `homeboy-code-audit` crate extraction). With both merged, the weekly Audit Debt sweep should file/refresh the deduplicated `audit:*` tracking issues.

Separately: data-machine's `homeboy.yml` is currently `startup_failure` on every run (a distinct CI-infra issue, not addressed here).