### PR TITLE
fix: bound baseline command liveness and cleanup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -557,6 +557,8 @@ runs:
         BASELINE_COMMANDS: ${{ inputs.baseline-commands }}
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
         RUN_GROUP_PREFIX: homeboy baseline
+        HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
+        HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
       run: bash ${{ github.action_path }}/scripts/core/run-baseline-commands.sh
 
     # ── Phase 6: Results and reporting ──

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -71,8 +71,11 @@ for CMD in "${BASELINE_RUN_COMMANDS[@]}"; do
 
   echo "::group::${GROUP_PREFIX} ${CMD}"
   set +e
-  eval "${FULL_CMD}" 2>&1 | tee "${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.log"
-  CMD_EXIT=${PIPESTATUS[0]}
+  bash "${GITHUB_ACTION_PATH}/scripts/core/run-with-liveness-timeout.sh" \
+    --log-file "${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.log" \
+    "baseline homeboy ${CMD}" bash -c "${FULL_CMD}"
+  CMD_EXIT=$?
+  cat "${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.log"
   set -e
   echo "::endgroup::"
 

--- a/scripts/core/run-with-liveness-timeout.sh
+++ b/scripts/core/run-with-liveness-timeout.sh
@@ -22,6 +22,9 @@ for value_name in timeout_seconds cleanup_timeout_seconds; do
 done
 
 start_seconds="$(date +%s)"
+timeout_marker="$(mktemp)"
+rm -f "${timeout_marker}"
+trap 'rm -f "${timeout_marker}"' EXIT
 
 # Job control gives the child command its own process group. Capturing its output
 # directly in a file prevents a descendant-held stdout pipe from wedging `tee`
@@ -42,7 +45,16 @@ set +m
       elapsed="$(( $(date +%s) - start_seconds ))"
       if [ "${elapsed}" -ge "${timeout_seconds}" ]; then
         echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout; terminating its process group."
+        touch "${timeout_marker}"
         kill -TERM -- "-${command_pid}" 2>/dev/null || true
+        cleanup_deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
+        while kill -0 -- "-${command_pid}" 2>/dev/null && [ "$(date +%s)" -lt "${cleanup_deadline}" ]; do
+          sleep 1
+        done
+        if kill -0 -- "-${command_pid}" 2>/dev/null; then
+          echo "::warning::${label} ignored SIGTERM for ${cleanup_timeout_seconds}s; sending SIGKILL to process group ${command_pid}."
+          kill -KILL -- "-${command_pid}" 2>/dev/null || true
+        fi
         exit 0
       fi
       if [ "$(( elapsed % 60 ))" -eq 0 ]; then
@@ -59,6 +71,11 @@ command_exit=$?
 set -e
 kill "${liveness_pid}" 2>/dev/null || true
 wait "${liveness_pid}" 2>/dev/null || true
+
+if [ -f "${timeout_marker}" ]; then
+  echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout and was terminated. Inspect this step's logs and rerun after resolving the blocked command; the caller can continue when this action is advisory."
+  exit 124
+fi
 
 if kill -0 -- "-${command_pid}" 2>/dev/null; then
   echo "::warning::${label} finalization found a live process group after the command parent exited; terminating it within ${cleanup_timeout_seconds}s."
@@ -83,11 +100,6 @@ if kill -0 -- "-${command_pid}" 2>/dev/null; then
   fi
 
   echo "::notice::${label} finalization terminated surviving process group ${command_pid}; retained command output: ${log_file:-standard output}."
-fi
-
-if [ "$(( $(date +%s) - start_seconds ))" -ge "${timeout_seconds}" ]; then
-  echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout and was terminated. Inspect this step's logs and rerun after resolving the blocked command; the caller can continue when this action is advisory."
-  exit 124
 fi
 
 exit "${command_exit}"

