### PR TITLE
fix: normalize refactor lint commands

### DIFF
--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -383,7 +383,12 @@ build_run_command() {
   global_flags="$(homeboy_global_flags "${output_file}")"
 
   if [[ "${cmd}" == refactor* ]]; then
-    full_cmd="homeboy ${global_flags}refactor ${component_id} ${cmd#refactor } --path ${workspace}"
+    local refactor_args
+    refactor_args="$(printf '%s' "${cmd#refactor}" | xargs)"
+    if [[ "${refactor_args}" == "lint" || "${refactor_args}" == "lint "* ]]; then
+      refactor_args="--from lint${refactor_args#lint}"
+    fi
+    full_cmd="homeboy ${global_flags}refactor ${component_id} ${refactor_args} --path ${workspace}"
   elif [[ "${cmd}" == bench* ]]; then
     local bench_args
     bench_args="$(printf '%s' "${cmd#bench}" | xargs)"

--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -322,6 +322,11 @@ assert_equals \
   "refactor keeps path with changed-since"
 
 assert_equals \
+  "homeboy refactor data-machine --from lint --path /tmp/workspace --changed-since origin/main --format json" \
+  "$(build_run_command "refactor lint" "${COMPONENT}" "${WORKSPACE}")" \
+  "refactor lint shorthand uses the component-scoped source flag"
+
+assert_equals \
   "refactor---all" \
   "$(command_output_stem "refactor --all")" \
   "output stem sanitizes spaced refactor command"


### PR DESCRIPTION
## Summary

- normalize configured `refactor lint` shorthand to Homeboy's supported component-scoped `refactor <component> --from lint` contract
- preserve output, workspace path, changed-since scope, and additional arguments
- add a command-builder regression matching the invocation that failed Data Machine PR #2974

## Verification

- `bash scripts/core/test-command-builders.sh`: passed
- shell syntax and `git diff --check`: passed
- all shell contracts except the pristine-main failure tracked in #293: passed
- `scripts/core/test-differential-gate.py` remains red identically on pristine main; tracked in #292
- current Homeboy accepts `homeboy refactor data-machine --from lint --path ... --changed-since ...`

## Incident

Data Machine run `29995128048`, job `89166911268`, failed before analysis because the action emitted:

```bash
homeboy refactor data-machine lint --path ... --changed-since ...
```

This PR emits:

```bash
homeboy refactor data-machine --from lint --path ... --changed-since ...
```

Closes #291