### PR TITLE
fix(issues): call reconcile at its real path 'homeboy runs findings reconcile'

### DIFF
--- a/scripts/issues/auto-file-categorized-issues.sh
+++ b/scripts/issues/auto-file-categorized-issues.sh
@@ -2,12 +2,12 @@
 #
 # File categorized GitHub issues from audit, lint, and test findings.
 #
-# Thin orchestrator over `homeboy issues reconcile`. The decision logic and
-# native-output rendering live in Homeboy core with real types and tests. This
-# script's only job is:
+# Thin orchestrator over `homeboy runs findings reconcile`. The decision logic
+# and native-output rendering live in Homeboy core with real types and tests.
+# This script's only job is:
 #
 #   1. Locate each command's structured JSON output.
-#   2. Call `homeboy issues reconcile --from-output ... --apply`.
+#   2. Call `homeboy runs findings reconcile --from-output ... --apply`.
 #   3. Surface the reconcile plan and totals in the run log.
 #
 # See homeboy issue #1551 for the architectural framing. This replaces
@@ -36,7 +36,7 @@ RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 
 # CI runners check out a single repo to GITHUB_WORKSPACE and don't have the
 # component registered in homeboy's global registry. Always pass --path so
-# `homeboy issues reconcile` discovers the component from its homeboy.json.
+# `homeboy runs findings reconcile` discovers the component from its homeboy.json.
 RECONCILE_PATH="${GITHUB_WORKSPACE:-$(pwd)}"
 
 # Track totals across all command types — populated from reconcile output.
@@ -49,7 +49,7 @@ RECONCILE_FAILURES=0
 # ─────────────────────────────────────────────────────────────────────────────
 # reconcile_command CMD_TYPE JSON_FILE COMP_ID
 #
-# Invoke `homeboy issues reconcile` with native command output and surface its
+# Invoke `homeboy runs findings reconcile` with native command output and surface its
 # plan in the run log. Core owns the command-specific rendering.
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -67,13 +67,13 @@ reconcile_command() {
 
   local result_file
   result_file=$(mktemp)
-  if ! homeboy issues reconcile "${comp_id}" \
+  if ! homeboy runs findings reconcile "${comp_id}" \
     --from-output "${cmd_type}=${json_file}" \
     --run-url "${RUN_URL}" \
     --path "${RECONCILE_PATH}" \
     --apply \
     > "${result_file}" 2>&1; then
-    echo "::warning::homeboy issues reconcile failed for ${cmd_type} — see log above"
+    echo "::warning::homeboy runs findings reconcile failed for ${cmd_type} — see log above"
     cat "${result_file}"
     rm -f "${result_file}"
     return 1


### PR DESCRIPTION
## Summary
The final blocker on auto-issue filing. The categorizer called **`homeboy issues reconcile`**, but homeboy has **no top-level `issues` subcommand** — so every reconcile died with:

```
error: unrecognized subcommand 'issues'
```

filing zero issues.

## Root cause
`crates/homeboy-cli/src/commands/issues.rs` is a **library module**, not a registered CLI command. There is no `Issues` variant in homeboy's top-level `Commands` enum. The reconcile capability is exposed at **`homeboy runs findings reconcile`** (`RunsFindingsArgs.command: Option<IssuesCommand>`, `IssuesCommand::Reconcile`). Its own doc comment says so: `//! `homeboy runs findings reconcile` — finding-stream → tracker reconciliation.`

The action has called the nonexistent `issues reconcile` path since the reconcile bridge first shipped (191cec1, "bridge to homeboy issues reconcile") — that top-level path was never actually exposed by homeboy.

## Fix
Repoint the invocation (and doc comments) from `homeboy issues reconcile` → `homeboy runs findings reconcile`. Same positional component arg, same flags (`--from-output`, `--run-url`, `--path`, `--apply`) — it's the identical `IssuesCommand::Reconcile` variant, just reached via `runs findings`.

## The full chain (for context)
This is the 4th and final fix in the "why has auto-issue filing never worked" chain:
1. Extra-Chill/homeboy#9269 — stale `audit.source_policies` paths (audit aborted before finding anything). ✅ merged
2. homeboy-action#288 — categorizer didn't handle `review`-prefixed commands / sanitized JSON stems (matched nothing). ✅ merged
3. **this PR** — the reconcile command path was wrong (`issues` vs `runs findings`).

## Verification
- `bash -n` passes.
- No `issues reconcile` references remain; all point to `runs findings reconcile`.
- Verified against homeboy `origin/main`: `runs findings reconcile <component> --from-output <type>=<file> --run-url ... --path ... --apply` is the real, current command surface.

After merge + `v2` float advances, the homeboy Audit Debt sweep (which already reaches `Reconciling audit issues for homeboy` with the 1058-finding JSON on disk) should finally file the deduplicated `audit:*` tracking issues.