### PR TITLE
fix: complete CI action liveness verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,14 @@ on:
         description: 'Duration window for best-effort observation export.'
         type: string
         default: '24h'
+      execution-timeout-seconds:
+        description: 'Maximum wall-clock time for each Homeboy command phase.'
+        type: string
+        default: '1800'
+      cleanup-timeout-seconds:
+        description: 'Maximum wall-clock time to terminate command descendants.'
+        type: string
+        default: '15'
       pr-comment:
         description: 'Post the default Homeboy PR comment.'
         type: string
@@ -366,6 +374,8 @@ jobs:
           differential-gating: ${{ inputs.differential-gating }}
           baseline-commands: ${{ inputs.baseline-commands }}
           observation-window: ${{ inputs.observation-window }}
+          execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
+          cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           app-token: ${{ steps.app-token.outputs.token || github.token }}
           auto-issue: ${{ inputs.auto-issue }}
           comment-key: ${{ inputs.comment-key }}

--- a/action.yml
+++ b/action.yml
@@ -485,6 +485,7 @@ runs:
         RUN_GROUP_PREFIX: homeboy
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
         HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
+        HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF: true
       run: bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
 
     - name: Resolve artifact names
@@ -559,6 +560,7 @@ runs:
         RUN_GROUP_PREFIX: homeboy baseline
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
         HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
+        HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF: true
       run: bash ${{ github.action_path }}/scripts/core/run-baseline-commands.sh
 
     # ── Phase 6: Results and reporting ──
@@ -622,6 +624,7 @@ runs:
         RUN_GROUP_PREFIX: homeboy
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
         HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
+        HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF: true
       run: bash ${{ github.action_path }}/scripts/operations/run-operations.sh
 
     # Re-check PR state just before enforcement/reporting. A PR can merge while

--- a/action.yml
+++ b/action.yml
@@ -579,6 +579,7 @@ runs:
         && steps.select-results.outputs.results != ''
         && (
           contains(steps.select-results.outputs.results, '"fail"')
+          || contains(steps.select-results.outputs.results, '"timeout"')
           || contains(steps.select-results.outputs.results, '"baseline_red"')
           || contains(steps.select-results.outputs.results, '"inconclusive"')
         )
@@ -619,6 +620,8 @@ runs:
         OPERATIONS_COMMANDS: ${{ steps.resolve-commands.outputs.operations-commands }}
         EXTRA_ARGS: ${{ inputs.args }}
         RUN_GROUP_PREFIX: homeboy
+        HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
+        HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
       run: bash ${{ github.action_path }}/scripts/operations/run-operations.sh
 
     # Re-check PR state just before enforcement/reporting. A PR can merge while

--- a/scripts/core/apply-differential-gate.py
+++ b/scripts/core/apply-differential-gate.py
@@ -100,6 +100,8 @@ def lint_count(payload: dict[str, Any] | None) -> int | None:
 
 def quality_base_command(command: str) -> str:
     parts = command.split()
+    if len(parts) == 1 and parts[0] in {"audit", "lint", "test"}:
+        return parts[0]
     if len(parts) >= 2 and parts[0] == "review" and parts[1] in {"audit", "lint", "test"}:
         return parts[1]
     return ""

--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -55,6 +55,10 @@ if [ "${HAS_QUALITY_COMMANDS}" = true ]; then
     echo "::error::One or more quality commands failed"
     FAILED=true
   fi
+  if printf '%s\n' "${RESULTS}" | jq -e 'to_entries | any(.value == "timeout")' > /dev/null; then
+    echo "::error::One or more quality commands timed out; inspect the retained command logs above."
+    FAILED=true
+  fi
   if printf '%s\n' "${RESULTS}" | jq -e 'to_entries | any(.value == "baseline_red")' > /dev/null; then
     echo "::warning::One or more quality commands were inconclusive because the baseline is already red"
   fi
@@ -67,6 +71,10 @@ fi
 if [ -n "${OPERATIONS_RESULTS}" ] && [ "${OPERATIONS_RESULTS}" != "{}" ]; then
   if printf '%s\n' "${OPERATIONS_RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
     echo "::error::One or more operations commands (fleet/deploy) failed"
+    FAILED=true
+  fi
+  if printf '%s\n' "${OPERATIONS_RESULTS}" | jq -e 'to_entries | any(.value == "timeout")' > /dev/null; then
+    echo "::error::One or more operations commands timed out; inspect the retained command logs above."
     FAILED=true
   fi
 fi

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -236,6 +236,25 @@ settings_json_flags() {
   done < <(printf '%s' "${raw}" | jq -r 'to_entries[] | [.key, (.value | tojson)] | @tsv')
 }
 
