### PR TITLE
fix: validate command result envelopes against the command root

### DIFF
--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -238,8 +238,14 @@ settings_json_flags() {
 
 valid_command_result_output() {
   local output_file="$1" expected_command="$2" command_exit="$3"
+  # Homeboy reports the top-level command in the result envelope (`review`),
+  # never the full CI command string (`review lint`). Compare the command root
+  # so the envelope still proves ownership by this invocation without asserting
+  # a subcommand field the binary does not emit.
+  local expected_root
+  expected_root="$(printf '%s' "${expected_command}" | awk '{print $1}')"
   jq -e \
-    --arg command "${expected_command}" \
+    --arg command "${expected_root}" \
     --argjson command_exit "${command_exit}" '
       type == "object"
       and .schema == "homeboy/command-result/v3"

--- a/scripts/core/test-placement-compatibility.sh
+++ b/scripts/core/test-placement-compatibility.sh
@@ -68,7 +68,7 @@ while [ "$#" -gt 0 ]; do
   fi
   shift
 done
-  [ -z "${output}" ] || printf '{"schema":"homeboy/command-result/v3","command":"review audit","success":true,"status":"succeeded","exit_code":0,"data":{}}\n' > "${output}"
+  [ -z "${output}" ] || printf '{"schema":"homeboy/command-result/v3","command":"review","success":true,"status":"succeeded","exit_code":0,"data":{}}\n' > "${output}"
 SH
 chmod +x "${FAKE_BIN}/homeboy"
 

--- a/scripts/core/test-run-baseline-commands.sh
+++ b/scripts/core/test-run-baseline-commands.sh
@@ -25,7 +25,7 @@ mkdir -p "$(dirname "${output}")"
 case "${FAKE_HOMEBOY_MODE:-}" in
   missing) : ;;
   malformed) printf '%s\n' 'not json' > "${output}" ;;
-  *) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review test","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
+  *) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
 esac
 
 case "${FAKE_HOMEBOY_MODE:-}" in

--- a/scripts/core/test-run-homeboy-commands.sh
+++ b/scripts/core/test-run-homeboy-commands.sh
@@ -19,7 +19,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review test","success":false,"status":"failed","exit_code":1,"data":{"test_counts":{"failed":2,"passed":41,"total":43}}}' > "${output}"
+printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review","success":false,"status":"failed","exit_code":1,"data":{"test_counts":{"failed":2,"passed":41,"total":43}}}' > "${output}"
 exit 1
 SH
 chmod +x "${TMP_DIR}/bin/homeboy"
@@ -92,8 +92,8 @@ done
 mkdir -p "$(dirname "${output}")"
 case "${FAKE_ENVELOPE_MODE}" in
   empty) printf '%s\n' '{}' > "${output}" ;;
-  wrong-command) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review audit","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
-  inconsistent) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review test","success":true,"status":"succeeded","exit_code":1,"data":{}}' > "${output}" ;;
+  wrong-command) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"deploy","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
+  inconsistent) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review","success":true,"status":"succeeded","exit_code":1,"data":{}}' > "${output}" ;;
 esac
 exit 0
 SH
@@ -108,6 +108,44 @@ SH
   fi
 done
 printf 'PASS: empty, wrong-command, and inconsistent envelopes fail closed\n'
+
+# Regression: real homeboy reports the top-level command (`review`) in the
+# envelope, never the full CI command string (`review lint`). Asserting the
+# full string turned every passing review gate into a red release run.
+cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$(dirname "${output}")"
+printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review","success":true,"status":"succeeded","exit_code":0,"data":{"status":"passed","findings":[]}}' > "${output}"
+exit 0
+SH
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+set +e
+PATH="${TMP_DIR}/bin:${PATH}" \
+GITHUB_ACTION_PATH="${ROOT_DIR}" \
+GITHUB_WORKSPACE="${TMP_DIR}/workspace" \
+GITHUB_OUTPUT="${TMP_DIR}/root-command-output" \
+GITHUB_ENV="${TMP_DIR}/root-command-env" \
+RESOLVED_COMMANDS='review lint' \
+COMPONENT_NAME='homeboy-action' \
+bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/root-command.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "${exit_code}" -ne 0 ] || ! grep -q '^results={"review lint":"pass"}$' "${TMP_DIR}/root-command-output"; then
+  printf 'FAIL: subcommand gate rejects the top-level command reported by real homeboy\n'
+  cat "${TMP_DIR}/root-command.log"
+  exit 1
+fi
+printf 'PASS: subcommand gate accepts the top-level command homeboy actually reports\n'
 
 cat > "${TMP_DIR}/bin/homeboy" <<'SH'
 #!/usr/bin/env bash

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -30,7 +30,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review test","success":true,"status":"succeeded","exit_code":0,"data":{"test_counts":{"failed":0,"passed":1,"total":1}}}' > "${output}"
+printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review","success":true,"status":"succeeded","exit_code":0,"data":{"test_counts":{"failed":0,"passed":1,"total":1}}}' > "${output}"
 case "${FAKE_HOMEBOY_MODE:-pass}" in
   descendant)
     sleep 30 &

