### PR TITLE
ci: gate releases on the action's own shell tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,22 @@ jobs:
             echo "::notice::Release dry-run predicts v${RELEASE_VERSION} (${BUMP_TYPE})"
           fi
 
-  # ── Step 2: Release ──
+  # ── Step 2: Shell tests ──
+  # Release-blocking. Publishing moves the floating v2 tag, so a regression
+  # here breaks every consumer at once — gate the tag move on the action's
+  # own tests passing.
+  self-test:
+    name: Self test
+    needs: check
+    if: needs.check.outputs.should-release == 'true'
+    uses: ./.github/workflows/self-test.yml
+
+  # ── Step 3: Release ──
   release:
     name: Release
-    needs: check
+    needs:
+      - check
+      - self-test
     if: needs.check.outputs.should-release == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -1,0 +1,33 @@
+# Validation for Homeboy Action's own shell implementation.
+#
+# Distinct from ci.yml, which is the reusable quality workflow this repo
+# publishes for consumers. This one tests the action itself.
+#
+# A release here re-points the floating `v2` tag, so a regression breaks every
+# consumer at once with zero commits in their repositories. These tests are
+# pure bash — no cargo, no network, no homeboy binary (each script stubs its
+# own fake) — so they are cheap enough to gate both pull requests and release.
+
+name: Self Test
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  workflow_call:
+
+concurrency:
+  group: self-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-tests:
+    name: Shell tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run action shell tests
+        run: bash scripts/run-tests.sh

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -27,7 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Full history: the scope tests resolve real revisions (`HEAD~1`) against
+      # this checkout, which a shallow clone cannot provide.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run action shell tests
         run: bash scripts/run-tests.sh

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKFLOW="${ROOT_DIR}/.github/workflows/release.yml"
 CI_WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
+SELF_TEST_WORKFLOW="${ROOT_DIR}/.github/workflows/self-test.yml"
 RUN_RELEASE="${ROOT_DIR}/scripts/release/run-release.sh"
 README="${ROOT_DIR}/README.md"
 COMMENT_SECTIONS="${ROOT_DIR}/scripts/pr/comment/sections.sh"
@@ -66,6 +67,13 @@ assert_count 'actions/checkout@v4' '3' "${WORKFLOW}" "release workflow uses chec
 assert_count 'actions/create-github-app-token@v2' '1' "${WORKFLOW}" "release workflow uses app-token v2"
 assert_not_contains 'actions/checkout@v6' "${WORKFLOW}" "release workflow does not use unavailable checkout v6"
 assert_not_contains 'actions/create-github-app-token@v3' "${WORKFLOW}" "release workflow does not use unavailable app-token v3"
+
+# Releasing moves the floating v2 tag, so the action's own shell tests must
+# gate publication rather than running advisory-only (or not at all).
+assert_contains 'uses: ./.github/workflows/self-test.yml' "${WORKFLOW}" "release workflow runs the action self-test suite"
+assert_contains '      - self-test' "${WORKFLOW}" "release job is gated on the self-test suite"
+assert_contains 'bash scripts/run-tests.sh' "${SELF_TEST_WORKFLOW}" "self-test workflow runs every action shell test"
+assert_contains 'pull_request' "${SELF_TEST_WORKFLOW}" "self-test workflow also guards pull requests"
 
 assert_contains 'uses: ./' "${WORKFLOW}" "release workflow uses checked-out action code for self-release"
 assert_not_contains 'Extra-Chill/homeboy-action@v2' "${WORKFLOW}" "release workflow is not bootstrapped from the stale floating v2 channel"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Runs every action shell test script and reports one aggregate result.