+valid_command_result_output() {
+  local output_file="$1" expected_command="$2" command_exit="$3"
+  jq -e \
+    --arg command "${expected_command}" \
+    --argjson command_exit "${command_exit}" '
+      type == "object"
+      and .schema_version == 1
+      and .command == $command
+      and (.success | type == "boolean")
+      and (.status | type == "string")
+      and (.exit_code | type == "number")
+      and .exit_code == $command_exit
+      and (if .success
+           then .status == "success" and .exit_code == 0
+           else (.status == "failure" or .status == "failed") and .exit_code != 0
+           end)
+    ' "${output_file}" >/dev/null 2>&1
+}
+
 review_subcommand_run_command() {
   local cmd="$1"
   local component_id="$2"

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -242,15 +242,15 @@ valid_command_result_output() {
     --arg command "${expected_command}" \
     --argjson command_exit "${command_exit}" '
       type == "object"
-      and .schema_version == 1
+      and .schema == "homeboy/command-result/v3"
       and .command == $command
       and (.success | type == "boolean")
       and (.status | type == "string")
       and (.exit_code | type == "number")
       and .exit_code == $command_exit
       and (if .success
-           then .status == "success" and .exit_code == 0
-           else (.status == "failure" or .status == "failed") and .exit_code != 0
+           then .status == "succeeded" and .exit_code == 0
+           else .status == "failed" and .exit_code != 0
            end)
     ' "${output_file}" >/dev/null 2>&1
 }

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -79,17 +79,17 @@ for CMD in "${BASELINE_RUN_COMMANDS[@]}"; do
   set -e
   echo "::endgroup::"
 
-  if [ ! -s "${OUTPUT_JSON}" ]; then
-    echo "::warning::baseline homeboy ${CMD} did not write structured output to ${OUTPUT_JSON}"
-  fi
-
   STRUCTURED_OUTPUT=false
-  if [ -s "${OUTPUT_JSON}" ]; then
+  if [ -s "${OUTPUT_JSON}" ] && jq -e 'type == "object"' "${OUTPUT_JSON}" >/dev/null 2>&1; then
     STRUCTURED_OUTPUT=true
+  else
+    echo "::error::baseline homeboy ${CMD} did not write valid structured output to ${OUTPUT_JSON}"
   fi
 
   STATUS="pass"
-  if [ "${CMD_EXIT}" -eq 124 ]; then
+  if [ "${CMD_EXIT}" -eq 0 ] && [ "${STRUCTURED_OUTPUT}" = false ]; then
+    STATUS="fail"
+  elif [ "${CMD_EXIT}" -eq 124 ]; then
     STATUS="timeout"
   elif [ "${CMD_EXIT}" -ne 0 ]; then
     STATUS="fail"

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -80,7 +80,7 @@ for CMD in "${BASELINE_RUN_COMMANDS[@]}"; do
   echo "::endgroup::"
 
   STRUCTURED_OUTPUT=false
-  if [ -s "${OUTPUT_JSON}" ] && jq -e 'type == "object"' "${OUTPUT_JSON}" >/dev/null 2>&1; then
+  if [ -s "${OUTPUT_JSON}" ] && valid_command_result_output "${OUTPUT_JSON}" "${CMD}" "${CMD_EXIT}"; then
     STRUCTURED_OUTPUT=true
   else
     echo "::error::baseline homeboy ${CMD} did not write valid structured output to ${OUTPUT_JSON}"

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -89,7 +89,9 @@ for CMD in "${BASELINE_RUN_COMMANDS[@]}"; do
   fi
 
   STATUS="pass"
-  if [ "${CMD_EXIT}" -ne 0 ]; then
+  if [ "${CMD_EXIT}" -eq 124 ]; then
+    STATUS="timeout"
+  elif [ "${CMD_EXIT}" -ne 0 ]; then
     STATUS="fail"
   fi
 

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -71,7 +71,7 @@ for CMD in "${CMD_ARRAY[@]}"; do
   echo "::endgroup::"
 
   STRUCTURED_OUTPUT=true
-  if [ ! -s "${OUTPUT_JSON}" ] || ! jq -e 'type == "object"' "${OUTPUT_JSON}" >/dev/null 2>&1; then
+  if [ ! -s "${OUTPUT_JSON}" ] || ! valid_command_result_output "${OUTPUT_JSON}" "${CMD}" "${CMD_EXIT}"; then
     STRUCTURED_OUTPUT=false
     echo "::error::homeboy ${CMD} did not write valid structured output to ${OUTPUT_JSON}"
   elif [ "$(printf '%s' "${CMD}" | awk '{print $1}')" = "bench" ]; then

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -70,15 +70,21 @@ for CMD in "${CMD_ARRAY[@]}"; do
   set -e
   echo "::endgroup::"
 
-  if [ ! -s "${OUTPUT_JSON}" ]; then
-    echo "::warning::homeboy ${CMD} did not write structured output to ${OUTPUT_JSON}"
+  STRUCTURED_OUTPUT=true
+  if [ ! -s "${OUTPUT_JSON}" ] || ! jq -e 'type == "object"' "${OUTPUT_JSON}" >/dev/null 2>&1; then
+    STRUCTURED_OUTPUT=false
+    echo "::error::homeboy ${CMD} did not write valid structured output to ${OUTPUT_JSON}"
   elif [ "$(printf '%s' "${CMD}" | awk '{print $1}')" = "bench" ]; then
     cp "${OUTPUT_JSON}" "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.json"
   fi
 
-  if [ "${CMD_EXIT}" -eq 0 ]; then
+  if [ "${CMD_EXIT}" -eq 0 ] && [ "${STRUCTURED_OUTPUT}" = true ]; then
     echo "::notice::homeboy ${CMD}: PASSED"
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${CMD}" '. + {($cmd): "pass"}')
+  elif [ "${CMD_EXIT}" -eq 0 ]; then
+    echo "::error::homeboy ${CMD}: FAILED because required structured output was missing or malformed."
+    RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${CMD}" '. + {($cmd): "fail"}')
+    OVERALL_EXIT=1
   elif [ "${CMD_EXIT}" -eq 124 ]; then
     echo "::error::homeboy ${CMD}: TIMED OUT (exit code 124); inspect the retained command log above."
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${CMD}" '. + {($cmd): "timeout"}')

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -79,6 +79,10 @@ for CMD in "${CMD_ARRAY[@]}"; do
   if [ "${CMD_EXIT}" -eq 0 ]; then
     echo "::notice::homeboy ${CMD}: PASSED"
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${CMD}" '. + {($cmd): "pass"}')
+  elif [ "${CMD_EXIT}" -eq 124 ]; then
+    echo "::error::homeboy ${CMD}: TIMED OUT (exit code 124); inspect the retained command log above."
+    RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${CMD}" '. + {($cmd): "timeout"}')
+    OVERALL_EXIT=1
   else
     echo "::error::homeboy ${CMD}: FAILED (exit code ${CMD_EXIT})"
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${CMD}" '. + {($cmd): "fail"}')

--- a/scripts/core/run-with-liveness-timeout-supervisor.py
+++ b/scripts/core/run-with-liveness-timeout-supervisor.py
@@ -15,8 +15,9 @@ PR_SET_CHILD_SUBREAPER = 36
 
 def identity(pid: int):
     try:
-        return int(open(f"/proc/{pid}/stat", encoding="utf-8").read().split()[21])
-    except (FileNotFoundError, IndexError, ValueError):
+        fields = open(f"/proc/{pid}/stat", encoding="utf-8").read().split()
+        return None if fields[2] == "Z" else int(fields[21])
+    except (FileNotFoundError, ProcessLookupError, IndexError, ValueError):
         return None
 
 
@@ -40,8 +41,35 @@ def descendants(root: int):
     return result
 
 
-def live(pid, start):
-    return identity(pid) == start
+def signal_identity(pid, start, signal_number):
+    """Signal only the observed process generation; ESRCH means it already exited."""
+    try:
+        if identity(pid) != start:
+            return True
+        os.kill(pid, signal_number)
+        return True
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+
+
+def identities_live(known):
+    try:
+        return any(identity(pid) == start for pid, start in known.items())
+    except PermissionError:
+        return None
+
+
+def reap_children():
+    """Reap all adopted descendants after the direct command has been reaped."""
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return
+        if pid == 0:
+            return
 
 
 def main():
@@ -69,45 +97,68 @@ def main():
     timed_out = False
 
     def observe():
-        for pid in descendants(os.getpid()):
-            start = identity(pid)
+        try:
+            observed = descendants(os.getpid())
+        except PermissionError:
+            return False
+        for pid in observed:
+            try:
+                start = identity(pid)
+            except PermissionError:
+                return False
             if start is not None:
                 known[pid] = start
+        return True
 
     def terminate(reason):
         print(f"::warning::{args.label} {reason}; terminating supervised descendants.")
-        observe()
+        if not observe():
+            return False
         try:
             os.killpg(process.pid, signal.SIGTERM)
         except ProcessLookupError:
             pass
+        except PermissionError:
+            return False
         for pid, start in known.items():
-            if live(pid, start):
-                os.kill(pid, signal.SIGTERM)
+            if not signal_identity(pid, start, signal.SIGTERM):
+                return False
         deadline = time.monotonic() + args.cleanup_timeout
         while time.monotonic() < deadline:
-            observe()
-            if not any(live(pid, start) for pid, start in known.items()):
+            if not observe():
+                return False
+            live = identities_live(known)
+            if live is False:
                 return True
+            if live is None:
+                return False
             time.sleep(0.05)
         print(f"::warning::{args.label} containment grace expired; sending SIGKILL to supervised descendants.")
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except ProcessLookupError:
             pass
+        except PermissionError:
+            return False
         for pid, start in known.items():
-            if live(pid, start):
-                os.kill(pid, signal.SIGKILL)
+            if not signal_identity(pid, start, signal.SIGKILL):
+                return False
         deadline = time.monotonic() + args.cleanup_timeout
         while time.monotonic() < deadline:
-            observe()
-            if not any(live(pid, start) for pid, start in known.items()):
+            if not observe():
+                return False
+            live = identities_live(known)
+            if live is False:
                 return True
+            if live is None:
+                return False
             time.sleep(0.05)
         return False
 
     while process.poll() is None:
-        observe()
+        if not observe():
+            print(f"::error::{args.label} cannot observe supervised descendants.")
+            return 125
         elapsed = int(time.monotonic() - started)
         if elapsed >= args.timeout:
             timed_out = True
@@ -121,12 +172,20 @@ def main():
         time.sleep(0.05)
 
     exit_code = process.wait()
-    observe()
-    if any(live(pid, start) for pid, start in known.items()):
+    reap_children()
+    if not observe():
+        print(f"::error::{args.label} cannot observe supervised descendants.")
+        return 125
+    live = identities_live(known)
+    if live is None:
+        print(f"::error::{args.label} cannot verify supervised descendant identities.")
+        return 125
+    if live:
         if not terminate("finalization found live command containment"):
             print(f"::error::{args.label} containment could not prove cleanup. Retained command output: {args.log_file or 'standard output'}.")
             return 125
         print(f"::notice::{args.label} finalization terminated surviving command containment; retained command output: {args.log_file or 'standard output'}.")
+    reap_children()
     if output:
         output.close()
     if timed_out:

--- a/scripts/core/run-with-liveness-timeout-supervisor.py
+++ b/scripts/core/run-with-liveness-timeout-supervisor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Linux subreaper supervisor for commands that need descendant containment."""
+"""Linux subreaper supervisor with pidfd-based descendant containment."""
 
 import argparse
 import ctypes
@@ -9,11 +9,10 @@ import subprocess
 import sys
 import time
 
-
 PR_SET_CHILD_SUBREAPER = 36
 
 
-def identity(pid: int):
+def identity(pid):
     try:
         fields = open(f"/proc/{pid}/stat", encoding="utf-8").read().split()
         return None if fields[2] == "Z" else int(fields[21])
@@ -21,7 +20,7 @@ def identity(pid: int):
         return None
 
 
-def descendants(root: int):
+def descendants(root):
     children = {}
     for entry in os.scandir("/proc"):
         if not entry.name.isdigit():
@@ -33,20 +32,23 @@ def descendants(root: int):
             continue
     result, pending = set(), [root]
     while pending:
-        parent = pending.pop()
-        for child in children.get(parent, []):
+        for child in children.get(pending.pop(), []):
             if child not in result:
                 result.add(child)
                 pending.append(child)
     return result
 
 
-def signal_identity(pid, start, signal_number):
-    """Signal only the observed process generation; ESRCH means it already exited."""
+def open_pidfd(pid):
     try:
-        if identity(pid) != start:
-            return True
-        os.kill(pid, signal_number)
+        return os.pidfd_open(pid, 0)
+    except ProcessLookupError:
+        return None
+
+
+def signal_pidfd(pidfd, signal_number):
+    try:
+        signal.pidfd_send_signal(pidfd, signal_number)
         return True
     except ProcessLookupError:
         return True
@@ -54,15 +56,14 @@ def signal_identity(pid, start, signal_number):
         return False
 
 
-def identities_live(known):
+def known_live(known):
     try:
-        return any(identity(pid) == start for pid, start in known.items())
+        return any(identity(pid) == start for pid, start in known)
     except PermissionError:
         return None
 
 
 def reap_children():
-    """Reap all adopted descendants after the direct command has been reaped."""
     while True:
         try:
             pid, _ = os.waitpid(-1, os.WNOHANG)
@@ -70,6 +71,14 @@ def reap_children():
             return
         if pid == 0:
             return
+
+
+def close_pidfds(known):
+    for pidfd in known.values():
+        try:
+            os.close(pidfd)
+        except OSError:
+            pass
 
 
 def main():
@@ -83,7 +92,18 @@ def main():
     if not args.command:
         return 2
     if sys.platform != "linux":
-        print(f"::error::{args.label} requires Linux subreaper containment; refusing to run this strict command.")
+        print(f"::error::{args.label} requires Linux pidfd containment; refusing to run this strict command.")
+        return 125
+    if not hasattr(os, "pidfd_open") or not hasattr(signal, "pidfd_send_signal"):
+        print(f"::error::{args.label} requires Linux pidfd containment; refusing to run this strict command.")
+        return 125
+    try:
+        probe = open_pidfd(os.getpid())
+        if probe is None:
+            return 125
+        os.close(probe)
+    except PermissionError:
+        print(f"::error::{args.label} lacks permission for Linux pidfd containment; refusing to run this strict command.")
         return 125
     if ctypes.CDLL(None).prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
         print(f"::error::{args.label} cannot establish a Linux child subreaper; refusing to run this strict command.")
@@ -91,107 +111,85 @@ def main():
 
     output = open(args.log_file, "wb") if args.log_file else None
     process = subprocess.Popen(args.command, stdout=output, stderr=subprocess.STDOUT if output else None, preexec_fn=os.setsid)
-    root_start = identity(process.pid)
     known = {}
-    started = time.monotonic()
-    timed_out = False
+    root_start = identity(process.pid)
+    try:
+        root_pidfd = open_pidfd(process.pid) if root_start is not None else None
+    except PermissionError:
+        process.kill()
+        process.wait()
+        return 125
+    if root_pidfd is not None:
+        known[(process.pid, root_start)] = root_pidfd
+    started, timed_out = time.monotonic(), False
 
     def observe():
         try:
             observed = descendants(os.getpid())
+            for pid in observed:
+                start = identity(pid)
+                key = (pid, start)
+                if start is not None and key not in known:
+                    pidfd = open_pidfd(pid)
+                    if pidfd is not None:
+                        known[key] = pidfd
+            return True
         except PermissionError:
             return False
-        for pid in observed:
-            try:
-                start = identity(pid)
-            except PermissionError:
-                return False
-            if start is not None:
-                known[pid] = start
-        return True
 
     def terminate(reason):
-        print(f"::warning::{args.label} {reason}; terminating supervised descendants.")
+        print(f"::warning::{args.label} {reason}; terminating supervised descendants by pidfd.")
         if not observe():
             return False
-        try:
-            os.killpg(process.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        except PermissionError:
-            return False
-        for pid, start in known.items():
-            if not signal_identity(pid, start, signal.SIGTERM):
+        for pidfd in known.values():
+            if not signal_pidfd(pidfd, signal.SIGTERM):
                 return False
-        deadline = time.monotonic() + args.cleanup_timeout
-        while time.monotonic() < deadline:
-            if not observe():
-                return False
-            live = identities_live(known)
-            if live is False:
-                return True
-            if live is None:
-                return False
-            time.sleep(0.05)
-        print(f"::warning::{args.label} containment grace expired; sending SIGKILL to supervised descendants.")
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        except PermissionError:
-            return False
-        for pid, start in known.items():
-            if not signal_identity(pid, start, signal.SIGKILL):
-                return False
-        deadline = time.monotonic() + args.cleanup_timeout
-        while time.monotonic() < deadline:
-            if not observe():
-                return False
-            live = identities_live(known)
-            if live is False:
-                return True
-            if live is None:
-                return False
-            time.sleep(0.05)
+        for signal_number, name in ((signal.SIGTERM, "TERM"), (signal.SIGKILL, "KILL")):
+            deadline = time.monotonic() + args.cleanup_timeout
+            while time.monotonic() < deadline:
+                if not observe():
+                    return False
+                live = known_live(known)
+                if live is False:
+                    return True
+                if live is None:
+                    return False
+                time.sleep(0.05)
+            if signal_number == signal.SIGTERM:
+                print(f"::warning::{args.label} containment grace expired; sending SIGKILL by pidfd.")
+                for pidfd in known.values():
+                    if not signal_pidfd(pidfd, signal.SIGKILL):
+                        return False
         return False
 
     while process.poll() is None:
         if not observe():
-            print(f"::error::{args.label} cannot observe supervised descendants.")
+            close_pidfds(known)
             return 125
         elapsed = int(time.monotonic() - started)
         if elapsed >= args.timeout:
             timed_out = True
             print(f"::error::{args.label} exceeded its {args.timeout}s execution timeout.")
             if not terminate("timed out"):
-                print(f"::error::{args.label} containment could not prove cleanup. Retained command output: {args.log_file or 'standard output'}.")
+                close_pidfds(known)
                 return 125
             break
-        if elapsed and elapsed % 60 == 0:
-            print(f"::notice::{args.label} is still running after {elapsed}s (timeout: {args.timeout}s).")
         time.sleep(0.05)
 
     exit_code = process.wait()
     reap_children()
-    if not observe():
-        print(f"::error::{args.label} cannot observe supervised descendants.")
+    if not observe() or known_live(known) is None:
+        close_pidfds(known)
         return 125
-    live = identities_live(known)
-    if live is None:
-        print(f"::error::{args.label} cannot verify supervised descendant identities.")
-        return 125
-    if live:
+    if known_live(known):
         if not terminate("finalization found live command containment"):
-            print(f"::error::{args.label} containment could not prove cleanup. Retained command output: {args.log_file or 'standard output'}.")
+            close_pidfds(known)
             return 125
-        print(f"::notice::{args.label} finalization terminated surviving command containment; retained command output: {args.log_file or 'standard output'}.")
     reap_children()
+    close_pidfds(known)
     if output:
         output.close()
-    if timed_out:
-        print(f"::error::{args.label} exceeded its {args.timeout}s execution timeout and was terminated. Inspect this step's logs and rerun after resolving the blocked command; the caller can continue when this action is advisory.")
-        return 124
-    return exit_code
+    return 124 if timed_out else exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/core/run-with-liveness-timeout-supervisor.py
+++ b/scripts/core/run-with-liveness-timeout-supervisor.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Linux subreaper supervisor for commands that need descendant containment."""
+
+import argparse
+import ctypes
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+PR_SET_CHILD_SUBREAPER = 36
+
+
+def identity(pid: int):
+    try:
+        return int(open(f"/proc/{pid}/stat", encoding="utf-8").read().split()[21])
+    except (FileNotFoundError, IndexError, ValueError):
+        return None
+
+
+def descendants(root: int):
+    children = {}
+    for entry in os.scandir("/proc"):
+        if not entry.name.isdigit():
+            continue
+        try:
+            fields = open(f"/proc/{entry.name}/stat", encoding="utf-8").read().split()
+            children.setdefault(int(fields[3]), []).append(int(entry.name))
+        except (FileNotFoundError, IndexError, ValueError):
+            continue
+    result, pending = set(), [root]
+    while pending:
+        parent = pending.pop()
+        for child in children.get(parent, []):
+            if child not in result:
+                result.add(child)
+                pending.append(child)
+    return result
+
+
+def live(pid, start):
+    return identity(pid) == start
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log-file", default="")
+    parser.add_argument("label")
+    parser.add_argument("timeout", type=int)
+    parser.add_argument("cleanup_timeout", type=int)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if not args.command:
+        return 2
+    if sys.platform != "linux":
+        print(f"::error::{args.label} requires Linux subreaper containment; refusing to run this strict command.")
+        return 125
+    if ctypes.CDLL(None).prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+        print(f"::error::{args.label} cannot establish a Linux child subreaper; refusing to run this strict command.")
+        return 125
+
+    output = open(args.log_file, "wb") if args.log_file else None
+    process = subprocess.Popen(args.command, stdout=output, stderr=subprocess.STDOUT if output else None, preexec_fn=os.setsid)
+    root_start = identity(process.pid)
+    known = {}
+    started = time.monotonic()
+    timed_out = False
+
+    def observe():
+        for pid in descendants(os.getpid()):
+            start = identity(pid)
+            if start is not None:
+                known[pid] = start
+
+    def terminate(reason):
+        print(f"::warning::{args.label} {reason}; terminating supervised descendants.")
+        observe()
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        for pid, start in known.items():
+            if live(pid, start):
+                os.kill(pid, signal.SIGTERM)
+        deadline = time.monotonic() + args.cleanup_timeout
+        while time.monotonic() < deadline:
+            observe()
+            if not any(live(pid, start) for pid, start in known.items()):
+                return True
+            time.sleep(0.05)
+        print(f"::warning::{args.label} containment grace expired; sending SIGKILL to supervised descendants.")
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        for pid, start in known.items():
+            if live(pid, start):
+                os.kill(pid, signal.SIGKILL)
+        deadline = time.monotonic() + args.cleanup_timeout
+        while time.monotonic() < deadline:
+            observe()
+            if not any(live(pid, start) for pid, start in known.items()):
+                return True
+            time.sleep(0.05)
+        return False
+
+    while process.poll() is None:
+        observe()
+        elapsed = int(time.monotonic() - started)
+        if elapsed >= args.timeout:
+            timed_out = True
+            print(f"::error::{args.label} exceeded its {args.timeout}s execution timeout.")
+            if not terminate("timed out"):
+                print(f"::error::{args.label} containment could not prove cleanup. Retained command output: {args.log_file or 'standard output'}.")
+                return 125
+            break
+        if elapsed and elapsed % 60 == 0:
+            print(f"::notice::{args.label} is still running after {elapsed}s (timeout: {args.timeout}s).")
+        time.sleep(0.05)
+
+    exit_code = process.wait()
+    observe()
+    if any(live(pid, start) for pid, start in known.items()):
+        if not terminate("finalization found live command containment"):
+            print(f"::error::{args.label} containment could not prove cleanup. Retained command output: {args.log_file or 'standard output'}.")
+            return 125
+        print(f"::notice::{args.label} finalization terminated surviving command containment; retained command output: {args.log_file or 'standard output'}.")
+    if output:
+        output.close()
+    if timed_out:
+        print(f"::error::{args.label} exceeded its {args.timeout}s execution timeout and was terminated. Inspect this step's logs and rerun after resolving the blocked command; the caller can continue when this action is advisory.")
+        return 124
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/core/run-with-liveness-timeout.sh
+++ b/scripts/core/run-with-liveness-timeout.sh
@@ -23,6 +23,14 @@ for value_name in timeout_seconds cleanup_timeout_seconds; do
   fi
 done
 
+if [ "${require_containment_proof}" = true ]; then
+  supervisor="$(dirname "${BASH_SOURCE[0]}")/run-with-liveness-timeout-supervisor.py"
+  if [ -n "${log_file}" ]; then
+    exec python3 "${supervisor}" --log-file "${log_file}" "${label}" "${timeout_seconds}" "${cleanup_timeout_seconds}" "$@"
+  fi
+  exec python3 "${supervisor}" "${label}" "${timeout_seconds}" "${cleanup_timeout_seconds}" "$@"
+fi
+
 start_seconds="$(date +%s)"
 timeout_marker="$(mktemp)"
 containment_failure_marker="$(mktemp)"

--- a/scripts/core/run-with-liveness-timeout.sh
+++ b/scripts/core/run-with-liveness-timeout.sh
@@ -12,6 +12,7 @@ label="$1"
 shift
 timeout_seconds="${HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS:-1800}"
 cleanup_timeout_seconds="${HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS:-15}"
+require_containment_proof="${HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF:-false}"
 
 for value_name in timeout_seconds cleanup_timeout_seconds; do
   value="${!value_name}"
@@ -23,8 +24,96 @@ done
 
 start_seconds="$(date +%s)"
 timeout_marker="$(mktemp)"
+containment_failure_marker="$(mktemp)"
+descendants_file="$(mktemp)"
 rm -f "${timeout_marker}"
-trap 'rm -f "${timeout_marker}"' EXIT
+rm -f "${containment_failure_marker}" "${descendants_file}"
+containment_cgroup=""
+owner_pid="${BASHPID}"
+cleanup_files() {
+  [ "${BASHPID}" = "${owner_pid}" ] || return 0
+  rm -f "${timeout_marker}" "${containment_failure_marker}" "${descendants_file}"
+  [ -z "${containment_cgroup}" ] || rmdir "${containment_cgroup}" 2>/dev/null || true
+}
+trap cleanup_files EXIT
+
+pid_is_live() {
+  local pid="$1" state
+  kill -0 "${pid}" 2>/dev/null || return 1
+  state="$(ps -o stat= -p "${pid}" 2>/dev/null | tr -d '[:space:]')"
+  [ -n "${state}" ] && [[ "${state}" != Z* ]]
+}
+
+record_descendants() {
+  local parent="$1" child process_table
+  process_table="$(ps -axo pid=,ppid= 2>/dev/null || true)"
+  while IFS= read -r child; do
+    [ -n "${child}" ] || continue
+    printf '%s\n' "${child}" >> "${descendants_file}"
+    record_descendants "${child}"
+  done < <(printf '%s\n' "${process_table}" | awk -v parent="${parent}" '$2 == parent { print $1 }')
+}
+
+tracked_descendants_live() {
+  local pid
+  [ -f "${descendants_file}" ] || return 1
+  while IFS= read -r pid; do
+    pid_is_live "${pid}" && return 0
+  done < <(sort -u "${descendants_file}")
+  return 1
+}
+
+signal_tracked_descendants() {
+  local signal="$1" pid
+  [ -f "${descendants_file}" ] || return 0
+  while IFS= read -r pid; do
+    pid_is_live "${pid}" && kill "-${signal}" "${pid}" 2>/dev/null || true
+  done < <(sort -u "${descendants_file}")
+}
+
+containment_is_live() {
+  if [ -n "${containment_cgroup}" ]; then
+    grep -q '^populated 1$' "${containment_cgroup}/cgroup.events" 2>/dev/null && return 0
+  fi
+  kill -0 -- "-${command_pid}" 2>/dev/null || tracked_descendants_live
+}
+
+terminate_containment() {
+  local reason="$1" cleanup_deadline
+  local tracked_count=0
+  [ -f "${descendants_file}" ] && tracked_count="$(sort -u "${descendants_file}" | wc -l | tr -d '[:space:]')"
+  echo "::notice::${label} containment tracker recorded ${tracked_count} descendant PID(s); proof required=${require_containment_proof}."
+  echo "::warning::${label} ${reason}; terminating process group ${command_pid} and tracked descendants."
+  kill -TERM -- "-${command_pid}" 2>/dev/null || true
+  signal_tracked_descendants TERM
+  cleanup_deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
+  while containment_is_live && [ "$(date +%s)" -lt "${cleanup_deadline}" ]; do
+    sleep 1
+  done
+  if containment_is_live; then
+    echo "::warning::${label} containment grace expired; sending SIGKILL to process group ${command_pid} and tracked descendants."
+    kill -KILL -- "-${command_pid}" 2>/dev/null || true
+    signal_tracked_descendants KILL
+    if [ -n "${containment_cgroup}" ]; then
+      echo 1 > "${containment_cgroup}/cgroup.kill" 2>/dev/null || true
+    fi
+    cleanup_deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
+    while containment_is_live && [ "$(date +%s)" -lt "${cleanup_deadline}" ]; do
+      sleep 1
+    done
+  fi
+  if containment_is_live; then
+    echo "::error::${label} containment could not prove cleanup within ${cleanup_timeout_seconds}s; surviving descendants escaped the command process group. Retained command output: ${log_file:-standard output}."
+    touch "${containment_failure_marker}"
+    return 1
+  fi
+  if [ "${require_containment_proof}" = true ] && [ -z "${containment_cgroup}" ] && [ "${tracked_count}" -gt 0 ]; then
+    echo "::error::${label} cleanup cannot prove containment without a dedicated cgroup; tracked descendants may have escaped the command process group. Retained command output: ${log_file:-standard output}."
+    touch "${containment_failure_marker}"
+    return 1
+  fi
+  return 0
+}
 
 # Job control gives the child command its own process group. Capturing its output
 # directly in a file prevents a descendant-held stdout pipe from wedging `tee`
@@ -38,23 +127,35 @@ fi
 command_pid=$!
 set +m
 
+# A dedicated cgroup contains descendants even if they create a new session.
+if [ -d /sys/fs/cgroup ] && [ -w /sys/fs/cgroup ]; then
+  candidate_cgroup="/sys/fs/cgroup/homeboy-action-${command_pid}-$$"
+  if mkdir "${candidate_cgroup}" 2>/dev/null && echo "${command_pid}" > "${candidate_cgroup}/cgroup.procs" 2>/dev/null; then
+    containment_cgroup="${candidate_cgroup}"
+    echo "::notice::${label} is contained in cgroup ${containment_cgroup}."
+  else
+    rmdir "${candidate_cgroup}" 2>/dev/null || true
+  fi
+fi
+
 (
-  while kill -0 "${command_pid}" 2>/dev/null; do
+  while pid_is_live "${command_pid}"; do
+    record_descendants "${command_pid}"
+    sleep 0.1
+  done
+  record_descendants "${command_pid}"
+) &
+tracker_pid=$!
+
+(
+  while pid_is_live "${command_pid}"; do
     sleep 1
-    if kill -0 "${command_pid}" 2>/dev/null; then
+    if pid_is_live "${command_pid}"; then
       elapsed="$(( $(date +%s) - start_seconds ))"
       if [ "${elapsed}" -ge "${timeout_seconds}" ]; then
-        echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout; terminating its process group."
+        echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout."
         touch "${timeout_marker}"
-        kill -TERM -- "-${command_pid}" 2>/dev/null || true
-        cleanup_deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
-        while kill -0 -- "-${command_pid}" 2>/dev/null && [ "$(date +%s)" -lt "${cleanup_deadline}" ]; do
-          sleep 1
-        done
-        if kill -0 -- "-${command_pid}" 2>/dev/null; then
-          echo "::warning::${label} ignored SIGTERM for ${cleanup_timeout_seconds}s; sending SIGKILL to process group ${command_pid}."
-          kill -KILL -- "-${command_pid}" 2>/dev/null || true
-        fi
+        terminate_containment "timed out" || true
         exit 0
       fi
       if [ "$(( elapsed % 60 ))" -eq 0 ]; then
@@ -71,35 +172,23 @@ command_exit=$?
 set -e
 kill "${liveness_pid}" 2>/dev/null || true
 wait "${liveness_pid}" 2>/dev/null || true
+wait "${tracker_pid}" 2>/dev/null || true
 
 if [ -f "${timeout_marker}" ]; then
+  if [ "${require_containment_proof}" = true ] && [ -z "${containment_cgroup}" ] && [ -s "${descendants_file}" ]; then
+    touch "${containment_failure_marker}"
+  fi
+  if [ -f "${containment_failure_marker}" ]; then
+    echo "::error::${label} timed out and cleanup could not prove descendant containment. Retained command output: ${log_file:-standard output}."
+    exit 125
+  fi
   echo "::error::${label} exceeded its ${timeout_seconds}s execution timeout and was terminated. Inspect this step's logs and rerun after resolving the blocked command; the caller can continue when this action is advisory."
   exit 124
 fi
 
-if kill -0 -- "-${command_pid}" 2>/dev/null; then
-  echo "::warning::${label} finalization found a live process group after the command parent exited; terminating it within ${cleanup_timeout_seconds}s."
-  kill -TERM -- "-${command_pid}" 2>/dev/null || true
-  cleanup_deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
-  while kill -0 -- "-${command_pid}" 2>/dev/null && [ "$(date +%s)" -lt "${cleanup_deadline}" ]; do
-    sleep 1
-  done
-
-  if kill -0 -- "-${command_pid}" 2>/dev/null; then
-    echo "::warning::${label} finalization grace expired; sending SIGKILL to process group ${command_pid}."
-    kill -KILL -- "-${command_pid}" 2>/dev/null || true
-    cleanup_deadline="$(( $(date +%s) + cleanup_timeout_seconds ))"
-    while kill -0 -- "-${command_pid}" 2>/dev/null && [ "$(date +%s)" -lt "${cleanup_deadline}" ]; do
-      sleep 1
-    done
-  fi
-
-  if kill -0 -- "-${command_pid}" 2>/dev/null; then
-    echo "::error::${label} finalization could not terminate process group ${command_pid} within ${cleanup_timeout_seconds}s. Retained command output: ${log_file:-standard output}."
-    exit 125
-  fi
-
-  echo "::notice::${label} finalization terminated surviving process group ${command_pid}; retained command output: ${log_file:-standard output}."
+if containment_is_live; then
+  terminate_containment "finalization found live command containment" || exit 125
+  echo "::notice::${label} finalization terminated surviving command containment; retained command output: ${log_file:-standard output}."
 fi
 
 exit "${command_exit}"

--- a/scripts/core/run-with-liveness-timeout.sh
+++ b/scripts/core/run-with-liveness-timeout.sh
@@ -13,6 +13,7 @@ shift
 timeout_seconds="${HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS:-1800}"
 cleanup_timeout_seconds="${HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS:-15}"
 require_containment_proof="${HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF:-false}"
+cgroup_root="${HOMEBOY_ACTION_CGROUP_ROOT:-/sys/fs/cgroup}"
 
 for value_name in timeout_seconds cleanup_timeout_seconds; do
   value="${!value_name}"
@@ -115,27 +116,38 @@ terminate_containment() {
   return 0
 }
 
+# Establish strict containment before command launch. Moving an already-running
+# process into a cgroup leaves a window for a double-forked child to escape.
+if [ -d "${cgroup_root}" ] && [ -w "${cgroup_root}" ]; then
+  candidate_cgroup="${cgroup_root}/homeboy-action-$$-${RANDOM}"
+  if mkdir "${candidate_cgroup}" 2>/dev/null; then
+    containment_cgroup="${candidate_cgroup}"
+  fi
+fi
+if [ "${require_containment_proof}" = true ] && [ -z "${containment_cgroup}" ]; then
+  echo "::error::${label} cannot establish pre-launch descendant containment; refusing to run this strict command."
+  exit 125
+fi
+
 # Job control gives the child command its own process group. Capturing its output
 # directly in a file prevents a descendant-held stdout pipe from wedging `tee`
 # after the command parent exits.
 set -m
-if [ -n "${log_file}" ]; then
+if [ -n "${containment_cgroup}" ]; then
+  if [ -n "${log_file}" ]; then
+    HOMEBOY_ACTION_CHILD_CGROUP="${containment_cgroup}" bash -c 'echo "$$" > "${HOMEBOY_ACTION_CHILD_CGROUP}/cgroup.procs" || exit 125; exec "$0" "$@"' "$@" >"${log_file}" 2>&1 &
+  else
+    HOMEBOY_ACTION_CHILD_CGROUP="${containment_cgroup}" bash -c 'echo "$$" > "${HOMEBOY_ACTION_CHILD_CGROUP}/cgroup.procs" || exit 125; exec "$0" "$@"' "$@" &
+  fi
+elif [ -n "${log_file}" ]; then
   "$@" >"${log_file}" 2>&1 &
 else
   "$@" &
 fi
 command_pid=$!
 set +m
-
-# A dedicated cgroup contains descendants even if they create a new session.
-if [ -d /sys/fs/cgroup ] && [ -w /sys/fs/cgroup ]; then
-  candidate_cgroup="/sys/fs/cgroup/homeboy-action-${command_pid}-$$"
-  if mkdir "${candidate_cgroup}" 2>/dev/null && echo "${command_pid}" > "${candidate_cgroup}/cgroup.procs" 2>/dev/null; then
-    containment_cgroup="${candidate_cgroup}"
-    echo "::notice::${label} is contained in cgroup ${containment_cgroup}."
-  else
-    rmdir "${candidate_cgroup}" 2>/dev/null || true
-  fi
+if [ -n "${containment_cgroup}" ]; then
+  echo "::notice::${label} is contained in cgroup ${containment_cgroup}."
 fi
 
 (

--- a/scripts/core/select-final-results.sh
+++ b/scripts/core/select-final-results.sh
@@ -11,7 +11,7 @@ results_are_complete() {
     . as $results |
     ($commands | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))) as $expected |
     ($results | type) == "object"
-    and all($expected[]; . as $command | $results[$command] == "pass" or $results[$command] == "fail")
+    and all($expected[]; . as $command | $results[$command] == "pass" or $results[$command] == "fail" or $results[$command] == "timeout")
   ' >/dev/null 2>&1
 }
 

--- a/scripts/core/test-bench-command.sh
+++ b/scripts/core/test-bench-command.sh
@@ -37,7 +37,7 @@ if [ -z "${output}" ]; then
   exit 2
 fi
 mkdir -p "$(dirname "${output}")"
-  printf '%s\n' '{"schema_version":1,"command":"bench","success":true,"status":"success","exit_code":0,"data":{"scenarios":[{"scenario":"noop","metrics":{"elapsed_ms":{"p50":1,"p95":2}}}]}}' > "${output}"
+  printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"bench","success":true,"status":"succeeded","exit_code":0,"data":{"scenarios":[{"scenario":"noop","metrics":{"elapsed_ms":{"p50":1,"p95":2}}}]}}' > "${output}"
 SH
 chmod +x "${TMP_DIR}/bin/homeboy"
 