--- a/scripts/operations/test-run-operations.sh
+++ b/scripts/operations/test-run-operations.sh
@@ -19,12 +19,14 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 mkdir -p "$(dirname "${output}")"
-command_string="${command[*]}"
+# Real homeboy reports only the top-level command in the envelope, so the fake
+# mirrors that contract instead of echoing the full command string back.
+command_root="${command[0]}"
 case "${FAKE_OPERATION_MODE:-valid}" in
-  valid) printf '{"schema":"homeboy/command-result/v3","command":"%s","success":true,"status":"succeeded","exit_code":0,"data":{}}\n' "${command_string}" > "${output}" ;;
+  valid) printf '{"schema":"homeboy/command-result/v3","command":"%s","success":true,"status":"succeeded","exit_code":0,"data":{}}\n' "${command_root}" > "${output}" ;;
   missing) : ;;
   malformed) printf '%s\n' '{}' > "${output}" ;;
-  wrong-command) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"fleet wrong","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
+  wrong-command) printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"deploy","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}" ;;
   timeout)
     trap '' TERM
     (trap '' TERM; while :; do sleep 1; done) &


### PR DESCRIPTION
## Problem

Homeboy `main` has been red on every release run since homeboy-action **v2.8.22**. Lint and Test are release-blocking, so `Release Quality Policy` refuses every push:

```
##[error]homeboy review lint did not write valid structured output to /tmp/.../review-lint.json
##[error]homeboy review lint: FAILED because required structured output was missing or malformed.
```

The underlying command *passed*. From the same job's log:

```json
{ "schema": "homeboy/command-result/v3", "command": "review",
  "success": true, "exit_code": 0, "status": "succeeded",
  "data": { "findings": [], "passed": true, "status": "passed" } }
```

## Root cause

`valid_command_result_output()` (added in c207dbc, shipped in v2.8.22) asserts:

```
.command == $expected_command    # "review lint"
```

Real homeboy reports only the **top-level** command in the envelope. Verified against the actual binary:

```console
$ homeboy --output out.json review audit homeboy-action --path .
$ jq -c '{schema, command, success, status, exit_code}' out.json
{"schema":"homeboy/command-result/v3","command":"review","success":true,"status":"succeeded","exit_code":0}
```

Every other clause in the check (schema, success/status/exit_code consistency) matches real output — including the failure path (`success:false, status:"failed", exit_code:4`). `.command` was the only fictional assertion, and it can never hold for a multi-word CI command.

This affects `review audit`, `review lint`, and `review test` alike. Audit only looked green because it is non-blocking; its log shows the same error.

## Why tests didn't catch it

Every fake `homeboy` in the action's test suite echoed the full command string back into `.command`, encoding a contract the binary does not implement. The check was only ever validated against stubs built to satisfy it.

## Fix

- Compare `.command` against the **command root** (first token). This still proves the output file belongs to this invocation — a stale file from a different top-level command is rejected — without asserting a subcommand field homeboy does not emit.
- Correct the fakes to mirror real homeboy output.
- Repoint the negative `wrong-command` cases at a genuinely different root (`deploy`) so they keep failing closed.
- Add a regression test: a `review lint` run whose envelope reports `command: "review"` must pass.

## Verification

The new test fails on `main` and passes with the fix:

```
# with scripts/core/lib.sh reverted to main
FAIL: subcommand gate rejects the top-level command reported by real homeboy

# with the fix
PASS: subcommand gate accepts the top-level command homeboy actually reports
```

Full shell suite run locally — 25/26 scripts pass. The one failure, `test-run-with-liveness-timeout.sh` ("cgroup-denied Linux supervisor did not contain immediate double-fork escape"), reproduces identically on pristine `main` and is unrelated to this change.
