### PR TITLE
fix: report the classified release failure instead of "Unknown error"

### DIFF
--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -222,12 +222,31 @@ if [ -n "${SKIPPED_REASON}" ]; then
 fi
 
 if [ "${SUCCESS}" != "true" ] || [ "${RELEASE_EXIT}" -ne 0 ]; then
-  ERROR_MSG="$(json_field "${RELEASE_OUTPUT_FILE}" '.error.message // "Unknown error"')"
+  # `.error.message` only exists on the legacy error envelope. A release that
+  # runs and then fails a step returns the v3 command-result envelope, which
+  # classifies the failure under `.diagnostics` and `.summary` and carries the
+  # repair commands in `.next_actions` — so reading `.error.message` alone
+  # printed "Release failed: Unknown error" while the payload held
+  # `reason: "gh-upload-failed"` and a ready-to-paste `gh release ...` command
+  # (Extra-Chill/homeboy#10441). Read the classified fields first.
+  ERROR_MSG="$(json_field "${RELEASE_OUTPUT_FILE}" \
+    '[.error.message?, .diagnostics.message?, .diagnostics.failure_digest.summary?, .summary?]
+     | map(select(type == "string" and . != "")) | first // "Unknown error"')"
   if [ -z "${ERROR_MSG}" ] || [ "${ERROR_MSG}" = "null" ]; then
     ERROR_MSG="Unknown error"
   fi
 
   echo "::error::Release failed: ${ERROR_MSG}"
+
+  # The repair commands are the whole point of the structured envelope: print
+  # them next to the failure instead of leaving them buried in the JSON.
+  while IFS= read -r action; do
+    [ -n "${action}" ] || continue
+    echo "::notice::Release repair: ${action}"
+  done < <(json_field "${RELEASE_OUTPUT_FILE}" \
+    '.next_actions? // [] | .[] | select(.command? != null and .command != "")
+     | "\(.label // "next action") → \(.command)"')
+
   write_release_outputs "${RELEASE_OUTPUT_FILE}" "false" "release-failed"
   rm -f "${RELEASE_OUTPUT_FILE}"
   exit 1

--- a/scripts/release/test-run-release-wrapper.sh
+++ b/scripts/release/test-run-release-wrapper.sh
@@ -144,6 +144,15 @@ JSON
 JSON
     exit 1
     ;;
+  step-failed)
+    # The v3 command-result envelope a release that RAN and then failed a step
+    # emits: no `.error`, but a fully classified `.diagnostics` and executable
+    # `.next_actions` (Extra-Chill/homeboy#10441).
+    cat > "${output_file}" <<'JSON'
+{"schema":"command-result/v3","command":"release","success":false,"exit_code":1,"status":"failed","summary":"Release step github.release (github.release) failed: gh-upload-failed","next_actions":[{"label":"attach the built artifacts to the release that already exists","command":"gh release upload 'v2.1.0' --clobber -R 'Extra-Chill/homeboy'","kind":"repair"}],"diagnostics":{"code":"command.failed","message":"Release step github.release (github.release) failed: gh-upload-failed — `gh release upload` failed for v2.1.0: gh api release metadata exited with status 1"},"data":{"command":"release","result":{"component_id":"mock-component"}}}
+JSON
+    exit 1
+    ;;
   *)
     echo "unknown HOMEBOY_MOCK_SCENARIO=${HOMEBOY_MOCK_SCENARIO}" >&2
     exit 2
@@ -284,5 +293,44 @@ assert_output_line 'release-version=2.1.0' "${OUTPUT_FILE}" "dry-run preserves p
 assert_output_line 'release-tag=v2.1.0' "${OUTPUT_FILE}" "dry-run preserves planned tag"
 assert_output_line 'release-bump-type=minor' "${OUTPUT_FILE}" "dry-run preserves planned bump"
 assert_output_line 'skipped-reason=dry-run' "${OUTPUT_FILE}" "dry-run reason is action glue"