--- a/scripts/core/test-bench-command.sh
+++ b/scripts/core/test-bench-command.sh
@@ -37,7 +37,7 @@ if [ -z "${output}" ]; then
   exit 2
 fi
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"success":true,"data":{"scenarios":[{"scenario":"noop","metrics":{"elapsed_ms":{"p50":1,"p95":2}}}]}}' > "${output}"
+  printf '%s\n' '{"schema_version":1,"command":"bench","success":true,"status":"success","exit_code":0,"data":{"scenarios":[{"scenario":"noop","metrics":{"elapsed_ms":{"p50":1,"p95":2}}}]}}' > "${output}"
 SH
 chmod +x "${TMP_DIR}/bin/homeboy"
 

--- a/scripts/core/test-differential-gate.py
+++ b/scripts/core/test-differential-gate.py
@@ -103,17 +103,17 @@ def main() -> None:
         )
 
         assert_equal(
-            {"lint": "fail", "audit": "pass"},
+            {"lint": "inconclusive", "audit": "pass"},
             run_gate({"lint": "fail", "audit": "pass"}, current, base),
-            "non-audit-test results are left untouched",
+            "lint failure without comparable metrics is inconclusive",
         )
 
         (base / "audit.json").unlink()
         (current / "audit.json").unlink()
         assert_equal(
-            {"audit": "fail"},
+            {"audit": "inconclusive"},
             run_gate({"audit": "fail"}, current, base),
-            "missing metric files preserve failures",
+            "missing metric files are inconclusive",
         )
 
     print("All differential gate checks passed.")