--- a/scripts/core/test-run-baseline-commands.sh
+++ b/scripts/core/test-run-baseline-commands.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="${ROOT_DIR}/scripts/core/run-baseline-commands.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin" "${TMP_DIR}/workspace"
+cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+mkdir -p "$(dirname "${output}")"
+printf '%s\n' '{"success":true}' > "${output}"
+
+case "${FAKE_HOMEBOY_MODE:-}" in
+  descendant)
+    sleep 30 &
+    echo "$!" > "${FAKE_HOMEBOY_CHILD_PID_FILE}"
+    printf 'baseline output retained\n'
+    ;;
+  timeout)
+    sleep 30
+    ;;
+esac
+SH
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+cd "${TMP_DIR}/workspace"
+git init -q -b main
+git config user.email test@example.com
+git config user.name test
+touch fixture
+git add fixture
+git commit -qm fixture
+git checkout -qb feature
+
+run_baseline() {
+  local mode="$1"
+  local log_file="$2"
+  local env_file="${TMP_DIR}/github-env-${mode}"
+
+  set +e
+  PATH="${TMP_DIR}/bin:${PATH}" \
+  GITHUB_ACTION_PATH="${ROOT_DIR}" \
+  GITHUB_WORKSPACE="${TMP_DIR}/workspace" \
+  GITHUB_ENV="${env_file}" \
+  COMMANDS='review test' \
+  COMPONENT_NAME='fixture' \
+  BASELINE_COMMANDS='auto' \
+  HOMEBOY_DIFFERENTIAL_GATING=true \
+  SCOPE_CONTEXT=pr \
+  SCOPE_BASE_REF=main \
+  HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 \
+  HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 \
+  RUN_GROUP_PREFIX='baseline test' \
+  FAKE_HOMEBOY_MODE="${mode}" \
+  FAKE_HOMEBOY_CHILD_PID_FILE="${TMP_DIR}/child-${mode}.pid" \
+  bash "${RUNNER}" >"${log_file}" 2>&1
+  local exit_code=$?
+  set -e
+
+  if [ "${exit_code}" -ne 0 ]; then
+    printf 'FAIL: baseline runner exits 0 to preserve differential result processing, got %s\n' "${exit_code}"
+    exit 1
+  fi
+
+  local output_dir
+  output_dir="$(awk -F= '/^HOMEBOY_BASE_OUTPUT_DIR=/{print $2}' "${env_file}")"
+  printf '%s\n' "${output_dir}"
+}
+
+descendant_log="${TMP_DIR}/descendant.log"
+descendant_output_dir="$(run_baseline descendant "${descendant_log}")"
+child_pid="$(<"${TMP_DIR}/child-descendant.pid")"
+if kill -0 "${child_pid}" 2>/dev/null; then
+  printf 'FAIL: baseline finalization leaves descendant process %s alive\n' "${child_pid}"
+  exit 1
+fi
+if ! grep -q 'finalization terminated surviving process group' "${descendant_log}"; then
+  printf 'FAIL: baseline finalization did not report descendant cleanup\n'
+  exit 1
+fi
+if ! grep -q 'baseline output retained' "${descendant_log}"; then
+  printf 'FAIL: baseline did not emit retained command output after finalization\n'
+  exit 1
+fi
+if ! jq -e '."review test" | .status == "pass" and .exit_code == 0 and .structured_output == true' "${descendant_output_dir}/baseline-status.json" >/dev/null; then
+  printf 'FAIL: descendant cleanup changed a successful baseline result\n'
+  exit 1
+fi
+printf 'PASS: baseline finalization cleans descendants and preserves successful results\n'
+
+timeout_log="${TMP_DIR}/timeout.log"
+timeout_output_dir="$(run_baseline timeout "${timeout_log}")"
+if ! grep -q 'baseline homeboy review test exceeded its 1s execution timeout' "${timeout_log}"; then
+  printf 'FAIL: baseline timeout did not emit actionable liveness evidence\n'
+  exit 1
+fi
+if ! jq -e '."review test" | .status == "fail" and .exit_code == 124 and .structured_output == true' "${timeout_output_dir}/baseline-status.json" >/dev/null; then
+  printf 'FAIL: baseline timeout did not preserve differential failure semantics\n'
+  exit 1
+fi
+printf 'PASS: baseline timeout records actionable failure evidence\n'

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -86,8 +86,24 @@ if ! grep -q 'run-with-liveness-timeout.sh' "${ROOT_DIR}/scripts/core/run-homebo
   printf 'FAIL: quality commands are not individually bounded\n'
   exit 1
 fi