+#
+# The action's tests are plain bash — no cargo, no network, no homeboy binary
+# (each script stubs its own fake). They are cheap enough to gate every PR and
+# every release on, which is the point: regressions in this repo re-point the
+# floating `v2` tag and break every consumer at once.
+#
+# Each script runs under a timeout so a hung supervisor test cannot wedge CI,
+# and all scripts run even after one fails so a single break does not hide the
+# rest.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+per_test_timeout="${HOMEBOY_ACTION_TEST_TIMEOUT_SECONDS:-600}"
+
+mapfile -t tests < <(find scripts -mindepth 2 -maxdepth 2 -name 'test-*.sh' -type f | sort)
+
+if [ "${#tests[@]}" -eq 0 ]; then
+  echo "::error::No action test scripts found under scripts/*/test-*.sh"
+  exit 1
+fi
+
+passed=0
+failed_tests=()
+
+for test in "${tests[@]}"; do
+  echo "::group::${test}"
+  start="$(date +%s)"
+  timeout "${per_test_timeout}" bash "${test}"
+  status=$?
+  elapsed=$(( $(date +%s) - start ))
+  echo "::endgroup::"
+
+  if [ "${status}" -eq 0 ]; then
+    passed=$((passed + 1))
+    printf 'PASS  %s (%ss)\n' "${test}" "${elapsed}"
+  elif [ "${status}" -eq 124 ]; then
+    failed_tests+=("${test}")
+    echo "::error::${test} timed out after ${per_test_timeout}s"
+  else
+    failed_tests+=("${test}")
+    echo "::error::${test} failed (exit ${status})"
+  fi
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+printf '  Action shell tests: %s passed, %s failed, %s total\n' \
+  "${passed}" "${#failed_tests[@]}" "${#tests[@]}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "${#failed_tests[@]}" -ne 0 ]; then
+  for test in "${failed_tests[@]}"; do
+    printf '  FAILED  %s\n' "${test}"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Problem

**Nothing in this repo ever ran `scripts/**/test-*.sh`.** The release workflow had exactly two jobs — `Check for releasable commits` and `Release` — and there was no `pull_request` trigger at all. Every change went straight to the floating `v2` tag with zero validation.

That is the common cause behind two breaks landed this week:

- **#297** — `valid_command_result_output()` asserted a `.command` field real homeboy never emits, so every passing `review audit/lint/test` gate was reported as a failure. It broke homeboy `main` on every release run from v2.8.22 onward. The action's own tests "passed" because each fake `homeboy` stub echoed the fictional contract back.
- **#299** — the strict supervisor reported success for a command that leaked a `SIGTERM`-ignoring descendant it had to SIGKILL. Its self-test had been failing on pristine `main` the entire time; nobody saw it because nothing ran it.

Because a release here re-points `v2`, a regression breaks every consumer at once with zero commits in their repositories.

## Change

**`scripts/run-tests.sh`** — runs every `scripts/*/test-*.sh`:
- each under a timeout (`HOMEBOY_ACTION_TEST_TIMEOUT_SECONDS`, default 600) so a hung supervisor test cannot wedge CI
- continues past failures so one break cannot hide the rest — this repo has a real history of `set -e` in a test file silently skipping later assertions
- fails closed if it discovers zero test scripts
- prints an aggregate summary and lists every failure

**`.github/workflows/self-test.yml`** — runs it on `pull_request` and exposes `workflow_call`.

**`release.yml`** — new release-blocking `self-test` job; `release` now needs `[check, self-test]`.

Named `self-test.yml` deliberately: `ci.yml` is the **reusable quality workflow this repo publishes for consumers**, not its own CI. It is untouched.

**`test-release-workflow.sh`** — asserts the wiring (self-test invoked, release gated on it, runner script called, PRs covered) so the gate cannot be quietly dropped, matching the existing workflow-shape assertions in that file.

## Verification

Full suite locally:

```
  Action shell tests: 26 passed, 0 failed, 26 total
```

The new assertions are load-bearing — removing `- self-test` from the release job's `needs` fails immediately:

```
FAIL: release job is gated on the self-test suite
```

And the runner reports failures rather than swallowing them. An earlier iteration of this branch produced:

```
  Action shell tests: 24 passed, 2 failed, 26 total
  FAILED  scripts/core/test-test-action-workflow-liveness.sh
  FAILED  scripts/release/test-release-workflow.sh
```

That was the suite catching a genuine mistake of mine mid-change (I had overwritten `ci.yml`), which is a fair demonstration of the value: **this PR's own CI run is the first time these tests have ever gated a change in this repo.**

## Note

Since `pull_request` is new here, the checks appearing on this PR are themselves the proof the wiring works on `ubuntu-latest`. Worth confirming they are green before merge.