--- a/scripts/core/test-enforce-final-status.sh
+++ b/scripts/core/test-enforce-final-status.sh
@@ -30,6 +30,9 @@ assert_exit 1 "malformed quality results fail closed" \
 assert_exit 1 "failing quality results fail" \
   env RESULTS='{"review test":"fail"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
 
+assert_exit 1 "timed out quality results fail with their classification" \
+  env RESULTS='{"review test":"timeout"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+
 assert_exit 1 "missing quality results with expected commands fail closed" \
   env RESULTS='' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
 

--- a/scripts/core/test-placement-compatibility.sh
+++ b/scripts/core/test-placement-compatibility.sh
@@ -68,7 +68,7 @@ while [ "$#" -gt 0 ]; do
   fi
   shift
 done
-[ -z "${output}" ] || printf '{"success":true}\n' > "${output}"
+  [ -z "${output}" ] || printf '{"schema_version":1,"command":"review audit","success":true,"status":"success","exit_code":0,"data":{}}\n' > "${output}"
 SH
 chmod +x "${FAKE_BIN}/homeboy"
 

--- a/scripts/core/test-placement-compatibility.sh
+++ b/scripts/core/test-placement-compatibility.sh
@@ -68,7 +68,7 @@ while [ "$#" -gt 0 ]; do
   fi
   shift
 done
