### PR TITLE
fix: fail closed when a strict command leaks force-killed descendants

### DIFF
--- a/scripts/core/run-with-liveness-timeout-supervisor.py
+++ b/scripts/core/run-with-liveness-timeout-supervisor.py
@@ -185,7 +185,9 @@ def main():
     if not observe() or known_live(known) is None:
         close_pidfds(known)
         return 125
+    leaked_containment = False
     if known_live(known):
+        leaked_containment = True
         if not terminate("finalization found live command containment"):
             close_pidfds(known)
             return 125
@@ -193,7 +195,16 @@ def main():
     close_pidfds(known)
     if output:
         output.close()
-    return 124 if timed_out else exit_code
+    if timed_out:
+        return 124
+    # A command that outlived its own exit by leaking descendants we had to
+    # force-terminate did not finish cleanly, whatever it reported. Strict mode
+    # exists to prove containment, so refuse to launder that into a pass. A real
+    # non-zero exit still wins: it is more actionable than a synthetic timeout.
+    if leaked_containment and exit_code == 0:
+        print(f"::error::{args.label} leaked descendants that outlived the command; reporting containment failure.")
+        return 124
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -111,6 +111,28 @@ else
   printf 'PASS: unsupported strict platform refuses launch before double-fork escape\n'
 fi
 
+# Containment failure must not swallow ordinary outcomes: a strict command that
+# leaves nothing behind still reports its own exit code, success or failure.
+if [ "$(uname -s)" = Linux ]; then
+  set +e
+  HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=30 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 bash "${RUNNER}" "strict clean" bash -c 'exit 0' >"${TMP_DIR}/strict-clean.log" 2>&1
+  clean_exit=$?
+  HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF=true HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=30 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 bash "${RUNNER}" "strict failing" bash -c 'exit 3' >"${TMP_DIR}/strict-failing.log" 2>&1
+  failing_exit=$?
+  set -e
+  if [ "${clean_exit}" -ne 0 ]; then
+    printf 'FAIL: strict clean command reported %s instead of success\n' "${clean_exit}"
+    cat "${TMP_DIR}/strict-clean.log"
+    exit 1
+  fi
+  if [ "${failing_exit}" -ne 3 ]; then
+    printf 'FAIL: strict failing command reported %s instead of its own exit code\n' "${failing_exit}"
+    cat "${TMP_DIR}/strict-failing.log"
+    exit 1
+  fi
+  printf 'PASS: strict commands without leaked descendants report their own exit codes\n'
+fi
+
 python3 - "${ROOT_DIR}/scripts/core/run-with-liveness-timeout-supervisor.py" <<'PY'
 import importlib.util
 import os


### PR DESCRIPTION
Fixes #299.

## Problem

`scripts/core/test-run-with-liveness-timeout.sh` fails on pristine `main`, and because the script runs under `set -e` it aborts there — **silently skipping five later assertions**, including the pidfd ESRCH and mid-scan race coverage added in #298.

Isolating the failing case (double-forked, `SIGTERM`-ignoring escapee; 1s timeout):

```
exit=0
::warning::strict double-fork finalization found live command containment; terminating supervised descendants by pidfd.
::warning::strict double-fork containment grace expired; sending SIGKILL by pidfd.
```

Containment *works* — the escapee is detected and killed. The exit code is the bug: `0`, not `124`.

## Root cause

The supervisor watches only the **direct** child:

```python
while process.poll() is None:
    if elapsed >= args.timeout:
        timed_out = True
```

The forking parent calls `sys.exit(0)`, so the direct child is gone in ~30ms. The loop never reaches the timeout, `timed_out` stays `False`, and:

```python
return 124 if timed_out else exit_code   # -> 0
```

Finalization detects the survivor and SIGKILLs it, then throws that fact away. A command that leaked a descendant which **ignored SIGTERM and had to be force-killed** is reported as a clean pass — the inverse of the guarantee `require_containment_proof` exists to provide, and the same shape as the orphaned-`cargo` failures that made homeboy's Test gate report no structured counts.

Not environment-specific: the assertion cannot pass with the current loop on any machine.

## Why it was invisible

homeboy-action's release workflow runs only `Check for releasable commits` + `Release`. **Nothing executes `scripts/**/test-*.sh` in CI**, so a permanently-red self-test went unnoticed.

## Fix

Report a containment failure rather than success when finalization had to terminate surviving descendants. A genuine non-zero exit still wins — a real failure is more actionable than a synthetic timeout.

Strict mode covers quality commands, baseline commands, and fleet/deploy operations (`action.yml:488,563,627`); none should leave live descendants.

## Verification

Added a guard for the obvious over-fire risk — that clean and failing strict commands still report **their own** exit codes. It genuinely constrains the fix: stubbing the condition to `if exit_code == 0` (dropping the leak check) fails it immediately:

```
FAIL: strict clean command reported 124 instead of success
```

Full suite, all 26 shell test scripts:

```
pass=26 fail=0 total=26
```

`test-run-with-liveness-timeout.sh` now runs end to end — 12 assertions including the 5 previously skipped:

```
PASS: cgroup-denied Linux supervisor contains immediate double-fork escape
PASS: strict commands without leaked descendants report their own exit codes
PASS: supervisor treats pidfd ESRCH as exited, avoids PID reuse, and fails permission denial
PASS: supervisor scan survives processes exiting mid-scan
PASS: Linux supervisor reaps rapid child exits without signal races
PASS: invalid timeout is rejected
PASS: action applies bounded execution to each quality and baseline command
```

## Follow-up worth considering

These scripts not running in CI is the reason both this and the #297 envelope regression shipped. Wiring `scripts/**/test-*.sh` into the release workflow would close that gap — happy to do it in a separate PR.