### PR TITLE
fix: survive processes exiting during supervisor /proc scan

### DIFF
--- a/scripts/core/run-with-liveness-timeout-supervisor.py
+++ b/scripts/core/run-with-liveness-timeout-supervisor.py
@@ -28,7 +28,11 @@ def descendants(root):
         try:
             fields = open(f"/proc/{entry.name}/stat", encoding="utf-8").read().split()
             children.setdefault(int(fields[3]), []).append(int(entry.name))
-        except (FileNotFoundError, IndexError, ValueError):
+        except (FileNotFoundError, ProcessLookupError, PermissionError, IndexError, ValueError):
+            # A process that exits between scandir and read surfaces as ESRCH
+            # (ProcessLookupError), not just ENOENT. Scanning all of /proc means
+            # this race is routine; letting it escape kills the supervisor and
+            # orphans the very descendants it exists to contain.
             continue
     result, pending = set(), [root]
     while pending:

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -137,8 +137,28 @@ if original_send is None:
     del module.signal.pidfd_send_signal
 else:
     module.signal.pidfd_send_signal = original_send
+
+# A process that exits mid-scan makes /proc/<pid>/stat raise ESRCH, not ENOENT.
+# Letting that escape killed the supervisor and orphaned the descendants it
+# exists to contain, so descendants() must skip the racing entry and still
+# report the ones it can read.
+real_open = open
+
+
+def racing_open(path, *args, **kwargs):
+    if path == f"/proc/{os.getpid()}/stat":
+        raise ProcessLookupError()
+    return real_open(path, *args, **kwargs)
+
+
+module.open = racing_open
+observed = module.descendants(1)
+del module.open
+assert isinstance(observed, set)
+assert os.getpid() not in observed
 PY
 printf 'PASS: supervisor treats pidfd ESRCH as exited, avoids PID reuse, and fails permission denial\n'
+printf 'PASS: supervisor scan survives processes exiting mid-scan\n'
 
 if [ "$(uname -s)" = Linux ]; then
   HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true HOMEBOY_ACTION_CGROUP_ROOT="${TMP_DIR}/denied-cgroup" HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=5 bash "${RUNNER}" "rapid child exits" bash -c 'for _ in $(seq 1 200); do (exit 0) & done; wait' >"${TMP_DIR}/rapid.log" 2>&1


### PR DESCRIPTION
## Problem

The release **Test** job on homeboy `main` dies mid-run. From run [30167365605](https://github.com/Extra-Chill/homeboy/actions/runs/30167365605):

```
Traceback (most recent call last):
  File ".../scripts/core/run-with-liveness-timeout-supervisor.py", line 196, in <module>
    raise SystemExit(main())
  File ".../scripts/core/run-with-liveness-timeout-supervisor.py", line 166, in main
    if not observe():
  File ".../scripts/core/run-with-liveness-timeout-supervisor.py", line 128, in observe
    observed = descendants(os.getpid())
  File ".../scripts/core/run-with-liveness-timeout-supervisor.py", line 29, in descendants
    fields = open(f"/proc/{entry.name}/stat", encoding="utf-8").read().split()
ProcessLookupError: [Errno 3] No such process
```

The supervisor died while `cargo test` was still compiling. The observation artifact records the run as never finishing:

```json
{ "command": "homeboy test homeboy --skip-lint --changed-since=...",
  "exit_code": null, "status": "running", "test_counts": null }
```

and the runner cleaned up the orphans it left behind:

```
Cleaning up orphan processes
Terminate orphan process: pid (2721) (cargo)
```

## Root cause

`descendants()` scans **every** entry in `/proc`. A process that exits between `os.scandir()` and the read of `/proc/<pid>/stat` surfaces as **ESRCH** (`ProcessLookupError`), not ENOENT (`FileNotFoundError`). Only the latter was handled, so the exception escaped and killed the supervisor.

The sibling `identity()` helper directly above already catches `ProcessLookupError` for this exact reason — the scan loop simply missed it. On a busy CI runner mid-`cargo` this race is routine, which is why it surfaces as an intermittent, unattributable "test phase failed without structured counts".

## Fix

Skip per-process artifacts (ESRCH, ENOENT, EACCES) so the scan tolerates routine churn.

Deliberately **not** a blanket `except OSError`: process-independent failures such as fd exhaustion must stay visible, since silently swallowing them would shrink the descendant set and weaken the containment this supervisor exists to provide.

## Verification

Added a unit case to the existing supervisor test block that makes `/proc/<pid>/stat` raise `ProcessLookupError` mid-scan.

Against pristine `main` it reproduces the CI traceback exactly:

```
  File ".../run-with-liveness-timeout-supervisor.py", line 29, in descendants
    fields = open(f"/proc/{entry.name}/stat", encoding="utf-8").read().split()
ProcessLookupError
```

With the fix, `descendants()` skips the racing entry and returns the rest.

> Note: `test-run-with-liveness-timeout.sh` cannot run to completion on my local box — it aborts earlier at "cgroup-denied Linux supervisor did not contain immediate double-fork escape", which reproduces identically on pristine `main` and is unrelated to this change. The new assertions were therefore executed standalone against both the pristine and patched supervisor.

## Related

This is the second of two independent causes of red `main`. The other is #297 (command-result envelope validation); both are needed for a green release run.