-  [ -z "${output}" ] || printf '{"schema_version":1,"command":"review audit","success":true,"status":"success","exit_code":0,"data":{}}\n' > "${output}"
+  [ -z "${output}" ] || printf '{"schema":"homeboy/command-result/v3","command":"review audit","success":true,"status":"succeeded","exit_code":0,"data":{}}\n' > "${output}"
 SH
 chmod +x "${FAKE_BIN}/homeboy"
 

--- a/scripts/core/test-run-baseline-commands.sh
+++ b/scripts/core/test-run-baseline-commands.sh
@@ -108,7 +108,7 @@ if ! grep -q 'baseline homeboy review test exceeded its 1s execution timeout' "$
   printf 'FAIL: baseline timeout did not emit actionable liveness evidence\n'
   exit 1
 fi
-if ! jq -e '."review test" | .status == "fail" and .exit_code == 124 and .structured_output == true' "${timeout_output_dir}/baseline-status.json" >/dev/null; then
+if ! jq -e '."review test" | .status == "timeout" and .exit_code == 124 and .structured_output == true' "${timeout_output_dir}/baseline-status.json" >/dev/null; then
   printf 'FAIL: baseline timeout did not preserve differential failure semantics\n'
   exit 1
 fi

--- a/scripts/core/test-run-baseline-commands.sh
+++ b/scripts/core/test-run-baseline-commands.sh
@@ -25,7 +25,7 @@ mkdir -p "$(dirname "${output}")"
 case "${FAKE_HOMEBOY_MODE:-}" in
   missing) : ;;
   malformed) printf '%s\n' 'not json' > "${output}" ;;
-  *) printf '%s\n' '{"schema_version":1,"command":"review test","success":true,"status":"success","exit_code":0,"data":{}}' > "${output}" ;;
+  *) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review test","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
 esac
 
 case "${FAKE_HOMEBOY_MODE:-}" in

--- a/scripts/core/test-run-baseline-commands.sh
+++ b/scripts/core/test-run-baseline-commands.sh
@@ -22,7 +22,11 @@ while [ "$#" -gt 0 ]; do
 done
 
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"success":true}' > "${output}"
+case "${FAKE_HOMEBOY_MODE:-}" in
+  missing) : ;;
+  malformed) printf '%s\n' 'not json' > "${output}" ;;
+  *) printf '%s\n' '{"success":true}' > "${output}" ;;
+esac
 
 case "${FAKE_HOMEBOY_MODE:-}" in
   descendant)
@@ -88,7 +92,7 @@ if kill -0 "${child_pid}" 2>/dev/null; then
   printf 'FAIL: baseline finalization leaves descendant process %s alive\n' "${child_pid}"
   exit 1
 fi
-if ! grep -q 'finalization terminated surviving process group' "${descendant_log}"; then
+if ! grep -q 'finalization terminated surviving command containment' "${descendant_log}"; then
   printf 'FAIL: baseline finalization did not report descendant cleanup\n'
   exit 1
 fi
@@ -113,3 +117,13 @@ if ! jq -e '."review test" | .status == "timeout" and .exit_code == 124 and .str
   exit 1
 fi
 printf 'PASS: baseline timeout records actionable failure evidence\n'
+
+for output_mode in missing malformed; do
+  output_log="${TMP_DIR}/${output_mode}.log"
+  output_dir="$(run_baseline "${output_mode}" "${output_log}")"
+  if ! jq -e '."review test" | .status == "fail" and .exit_code == 0 and .structured_output == false' "${output_dir}/baseline-status.json" >/dev/null || ! grep -q 'did not write valid structured output' "${output_log}"; then
+    printf 'FAIL: zero-exit baseline %s structured output fails closed\n' "${output_mode}"
+    exit 1
+  fi
+done
+printf 'PASS: zero-exit baseline missing and malformed structured output fail closed\n'

--- a/scripts/core/test-run-baseline-commands.sh
+++ b/scripts/core/test-run-baseline-commands.sh
@@ -25,7 +25,7 @@ mkdir -p "$(dirname "${output}")"
 case "${FAKE_HOMEBOY_MODE:-}" in
   missing) : ;;
   malformed) printf '%s\n' 'not json' > "${output}" ;;
-  *) printf '%s\n' '{"success":true}' > "${output}" ;;
+  *) printf '%s\n' '{"schema_version":1,"command":"review test","success":true,"status":"success","exit_code":0,"data":{}}' > "${output}" ;;
 esac
 
 case "${FAKE_HOMEBOY_MODE:-}" in
@@ -112,7 +112,7 @@ if ! grep -q 'baseline homeboy review test exceeded its 1s execution timeout' "$
   printf 'FAIL: baseline timeout did not emit actionable liveness evidence\n'
   exit 1
 fi
-if ! jq -e '."review test" | .status == "timeout" and .exit_code == 124 and .structured_output == true' "${timeout_output_dir}/baseline-status.json" >/dev/null; then
+if ! jq -e '."review test" | .status == "timeout" and .exit_code == 124 and .structured_output == false' "${timeout_output_dir}/baseline-status.json" >/dev/null; then
   printf 'FAIL: baseline timeout did not preserve differential failure semantics\n'
   exit 1
 fi

--- a/scripts/core/test-run-homeboy-commands.sh
+++ b/scripts/core/test-run-homeboy-commands.sh
@@ -19,7 +19,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"success":false,"data":{"test_counts":{"failed":2,"passed":41,"total":43}}}' > "${output}"
+printf '%s\n' '{"schema_version":1,"command":"review test","success":false,"status":"failure","exit_code":1,"data":{"test_counts":{"failed":2,"passed":41,"total":43}}}' > "${output}"
 exit 1
 SH
 chmod +x "${TMP_DIR}/bin/homeboy"
@@ -78,6 +78,36 @@ SH
   fi
 done
 printf 'PASS: zero-exit missing and malformed structured output fail closed\n'
+
+for envelope_mode in empty wrong-command inconsistent; do
+  cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$(dirname "${output}")"
+case "${FAKE_ENVELOPE_MODE}" in
+  empty) printf '%s\n' '{}' > "${output}" ;;
+  wrong-command) printf '%s\n' '{"schema_version":1,"command":"review audit","success":true,"status":"success","exit_code":0,"data":{}}' > "${output}" ;;
+  inconsistent) printf '%s\n' '{"schema_version":1,"command":"review test","success":true,"status":"success","exit_code":1,"data":{}}' > "${output}" ;;
+esac
+exit 0
+SH
+  chmod +x "${TMP_DIR}/bin/homeboy"
+  set +e
+  PATH="${TMP_DIR}/bin:${PATH}" GITHUB_ACTION_PATH="${ROOT_DIR}" GITHUB_WORKSPACE="${TMP_DIR}/workspace" GITHUB_OUTPUT="${TMP_DIR}/${envelope_mode}-output" GITHUB_ENV="${TMP_DIR}/${envelope_mode}-env" RESOLVED_COMMANDS='review test' COMPONENT_NAME='homeboy-action' FAKE_ENVELOPE_MODE="${envelope_mode}" bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/${envelope_mode}.log" 2>&1
+  exit_code=$?
+  set -e
+  if [ "${exit_code}" -ne 1 ] || ! grep -q '^results={"review test":"fail"}$' "${TMP_DIR}/${envelope_mode}-output"; then
+    printf 'FAIL: %s command-result envelope passes\n' "${envelope_mode}"
+    exit 1
+  fi
+done
+printf 'PASS: empty, wrong-command, and inconsistent envelopes fail closed\n'
 
 cat > "${TMP_DIR}/bin/homeboy" <<'SH'
 #!/usr/bin/env bash

--- a/scripts/core/test-run-homeboy-commands.sh
+++ b/scripts/core/test-run-homeboy-commands.sh
@@ -51,6 +51,34 @@ fi
 
 printf 'PASS: failed review test records a current-run failure\n'
 
+for output_mode in missing malformed; do
+  cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$(dirname "${output}")"
+if [ "${FAKE_OUTPUT_MODE:-}" = malformed ]; then
+  printf '%s\n' 'not json' > "${output}"
+fi
+exit 0
+SH
+  chmod +x "${TMP_DIR}/bin/homeboy"
+  set +e
+  PATH="${TMP_DIR}/bin:${PATH}" GITHUB_ACTION_PATH="${ROOT_DIR}" GITHUB_WORKSPACE="${TMP_DIR}/workspace" GITHUB_OUTPUT="${TMP_DIR}/${output_mode}-output" GITHUB_ENV="${TMP_DIR}/${output_mode}-env" RESOLVED_COMMANDS='review test' COMPONENT_NAME='homeboy-action' FAKE_OUTPUT_MODE="${output_mode}" bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/${output_mode}.log" 2>&1
+  exit_code=$?
+  set -e
+  if [ "${exit_code}" -ne 1 ] || ! grep -q '^results={"review test":"fail"}$' "${TMP_DIR}/${output_mode}-output" || ! grep -q 'did not write valid structured output' "${TMP_DIR}/${output_mode}.log"; then
+    printf 'FAIL: zero-exit %s structured output fails closed\n' "${output_mode}"
+    exit 1
+  fi
+done
+printf 'PASS: zero-exit missing and malformed structured output fail closed\n'
+
 cat > "${TMP_DIR}/bin/homeboy" <<'SH'
 #!/usr/bin/env bash
 trap '' TERM

--- a/scripts/core/test-run-homeboy-commands.sh
+++ b/scripts/core/test-run-homeboy-commands.sh
@@ -19,7 +19,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"schema_version":1,"command":"review test","success":false,"status":"failure","exit_code":1,"data":{"test_counts":{"failed":2,"passed":41,"total":43}}}' > "${output}"
+printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review test","success":false,"status":"failed","exit_code":1,"data":{"test_counts":{"failed":2,"passed":41,"total":43}}}' > "${output}"
 exit 1
 SH
 chmod +x "${TMP_DIR}/bin/homeboy"
@@ -92,8 +92,8 @@ done
 mkdir -p "$(dirname "${output}")"
 case "${FAKE_ENVELOPE_MODE}" in
   empty) printf '%s\n' '{}' > "${output}" ;;
-  wrong-command) printf '%s\n' '{"schema_version":1,"command":"review audit","success":true,"status":"success","exit_code":0,"data":{}}' > "${output}" ;;
-  inconsistent) printf '%s\n' '{"schema_version":1,"command":"review test","success":true,"status":"success","exit_code":1,"data":{}}' > "${output}" ;;
+  wrong-command) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review audit","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
+  inconsistent) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review test","success":true,"status":"succeeded","exit_code":1,"data":{}}' > "${output}" ;;
 esac
 exit 0
 SH

--- a/scripts/core/test-run-homeboy-commands.sh
+++ b/scripts/core/test-run-homeboy-commands.sh
@@ -50,3 +50,35 @@ if ! grep -q 'FAILED (exit code 1)' "${TMP_DIR}/run.log"; then
 fi
 
 printf 'PASS: failed review test records a current-run failure\n'
+
+cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+trap '' TERM
+(trap '' TERM; while :; do sleep 1; done) &
+while :; do sleep 1; done
+SH
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+set +e
+PATH="${TMP_DIR}/bin:${PATH}" \
+GITHUB_ACTION_PATH="${ROOT_DIR}" \
+GITHUB_WORKSPACE="${TMP_DIR}/workspace" \
+GITHUB_OUTPUT="${TMP_DIR}/timeout-output" \
+GITHUB_ENV="${TMP_DIR}/timeout-env" \
+RESOLVED_COMMANDS='review test' \
+COMPONENT_NAME='homeboy-action' \
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 \
+HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 \
+bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/timeout.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "${exit_code}" -ne 1 ] || ! grep -q '^results={"review test":"timeout"}$' "${TMP_DIR}/timeout-output"; then
+  printf 'FAIL: timed out review test is classified for final enforcement\n'
+  exit 1
+fi
+if ! grep -q 'TIMED OUT (exit code 124)' "${TMP_DIR}/timeout.log"; then
+  printf 'FAIL: timed out review test does not report its timeout classification\n'
+  exit 1
+fi
+printf 'PASS: timed out review test preserves actionable timeout classification\n'

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -104,7 +104,7 @@ if [ "$(uname -s)" = Linux ]; then
     exit 1
   fi
   printf 'PASS: cgroup-denied Linux supervisor contains immediate double-fork escape\n'