+if ! grep -q 'run-with-liveness-timeout.sh' "${ROOT_DIR}/scripts/core/run-baseline-commands.sh"; then
+  printf 'FAIL: baseline commands are not individually bounded\n'
+  exit 1
+fi
+if grep -q 'run-with-liveness-timeout.sh.*| tee' "${ROOT_DIR}/scripts/core/run-baseline-commands.sh"; then
+  printf 'FAIL: baseline command finalization still depends on an unbounded tee pipeline\n'
+  exit 1
+fi
+if ! grep -A18 'name: Run baseline Homeboy commands' "${ACTION}" | grep -q 'HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS:'; then
+  printf 'FAIL: baseline commands do not receive the execution timeout input\n'
+  exit 1
+fi
+if ! grep -A18 'name: Run baseline Homeboy commands' "${ACTION}" | grep -q 'HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS:'; then
+  printf 'FAIL: baseline commands do not receive the cleanup timeout input\n'
+  exit 1
+fi
 if grep -q 'run-with-liveness-timeout.sh.*| tee' "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh"; then
   printf 'FAIL: quality command finalization still depends on an unbounded tee pipeline\n'
   exit 1
 fi
-printf 'PASS: action applies bounded execution to each quality command\n'
+printf 'PASS: action applies bounded execution to each quality and baseline command\n'

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -40,6 +40,41 @@ if kill -0 "${child_pid}" 2>/dev/null; then
 fi
 printf 'PASS: timeout terminates descendant process group\n'
 
+term_ignoring_parent_pid_file="${TMP_DIR}/term-ignoring-parent.pid"
+term_ignoring_child_pid_file="${TMP_DIR}/term-ignoring-child.pid"
+term_ignoring_start="$(date +%s)"
+set +e
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 bash "${RUNNER}" --log-file "${TMP_DIR}/term-ignoring-command.log" "TERM-ignoring command" bash -c 'trap "" TERM; echo $$ > "$0"; (trap "" TERM; while :; do sleep 1; done) & echo $! > "$1"; printf retained; while :; do sleep 1; done' "${term_ignoring_parent_pid_file}" "${term_ignoring_child_pid_file}" >"${TMP_DIR}/term-ignoring.log" 2>&1
+exit_code=$?
+set -e
+term_ignoring_elapsed="$(( $(date +%s) - term_ignoring_start ))"
+
+if [ "${exit_code}" -ne 124 ]; then
+  printf 'FAIL: TERM-ignoring timeout exits 124, got %s\n' "${exit_code}"
+  exit 1
+fi
+if [ "${term_ignoring_elapsed}" -gt 5 ]; then
+  printf 'FAIL: TERM-ignoring command exceeded hard wall-clock bound (%ss)\n' "${term_ignoring_elapsed}"
+  exit 1
+fi
+term_ignoring_parent_pid="$(<"${term_ignoring_parent_pid_file}")"
+term_ignoring_child_pid="$(<"${term_ignoring_child_pid_file}")"
+for pid in "${term_ignoring_parent_pid}" "${term_ignoring_child_pid}"; do
+  if kill -0 "${pid}" 2>/dev/null; then
+    printf 'FAIL: TERM-ignoring timeout leaves process %s alive\n' "${pid}"
+    exit 1
+  fi
+done
+if ! grep -q 'ignored SIGTERM for 1s; sending SIGKILL' "${TMP_DIR}/term-ignoring.log"; then
+  printf 'FAIL: TERM-ignoring timeout did not report SIGKILL escalation\n'
+  exit 1
+fi
+if [ "$(<"${TMP_DIR}/term-ignoring-command.log")" != "retained" ]; then
+  printf 'FAIL: TERM-ignoring cleanup did not preserve command output\n'
+  exit 1
+fi
+printf 'PASS: TERM-ignoring process group is hard-killed and reaped within the timeout bound\n'
+
 leaked_pid_file="${TMP_DIR}/leaked.pid"
 HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=5 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 bash "${RUNNER}" --log-file "${TMP_DIR}/leaked-command.log" "leaked child" bash -c 'sleep 30 & echo $! > "$0"; printf retained' "${leaked_pid_file}" >"${TMP_DIR}/cleanup.log" 2>&1
 leaked_pid="$(<"${leaked_pid_file}")"


### PR DESCRIPTION
Addresses https://github.com/Extra-Chill/homeboy/issues/7941

Routes baseline commands through the action's liveness/timeout contract. On timeout it emits progress, terminates the process group, applies a bounded TERM grace period, escalates to SIGKILL, reaps deterministically, retains output, and exits 124.

## Verification
- All `scripts/core/test-*.sh` passed
- TERM-ignoring parent/descendant regression completes within five seconds with no surviving PIDs
- `bash -n` and `git diff --check`

## AI assistance
OpenCode using gpt-5.6-sol diagnosed the upstream ownership boundary, implemented and reviewed the process-group fix, and added regression coverage. Chris remains responsible for the submitted code.