+
+# Extra-Chill/homeboy#10441: a release that fails a step returns the v3
+# envelope, which has no `.error`. Reading only `.error.message` printed
+# "Release failed: Unknown error" while the payload held the classified reason
+# AND a ready-to-paste repair command — the pipeline computed the answer and
+# printed prose. The wrapper must surface both.
+setup_fixture
+HOMEBOY_MOCK_SCENARIO="step-failed"
+GH_TOKEN="secret123"
+set +e
+FAILURE_OUTPUT="$(run_wrapper 2>&1)"
+FAILURE_EXIT=$?
+set -e
+if [ "${FAILURE_EXIT}" -eq 0 ]; then
+  printf 'FAIL: failed release must exit non-zero\n%s\n' "${FAILURE_OUTPUT}"
+  exit 1
+fi
+printf 'PASS: failed release exits non-zero\n'
+assert_not_contains 'Release failed: Unknown error' "${FAILURE_OUTPUT}" "classified step failure is never reported as Unknown error"
+assert_contains 'gh-upload-failed' "${FAILURE_OUTPUT}" "classified failure reason reaches the CI annotation"
+assert_contains "gh release upload 'v2.1.0' --clobber" "${FAILURE_OUTPUT}" "repair command is printed next to the failure"
+assert_output_line 'released=false' "${OUTPUT_FILE}" "failed release reports released=false"
+assert_output_line 'skipped-reason=release-failed' "${OUTPUT_FILE}" "failed release reports the release-failed reason"
+
+# The legacy `.error.message` envelope (validation errors, load failures) must
+# keep working — the new lookup adds fallbacks, it does not replace the field.
+setup_fixture
+HOMEBOY_MOCK_SCENARIO="failed"
+GH_TOKEN="secret123"
+set +e
+LEGACY_OUTPUT="$(run_wrapper 2>&1)"
+LEGACY_EXIT=$?
+set -e
+if [ "${LEGACY_EXIT}" -eq 0 ]; then
+  printf 'FAIL: legacy failure must exit non-zero\n%s\n' "${LEGACY_OUTPUT}"
+  exit 1
+fi
+printf 'PASS: legacy failure exits non-zero\n'
+assert_contains 'Release failed: mock failure' "${LEGACY_OUTPUT}" "legacy .error.message envelope still reports its message"
 
 printf 'All run-release wrapper checks passed.\n'


### PR DESCRIPTION
A transient `gh` API error stranded 188 commits for three hours while the pipeline was holding the exact repair command — and this wrapper is where the answer got thrown away.

When `v0.320.0`'s publish step failed, `Create GitHub Release` printed:

```
##[error]Release failed: Unknown error
```

The JSON it had just read held:

```json
"reason": "gh-upload-failed", "release_created": true, "missing": 0,
"repair": { "create_command": "gh release create v0.320.0 ..." },
"next_actions": ["Fix the issue and re-run (idempotent - completed steps will succeed again)"]
```

Everything needed to fix it was on disk. The operator got the word "Unknown".

## Cause

`run-release.sh` read `.error.message`. That field only exists on the **legacy error envelope** — a `homeboy release` that fails *before* running (validation, component load). A release that RUNS and then fails a step returns the **v3 command-result envelope**, which has no `.error` at all: the failure is classified under `.diagnostics` / `.summary`, and the executable repair commands live in `.next_actions`.

So the one failure mode that most needs a message — a real release that got most of the way and died at the last mile — was the exact one guaranteed to render as "Unknown error".

## Fix

Read the classified fields in order, first non-empty wins:

```
.error.message → .diagnostics.message → .diagnostics.failure_digest.summary → .summary
```

`.error.message` stays first, so every legacy path is unchanged.

Also print `.next_actions` as annotations right next to the failure, so the repair commands stop being buried in JSON nobody opens:

```
::error::Release failed: Release step github.release (github.release) failed: gh-upload-failed — `gh release upload` failed for v0.320.0: gh api release metadata exited with status 1
::notice::Release repair: attach the built artifacts to the release that already exists → gh release upload 'v0.320.0' --clobber -R 'Extra-Chill/homeboy'
::notice::Release repair: publish that release once its assets verify → gh release edit 'v0.320.0' --draft=false -R 'Extra-Chill/homeboy'
```

## Tests

Two new cases in `scripts/release/test-run-release-wrapper.sh`, driven by a `step-failed` mock emitting the real v3 envelope shape:

- a classified step failure must **never** render as "Unknown error", must surface `gh-upload-failed`, and must print the repair command
- the legacy `.error.message` envelope must keep reporting its message

Full suite green locally: **26 passed, 0 failed**.

## Related

Extra-Chill/homeboy#10476 fixes the producer side — the release executor's envelope digest was also dropping the step's `reason` and `repair` block — and makes the release pipeline self-recover stranded tags instead of waiting on a human.

Refs Extra-Chill/homeboy#10441