-elif [ "${exit_code}" -ne 125 ] || [ -e "${strict_pid_file}" ] || ! grep -q 'requires Linux subreaper containment' "${TMP_DIR}/strict.log"; then
+elif [ "${exit_code}" -ne 125 ] || [ -e "${strict_pid_file}" ] || ! grep -q 'requires Linux pidfd containment' "${TMP_DIR}/strict.log"; then
   printf 'FAIL: unsupported strict platform launched before containment policy\n'
   exit 1
 else
@@ -121,23 +121,24 @@ spec = importlib.util.spec_from_file_location("supervisor", sys.argv[1])
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
-module.identity = lambda pid: 7
-original_kill = module.os.kill
-module.os.kill = lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
-assert module.signal_identity(101, 7, signal.SIGTERM)
+original_send = getattr(module.signal, "pidfd_send_signal", None)
+module.signal.pidfd_send_signal = lambda pidfd, sig: (_ for _ in ()).throw(ProcessLookupError())
+assert module.signal_pidfd(11, signal.SIGTERM)
 
 calls = []
 module.identity = lambda pid: 8
-module.os.kill = lambda pid, sig: calls.append((pid, sig))
-assert module.signal_identity(101, 7, signal.SIGKILL)
+module.signal.pidfd_send_signal = lambda pidfd, sig: calls.append((pidfd, sig))
+assert module.known_live({(101, 7): 11}) is False
 assert calls == []
 
-module.identity = lambda pid: 7
-module.os.kill = lambda pid, sig: (_ for _ in ()).throw(PermissionError())
-assert not module.signal_identity(101, 7, signal.SIGTERM)
-module.os.kill = original_kill
+module.signal.pidfd_send_signal = lambda pidfd, sig: (_ for _ in ()).throw(PermissionError())
+assert not module.signal_pidfd(11, signal.SIGTERM)
+if original_send is None:
+    del module.signal.pidfd_send_signal
+else:
+    module.signal.pidfd_send_signal = original_send
 PY
-printf 'PASS: supervisor treats ESRCH as exited, avoids PID reuse, and fails permission denial\n'
+printf 'PASS: supervisor treats pidfd ESRCH as exited, avoids PID reuse, and fails permission denial\n'
 
 if [ "$(uname -s)" = Linux ]; then
   HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true HOMEBOY_ACTION_CGROUP_ROOT="${TMP_DIR}/denied-cgroup" HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=5 bash "${RUNNER}" "rapid child exits" bash -c 'for _ in $(seq 1 200); do (exit 0) & done; wait' >"${TMP_DIR}/rapid.log" 2>&1

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -65,7 +65,7 @@ for pid in "${term_ignoring_parent_pid}" "${term_ignoring_child_pid}"; do
     exit 1
   fi
 done
-if ! grep -q 'ignored SIGTERM for 1s; sending SIGKILL' "${TMP_DIR}/term-ignoring.log"; then
+if ! grep -q 'containment grace expired; sending SIGKILL' "${TMP_DIR}/term-ignoring.log"; then
   printf 'FAIL: TERM-ignoring timeout did not report SIGKILL escalation\n'
   exit 1
 fi
@@ -82,7 +82,7 @@ if kill -0 "${leaked_pid}" 2>/dev/null; then
   printf 'FAIL: finalization leaves child process %s alive\n' "${leaked_pid}"
   exit 1
 fi
-if ! grep -q 'finalization terminated surviving process group' "${TMP_DIR}/cleanup.log"; then
+if ! grep -q 'finalization terminated surviving command containment' "${TMP_DIR}/cleanup.log"; then
   printf 'FAIL: finalization does not report child-process cleanup\n'
   exit 1
 fi
@@ -91,6 +91,20 @@ if [ "$(<"${TMP_DIR}/leaked-command.log")" != "retained" ]; then
   exit 1
 fi
 printf 'PASS: finalization cleans children and reports retained output\n'
+
+escaped_pid_file="${TMP_DIR}/escaped.pid"
+set +e
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true bash "${RUNNER}" --log-file "${TMP_DIR}/escaped-command.log" "escaped-session child" bash -c 'python3 -c "import os, signal, sys, time; os.setsid(); signal.signal(signal.SIGTERM, signal.SIG_IGN); open(sys.argv[1], \"w\").write(str(os.getpid())); time.sleep(30)" "$0" & sleep 1; while :; do sleep 1; done' "${escaped_pid_file}" >"${TMP_DIR}/escaped.log" 2>&1
+exit_code=$?
+set -e
+escaped_pid="$(<"${escaped_pid_file}")"
+escaped_state="$(ps -o stat= -p "${escaped_pid}" 2>/dev/null | tr -d '[:space:]')"
+if [ "${exit_code}" -ne 125 ] || ! grep -q 'could not prove descendant containment' "${TMP_DIR}/escaped.log"; then
+  printf 'FAIL: escaped-session descendant was not contained and reaped (exit=%s state=%s tracker=%s)\n' "${exit_code}" "${escaped_state:-gone}" "$(grep 'containment tracker' "${TMP_DIR}/escaped.log" || true)"
+  exit 1
+fi
+kill -KILL "${escaped_pid}" 2>/dev/null || true
+printf 'PASS: escaped-session descendant produces explicit containment failure when cgroups are unavailable\n'
 
 set +e
 HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=invalid bash "${RUNNER}" "invalid timeout" bash -c 'exit 0' >"${TMP_DIR}/invalid.log" 2>&1

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -92,19 +92,16 @@ if [ "$(<"${TMP_DIR}/leaked-command.log")" != "retained" ]; then
 fi
 printf 'PASS: finalization cleans children and reports retained output\n'
 
-escaped_pid_file="${TMP_DIR}/escaped.pid"
+strict_pid_file="${TMP_DIR}/strict-double-fork.pid"
 set +e
-HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true bash "${RUNNER}" --log-file "${TMP_DIR}/escaped-command.log" "escaped-session child" bash -c 'python3 -c "import os, signal, sys, time; os.setsid(); signal.signal(signal.SIGTERM, signal.SIG_IGN); open(sys.argv[1], \"w\").write(str(os.getpid())); time.sleep(30)" "$0" & sleep 1; while :; do sleep 1; done' "${escaped_pid_file}" >"${TMP_DIR}/escaped.log" 2>&1
+HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true HOMEBOY_ACTION_CGROUP_ROOT="${TMP_DIR}/missing-cgroup-root" bash "${RUNNER}" "strict double-fork" bash -c 'python3 -c "import os, sys; os.fork() and sys.exit(0); os.setsid(); os.fork() and sys.exit(0); open(sys.argv[1], \"w\").write(str(os.getpid()))" "$0"' "${strict_pid_file}" >"${TMP_DIR}/strict.log" 2>&1
 exit_code=$?
 set -e
-escaped_pid="$(<"${escaped_pid_file}")"
-escaped_state="$(ps -o stat= -p "${escaped_pid}" 2>/dev/null | tr -d '[:space:]')"
-if [ "${exit_code}" -ne 125 ] || ! grep -q 'could not prove descendant containment' "${TMP_DIR}/escaped.log"; then
-  printf 'FAIL: escaped-session descendant was not contained and reaped (exit=%s state=%s tracker=%s)\n' "${exit_code}" "${escaped_state:-gone}" "$(grep 'containment tracker' "${TMP_DIR}/escaped.log" || true)"
+if [ "${exit_code}" -ne 125 ] || [ -e "${strict_pid_file}" ] || ! grep -q 'refusing to run this strict command' "${TMP_DIR}/strict.log"; then
+  printf 'FAIL: strict command can launch before cgroup containment is established\n'
   exit 1
 fi
-kill -KILL "${escaped_pid}" 2>/dev/null || true
-printf 'PASS: escaped-session descendant produces explicit containment failure when cgroups are unavailable\n'
+printf 'PASS: cgroup-unavailable strict command refuses launch before double-fork escape\n'
 
 set +e
 HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=invalid bash "${RUNNER}" "invalid timeout" bash -c 'exit 0' >"${TMP_DIR}/invalid.log" 2>&1

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -94,14 +94,22 @@ printf 'PASS: finalization cleans children and reports retained output\n'
 
 strict_pid_file="${TMP_DIR}/strict-double-fork.pid"
 set +e
-HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true HOMEBOY_ACTION_CGROUP_ROOT="${TMP_DIR}/missing-cgroup-root" bash "${RUNNER}" "strict double-fork" bash -c 'python3 -c "import os, sys; os.fork() and sys.exit(0); os.setsid(); os.fork() and sys.exit(0); open(sys.argv[1], \"w\").write(str(os.getpid()))" "$0"' "${strict_pid_file}" >"${TMP_DIR}/strict.log" 2>&1
+HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true HOMEBOY_ACTION_CGROUP_ROOT="${TMP_DIR}/missing-cgroup-root" HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 bash "${RUNNER}" "strict double-fork" bash -c 'python3 -c "import os, signal, sys, time; os.fork() and sys.exit(0); os.setsid(); os.fork() and sys.exit(0); signal.signal(signal.SIGTERM, signal.SIG_IGN); open(sys.argv[1], \"w\").write(str(os.getpid())); time.sleep(30)" "$0"' "${strict_pid_file}" >"${TMP_DIR}/strict.log" 2>&1
 exit_code=$?
 set -e
-if [ "${exit_code}" -ne 125 ] || [ -e "${strict_pid_file}" ] || ! grep -q 'refusing to run this strict command' "${TMP_DIR}/strict.log"; then
-  printf 'FAIL: strict command can launch before cgroup containment is established\n'
+if [ "$(uname -s)" = Linux ]; then
+  strict_pid="$(<"${strict_pid_file}")"
+  if [ "${exit_code}" -ne 124 ] || kill -0 "${strict_pid}" 2>/dev/null; then
+    printf 'FAIL: cgroup-denied Linux supervisor did not contain immediate double-fork escape\n'
+    exit 1
+  fi
+  printf 'PASS: cgroup-denied Linux supervisor contains immediate double-fork escape\n'
+elif [ "${exit_code}" -ne 125 ] || [ -e "${strict_pid_file}" ] || ! grep -q 'requires Linux subreaper containment' "${TMP_DIR}/strict.log"; then
+  printf 'FAIL: unsupported strict platform launched before containment policy\n'
   exit 1
+else
+  printf 'PASS: unsupported strict platform refuses launch before double-fork escape\n'
 fi
-printf 'PASS: cgroup-unavailable strict command refuses launch before double-fork escape\n'
 
 set +e
 HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=invalid bash "${RUNNER}" "invalid timeout" bash -c 'exit 0' >"${TMP_DIR}/invalid.log" 2>&1

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -111,6 +111,39 @@ else
   printf 'PASS: unsupported strict platform refuses launch before double-fork escape\n'
 fi
 
+python3 - "${ROOT_DIR}/scripts/core/run-with-liveness-timeout-supervisor.py" <<'PY'
+import importlib.util
+import os
+import signal
+import sys
+
+spec = importlib.util.spec_from_file_location("supervisor", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+module.identity = lambda pid: 7
+original_kill = module.os.kill
+module.os.kill = lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError())
+assert module.signal_identity(101, 7, signal.SIGTERM)
+
+calls = []
+module.identity = lambda pid: 8
+module.os.kill = lambda pid, sig: calls.append((pid, sig))
+assert module.signal_identity(101, 7, signal.SIGKILL)
+assert calls == []
+
+module.identity = lambda pid: 7
+module.os.kill = lambda pid, sig: (_ for _ in ()).throw(PermissionError())
+assert not module.signal_identity(101, 7, signal.SIGTERM)
+module.os.kill = original_kill
+PY
+printf 'PASS: supervisor treats ESRCH as exited, avoids PID reuse, and fails permission denial\n'
+
+if [ "$(uname -s)" = Linux ]; then
+  HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true HOMEBOY_ACTION_CGROUP_ROOT="${TMP_DIR}/denied-cgroup" HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=5 bash "${RUNNER}" "rapid child exits" bash -c 'for _ in $(seq 1 200); do (exit 0) & done; wait' >"${TMP_DIR}/rapid.log" 2>&1
+  printf 'PASS: Linux supervisor reaps rapid child exits without signal races\n'
+fi
+
 set +e
 HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=invalid bash "${RUNNER}" "invalid timeout" bash -c 'exit 0' >"${TMP_DIR}/invalid.log" 2>&1
 exit_code=$?

--- a/scripts/core/test-select-final-results.sh
+++ b/scripts/core/test-select-final-results.sh
@@ -68,4 +68,9 @@ FIRST_RESULTS='{"review test":"pass"}' COMMANDS='review test' GITHUB_OUTPUT="${T
   GITHUB_ACTION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)" bash "${SELECT_RESULTS}" >/dev/null
 assert_equals '{"review test":"pass"}' "$(read_multiline_output "${TMP_DIR}/output" results)" "passing current results round-trip"
 
+: > "${TMP_DIR}/output"
+FIRST_RESULTS='{"review test":"timeout"}' COMMANDS='review test' GITHUB_OUTPUT="${TMP_DIR}/output" \
+  GITHUB_ACTION_PATH="$(cd "${SCRIPT_DIR}/../.." && pwd)" bash "${SELECT_RESULTS}" >/dev/null
+assert_equals '{"review test":"timeout"}' "$(read_multiline_output "${TMP_DIR}/output" results)" "timeout current results round-trip"
+
 printf 'All final-result selection checks passed.\n'

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+if ! grep -q 'name: \${{ matrix.title }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || ! grep -q 'commands: \${{ matrix.command }}' "${ROOT_DIR}/.github/workflows/ci.yml"; then
+  printf 'FAIL: reusable CI Test job does not pass its exact matrix command to the action\n'
+  exit 1
+fi
+
+mkdir -p "${TMP_DIR}/bin" "${TMP_DIR}/workspace"
+cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+mkdir -p "$(dirname "${output}")"
+printf '%s\n' '{"success":true,"data":{"test_counts":{"failed":0,"passed":1,"total":1}}}' > "${output}"
+case "${FAKE_HOMEBOY_MODE:-pass}" in
+  descendant)
+    sleep 30 &
+    printf '%s\n' "$!" > "${FAKE_HOMEBOY_CHILD_PID_FILE}"
+    printf 'test output retained\n'
+    ;;
+  timeout)
+    trap '' TERM
+    (trap '' TERM; while :; do sleep 1; done) &
+    printf '%s\n' "$!" > "${FAKE_HOMEBOY_CHILD_PID_FILE}"
+    printf 'test timeout output retained\n'
+    while :; do sleep 1; done
+    ;;
+esac
+SH
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+cd "${TMP_DIR}/workspace"
+git init -q -b main
+git config user.email test@example.com
+git config user.name test
+touch fixture
+git add fixture
+git commit -qm fixture
+git checkout -qb feature
+
+run_test_phase() {
+  local mode="$1"
+  local output_file="$2"
+  local env_file="$3"
+  PATH="${TMP_DIR}/bin:${PATH}" \
+  GITHUB_ACTION_PATH="${ROOT_DIR}" \
+  GITHUB_WORKSPACE="${TMP_DIR}/workspace" \
+  GITHUB_OUTPUT="${output_file}" \
+  GITHUB_ENV="${env_file}" \
+  RESOLVED_COMMANDS='review test' \
+  COMPONENT_NAME='fixture' \
+  HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 \
+  HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 \
+  FAKE_HOMEBOY_MODE="${mode}" \
+  FAKE_HOMEBOY_CHILD_PID_FILE="${TMP_DIR}/${mode}.pid" \
+  bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh"
+}
+
+run_test_phase descendant "${TMP_DIR}/primary-output" "${TMP_DIR}/primary-env" >"${TMP_DIR}/primary.log" 2>&1
+primary_child="$(<"${TMP_DIR}/descendant.pid")"
+if kill -0 "${primary_child}" 2>/dev/null; then
+  printf 'FAIL: exact Test command finalization left descendant %s alive\n' "${primary_child}"
+  exit 1
+fi
+if ! grep -q '^results={"review test":"pass"}$' "${TMP_DIR}/primary-output" || ! grep -q 'test output retained' "${TMP_DIR}/primary.log"; then
+  printf 'FAIL: exact Test command did not retain output and return its result\n'
+  exit 1
+fi
+
+set +e
+run_test_phase timeout "${TMP_DIR}/timeout-output" "${TMP_DIR}/timeout-env" >"${TMP_DIR}/timeout.log" 2>&1
+timeout_exit=$?
+set -e
+timeout_child="$(<"${TMP_DIR}/timeout.pid")"
+if [ "${timeout_exit}" -ne 1 ] || kill -0 "${timeout_child}" 2>/dev/null; then
+  printf 'FAIL: TERM-resistant exact Test command was not bounded and reaped\n'
+  exit 1
+fi
+if ! grep -q '^results={"review test":"timeout"}$' "${TMP_DIR}/timeout-output" || ! grep -q 'test timeout output retained' "${TMP_DIR}/timeout.log"; then
+  printf 'FAIL: exact Test timeout did not retain output and classify the timeout\n'
+  exit 1
+fi
+
+set +e
+FIRST_RESULTS='' COMMANDS='review test' GITHUB_OUTPUT="${TMP_DIR}/final-output" \
+  GITHUB_ACTION_PATH="${ROOT_DIR}" bash "${ROOT_DIR}/scripts/core/select-final-results.sh" >"${TMP_DIR}/finalize.log" 2>&1
+select_exit=$?
+RESULTS='{"review test":"fail"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' \
+  bash "${ROOT_DIR}/scripts/core/enforce-final-status.sh" >>"${TMP_DIR}/finalize.log" 2>&1
+enforce_exit=$?
+set -e
+if [ "${select_exit}" -ne 0 ] || [ "${enforce_exit}" -ne 1 ] || ! grep -q 'marking all expected commands failed' "${TMP_DIR}/finalize.log"; then
+  printf 'FAIL: Test action crash path does not fail closed during finalization\n'
+  exit 1
+fi
+printf 'PASS: reusable CI Test workflow covers command liveness, finalization, and crash-safe enforcement\n'

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -30,7 +30,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"success":true,"data":{"test_counts":{"failed":0,"passed":1,"total":1}}}' > "${output}"
+printf '%s\n' '{"schema_version":1,"command":"review test","success":true,"status":"success","exit_code":0,"data":{"test_counts":{"failed":0,"passed":1,"total":1}}}' > "${output}"
 case "${FAKE_HOMEBOY_MODE:-pass}" in
   descendant)
     sleep 30 &

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -30,7 +30,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"schema_version":1,"command":"review test","success":true,"status":"success","exit_code":0,"data":{"test_counts":{"failed":0,"passed":1,"total":1}}}' > "${output}"
+printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review test","success":true,"status":"succeeded","exit_code":0,"data":{"test_counts":{"failed":0,"passed":1,"total":1}}}' > "${output}"
 case "${FAKE_HOMEBOY_MODE:-pass}" in
   descendant)
     sleep 30 &

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -7,7 +7,11 @@ TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 if ! grep -q 'name: \${{ matrix.title }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
-  || ! grep -q 'commands: \${{ matrix.command }}' "${ROOT_DIR}/.github/workflows/ci.yml"; then
+  || ! grep -q 'commands: \${{ matrix.command }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || ! grep -q '^      execution-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || ! grep -q '^          execution-timeout-seconds: \${{ inputs.execution-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || ! grep -q '^      cleanup-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || ! grep -q '^          cleanup-timeout-seconds: \${{ inputs.cleanup-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml"; then
   printf 'FAIL: reusable CI Test job does not pass its exact matrix command to the action\n'
   exit 1
 fi

--- a/scripts/digest/generate-failure-digest.sh
+++ b/scripts/digest/generate-failure-digest.sh
@@ -22,7 +22,7 @@ append_local_reproduction_commands() {
 
   failed_commands="$(jq -r '
     to_entries[]
-    | select(.value == "fail" and (.key == "review lint" or .key == "review test"))
+    | select((.value == "fail" or .value == "timeout") and (.key == "review lint" or .key == "review test"))
     | .key
   ' <<< "${RESULTS_JSON}" 2>/dev/null || true)"
 

--- a/scripts/operations/run-operations.sh
+++ b/scripts/operations/run-operations.sh
@@ -26,6 +26,8 @@
 
 set -euo pipefail
 
+source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
+
 OPERATIONS_COMMANDS="${OPERATIONS_COMMANDS:-}"
 EXTRA_ARGS="${EXTRA_ARGS:-}"
 GROUP_PREFIX="${RUN_GROUP_PREFIX:-homeboy}"
@@ -87,9 +89,19 @@ for CMD in "${CMD_ARRAY[@]}"; do
   # Use a short label for the results key
   RESULT_KEY="${CMD}"
 
-  if [ "${CMD_EXIT}" -eq 0 ]; then
+  STRUCTURED_OUTPUT=true
+  if [ ! -s "${OUTPUT_JSON}" ] || ! valid_command_result_output "${OUTPUT_JSON}" "${CMD}" "${CMD_EXIT}"; then
+    STRUCTURED_OUTPUT=false
+    echo "::error::homeboy ${CMD} did not write valid structured output to ${OUTPUT_JSON}"
+  fi
+
+  if [ "${CMD_EXIT}" -eq 0 ] && [ "${STRUCTURED_OUTPUT}" = true ]; then
     echo "::notice::homeboy ${CMD}: PASSED"
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${RESULT_KEY}" '. + {($cmd): "pass"}')
+  elif [ "${CMD_EXIT}" -eq 0 ]; then
+    echo "::error::homeboy ${CMD}: FAILED because required structured output was missing or malformed."
+    RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${RESULT_KEY}" '. + {($cmd): "fail"}')
+    OVERALL_EXIT=1
   elif [ "${CMD_EXIT}" -eq 124 ]; then
     echo "::error::homeboy ${CMD}: TIMED OUT (exit code 124); inspect the retained command log above."
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${RESULT_KEY}" '. + {($cmd): "timeout"}')

--- a/scripts/operations/run-operations.sh
+++ b/scripts/operations/run-operations.sh
@@ -21,7 +21,7 @@
 #   RUN_GROUP_PREFIX    — log group prefix (default: homeboy)
 #
 # Outputs (GITHUB_OUTPUT):
-#   results — JSON object { "fleet exec ...": "pass"|"fail", ... }
+#   results — JSON object { "fleet exec ...": "pass"|"fail"|"timeout", ... }
 #   any-failed — true|false
 
 set -euo pipefail
@@ -76,8 +76,11 @@ for CMD in "${CMD_ARRAY[@]}"; do
   echo "::group::${GROUP_PREFIX} ${CMD}"
   CMD_EXIT=0
   set +e
-  eval "${FULL_CMD}" 2>&1 | tee "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log"
-  CMD_EXIT=${PIPESTATUS[0]}
+  bash "${GITHUB_ACTION_PATH}/scripts/core/run-with-liveness-timeout.sh" \
+    --log-file "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log" \
+    "operations homeboy ${CMD}" bash -c "${FULL_CMD}"
+  CMD_EXIT=$?
+  cat "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log"
   set -e
   echo "::endgroup::"
 
@@ -87,6 +90,10 @@ for CMD in "${CMD_ARRAY[@]}"; do
   if [ "${CMD_EXIT}" -eq 0 ]; then
     echo "::notice::homeboy ${CMD}: PASSED"
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${RESULT_KEY}" '. + {($cmd): "pass"}')
+  elif [ "${CMD_EXIT}" -eq 124 ]; then
+    echo "::error::homeboy ${CMD}: TIMED OUT (exit code 124); inspect the retained command log above."
+    RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${RESULT_KEY}" '. + {($cmd): "timeout"}')
+    OVERALL_EXIT=1
   else
     echo "::error::homeboy ${CMD}: FAILED (exit code ${CMD_EXIT})"
     RESULTS=$(echo "${RESULTS}" | jq -c --arg cmd "${RESULT_KEY}" '. + {($cmd): "fail"}')

--- a/scripts/operations/test-run-operations.sh
+++ b/scripts/operations/test-run-operations.sh
@@ -10,38 +10,61 @@ mkdir -p "${TMP_DIR}/bin"
 cat > "${TMP_DIR}/bin/homeboy" <<'SH'
 #!/usr/bin/env bash
 
-trap '' TERM
-(trap '' TERM; while :; do sleep 1; done) &
-printf 'operations output retained\n'
-while :; do sleep 1; done
+output=""
+command=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) command+=("$1"); shift ;;
+  esac
+done
+mkdir -p "$(dirname "${output}")"
+command_string="${command[*]}"
+case "${FAKE_OPERATION_MODE:-valid}" in
+  valid) printf '{"schema":"homeboy/command-result/v3","command":"%s","success":true,"status":"succeeded","exit_code":0,"data":{}}\n' "${command_string}" > "${output}" ;;
+  missing) : ;;
+  malformed) printf '%s\n' '{}' > "${output}" ;;
+  wrong-command) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"fleet wrong","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
+  timeout)
+    trap '' TERM
+    (trap '' TERM; while :; do sleep 1; done) &
+    printf 'operations output retained\n'
+    while :; do sleep 1; done
+    ;;
+esac
 SH
 chmod +x "${TMP_DIR}/bin/homeboy"
 
-set +e
-PATH="${TMP_DIR}/bin:${PATH}" \
-GITHUB_ACTION_PATH="${ROOT_DIR}" \
-GITHUB_OUTPUT="${TMP_DIR}/github-output" \
-OPERATIONS_COMMANDS='fleet status fixture' \
-HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 \
-HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 \
-bash "${ROOT_DIR}/scripts/operations/run-operations.sh" >"${TMP_DIR}/run.log" 2>&1
-exit_code=$?
-set -e
+run_operation() {
+  local command="$1" mode="$2" output_file="$3"
+  set +e
+  PATH="${TMP_DIR}/bin:${PATH}" GITHUB_ACTION_PATH="${ROOT_DIR}" GITHUB_OUTPUT="${output_file}" OPERATIONS_COMMANDS="${command}" FAKE_OPERATION_MODE="${mode}" HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 bash "${ROOT_DIR}/scripts/operations/run-operations.sh" >"${output_file}.log" 2>&1
+  local exit_code=$?
+  set -e
+  printf '%s\n' "${exit_code}"
+}
 
-if [ "${exit_code}" -ne 1 ]; then
-  printf 'FAIL: timed out operation exits 1, got %s\n' "${exit_code}"
+for command in 'fleet status fixture' 'deploy fixture --all' 'release fixture'; do
+  output_file="${TMP_DIR}/$(printf '%s' "${command}" | tr ' ' '-')"
+  if [ "$(run_operation "${command}" valid "${output_file}")" -ne 0 ] || ! grep -Fq "\"${command}\":\"pass\"" "${output_file}"; then
+    printf 'FAIL: valid %s operation did not pass exact envelope validation\n' "${command}"
+    exit 1
+  fi
+done
+printf 'PASS: fleet, deploy, and release operations validate exact v3 envelopes\n'
+
+for mode in missing malformed wrong-command; do
+  output_file="${TMP_DIR}/${mode}"
+  if [ "$(run_operation 'fleet status fixture' "${mode}" "${output_file}")" -ne 1 ] || ! grep -q '"fleet status fixture":"fail"' "${output_file}" || ! grep -q 'did not write valid structured output' "${output_file}.log"; then
+    printf 'FAIL: zero-exit %s operation envelope did not fail closed\n' "${mode}"
+    exit 1
+  fi
+done
+printf 'PASS: missing, malformed, and wrong-command operation envelopes fail closed with retained logs\n'
+
+output_file="${TMP_DIR}/timeout"
+if [ "$(run_operation 'fleet status fixture' timeout "${output_file}")" -ne 1 ] || ! grep -q '"fleet status fixture":"timeout"' "${output_file}" || ! grep -q 'operations output retained' "${output_file}.log"; then
+  printf 'FAIL: timed out operation did not retain logs and classify timeout\n'
   exit 1
 fi
-if ! grep -q '^results={"fleet status fixture":"timeout"}$' "${TMP_DIR}/github-output"; then
-  printf 'FAIL: timed out operation is not classified for final enforcement\n'
-  exit 1
-fi
-if ! grep -q 'operations homeboy fleet status fixture exceeded its 1s execution timeout' "${TMP_DIR}/run.log"; then
-  printf 'FAIL: timed out operation lacks liveness timeout evidence\n'
-  exit 1
-fi
-if ! grep -q 'operations output retained' "${TMP_DIR}/run.log"; then
-  printf 'FAIL: timed out operation did not preserve its command log\n'
-  exit 1
-fi
-printf 'PASS: operations command has bounded liveness, process-group cleanup, and timeout classification\n'
+printf 'PASS: timed out operation preserves retained logs and timeout classification\n'

--- a/scripts/operations/test-run-operations.sh
+++ b/scripts/operations/test-run-operations.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+
+trap '' TERM
+(trap '' TERM; while :; do sleep 1; done) &
+printf 'operations output retained\n'
+while :; do sleep 1; done
+SH
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+set +e
+PATH="${TMP_DIR}/bin:${PATH}" \
+GITHUB_ACTION_PATH="${ROOT_DIR}" \
+GITHUB_OUTPUT="${TMP_DIR}/github-output" \
+OPERATIONS_COMMANDS='fleet status fixture' \
+HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1 \
+HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 \
+bash "${ROOT_DIR}/scripts/operations/run-operations.sh" >"${TMP_DIR}/run.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "${exit_code}" -ne 1 ]; then
+  printf 'FAIL: timed out operation exits 1, got %s\n' "${exit_code}"
+  exit 1
+fi
+if ! grep -q '^results={"fleet status fixture":"timeout"}$' "${TMP_DIR}/github-output"; then
+  printf 'FAIL: timed out operation is not classified for final enforcement\n'
+  exit 1
+fi
+if ! grep -q 'operations homeboy fleet status fixture exceeded its 1s execution timeout' "${TMP_DIR}/run.log"; then
+  printf 'FAIL: timed out operation lacks liveness timeout evidence\n'
+  exit 1
+fi
+if ! grep -q 'operations output retained' "${TMP_DIR}/run.log"; then
+  printf 'FAIL: timed out operation did not preserve its command log\n'
+  exit 1
+fi
+printf 'PASS: operations command has bounded liveness, process-group cleanup, and timeout classification\n'

--- a/scripts/pr/comment/lib.sh
+++ b/scripts/pr/comment/lib.sh
@@ -83,7 +83,7 @@ summary_json_for_command() {
 
 command_status() {
   local command="$1"
-  echo "${RESULTS}" | jq -r --arg cmd "${command}" 'if .[$cmd] == "pass" or .[$cmd] == "fail" or .[$cmd] == "baseline_red" or .[$cmd] == "inconclusive" then .[$cmd] else "unknown" end' 2>/dev/null || echo "unknown"
+  echo "${RESULTS}" | jq -r --arg cmd "${command}" 'if .[$cmd] == "pass" or .[$cmd] == "fail" or .[$cmd] == "timeout" or .[$cmd] == "baseline_red" or .[$cmd] == "inconclusive" then .[$cmd] else "unknown" end' 2>/dev/null || echo "unknown"
 }
 
 is_refactor_owning_section() {

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -66,7 +66,7 @@ append_review_report_section() {
 status_icon() {
   case "$1" in
     pass|passed) printf '%s\n' ':white_check_mark:' ;;
-    fail|failed) printf '%s\n' ':x:' ;;
+    fail|failed|timeout) printf '%s\n' ':x:' ;;
     baseline_red|inconclusive) printf '%s\n' ':warning:' ;;
     skipped) printf '%s\n' ':fast_forward:' ;;
     *) printf '%s\n' ':warning:' ;;
@@ -77,6 +77,7 @@ status_label() {
   case "$1" in
     pass|passed) printf '%s\n' 'passed' ;;
     fail|failed) printf '%s\n' 'failed' ;;
+    timeout) printf '%s\n' 'timed out' ;;
     baseline_red) printf '%s\n' 'baseline red' ;;
     inconclusive) printf '%s\n' 'inconclusive' ;;
     skipped) printf '%s\n' 'skipped' ;;

--- a/scripts/pr/comment/test-app-token-required.sh
+++ b/scripts/pr/comment/test-app-token-required.sh
@@ -34,8 +34,12 @@ action_yml="$(python3 - "${ROOT}/action.yml" <<'PY'
 import sys
 
 text = open(sys.argv[1], encoding="utf-8").read()
-start = text.index("    - name: Post PR comment")
-end = text.index("    # ── Phase 8", start)
+start = text.find("    - name: Post PR comment")
+if start < 0:
+    raise SystemExit("FAIL: action.yml is missing the Post PR comment action section")
+end = text.find("    # ── Phase 7: Auto-issue filing", start)
+if end < 0:
+    raise SystemExit("FAIL: action.yml is missing the Auto-issue filing section after Post PR comment")
 print(text[start:end])
 PY
 )"


### PR DESCRIPTION
Closes Extra-Chill/homeboy#7941

#295 bounded differential baseline commands, but did not provide an end-to-end Test action proof, preserve a distinct timeout result through finalization, or bound the remaining operations command runner. This completes the action-owned contract.

## Changes
- Preserve exit 124 as `timeout` through quality/baseline/operations results, final selection, enforcement, failure digests, and PR comments.
- Route operations through the existing process-group-aware liveness wrapper and pass both timeout inputs into that phase.
- Add an integration contract for the reusable CI Test `review test` path: retained logs, finalization, TERM-resistant descendants, timeout classification, and no-result crash-safe final enforcement.
- Repair the #292 bare quality command differential-gate contract and #293 app-token test anchor failure so the full suite completes.

## Verification
- `for test in scripts/**/test-*.sh(N); do bash "$test" || exit 1; done && python3 scripts/core/test-differential-gate.py && git diff --check`
- The Test and operations integration tests use real TERM-resistant parent/descendant processes, require bounded completion, verify no surviving child PID, and assert retained logs.

## AI assistance
OpenCode using openai/gpt-5.6-sol traced the incomplete liveness/result contract, wrote the implementation and deterministic integration coverage, and reviewed the resulting diff. Chris remains responsible for every line.