### PR TITLE
fix: let the differential gate tell a timeout from a test failure

### DIFF
--- a/scripts/core/apply-differential-gate.py
+++ b/scripts/core/apply-differential-gate.py
@@ -179,8 +179,15 @@ def main() -> int:
         base_command = quality_base_command(command)
         if base_command not in {"audit", "lint", "test"}:
             continue
-        if status != "fail":
+        # A timeout is admitted here so that a candidate which ran out of clock
+        # can still be recognised as pre-existing when the baseline ran out of
+        # clock too. Before this, `timeout` skipped the gate entirely and stayed
+        # a hard red even when main was equally unable to finish, which is the
+        # one thing differential gating exists to rule out.
+        if status not in {"fail", "timeout"}:
             continue
+
+        timed_out = status == "timeout"
 
         current = metric_for(command, current_dir)
         base = metric_for(command, base_dir)
@@ -192,6 +199,27 @@ def main() -> int:
             adjusted[command] = "baseline_red"
             print(
                 f"::warning::Differential gate marked {command} baseline_red: baseline command `{command_label(command, base_metadata)}` exited {base_metadata.get('exit_code', 'unknown')} before comparable counts were available",
+                file=sys.stderr,
+            )
+            continue
+
+        # Past this point the baseline is healthy, so an incomplete candidate
+        # run is the candidate's problem and must keep blocking.
+        #
+        # This guard must precede every count-based branch below. Counts from a
+        # suite that was killed mid-run are not comparable to counts from one
+        # that finished: a timeout typically reports *fewer* failures than the
+        # baseline (often zero, because the results sidecar was never written),
+        # so `current <= base` would read as an improvement and silently mark
+        # the command `pass`. Turning "the suite never finished" into a green
+        # gate is a strictly worse failure than the false red this change
+        # exists to remove. `inconclusive` is equally wrong here -- it only
+        # warns, and a timeout against a healthy baseline is actionable.
+        if timed_out:
+            print(
+                f"::error::Differential gate kept {command} as timeout: the candidate run did not "
+                f"finish, so its counts are not comparable to the baseline. Raise the command's "
+                f"execution budget or reduce suite duration; do not read this as a test failure.",
                 file=sys.stderr,
             )
             continue

--- a/scripts/core/test-apply-differential-gate.sh
+++ b/scripts/core/test-apply-differential-gate.sh
@@ -51,4 +51,91 @@ printf '{"review lint":{"status":"fail","exit_code":1,"command":"homeboy review 
 result="$(python3 "${APPLY_GATE}" '{"review lint":"fail"}' "${current_dir}" "${base_dir}")"
 assert_equals '{"review lint":"pass"}' "${result}" "lint baseline count is compared"
 
+# --- Timeout classification (Extra-Chill/homeboy#10639) -----------------------
+#
+# Fixtures below are the shape Homeboy actually emits when a test command
+# exhausts its budget, recorded from Extra-Chill/homeboy run 30376771886
+# (job 90334340546): exit 124, a stderr timeout marker, and an all-zero counts
+# summary because the child was killed before it wrote its results sidecar.
+#
+# These assert the classified *result* of that recorded timeout, never the
+# command line that produced it.
+
+timed_out_payload='{"success":false,"data":{"exit_code":124,"failure":{"category":"infrastructure","phase":"test"},"raw_output":{"stderr_tail":"Homeboy command timed out after 1500000ms; terminated child process group before returning failure evidence."},"test_counts":{"failed":0,"errors":0}}}'
+
+# A timeout that also happens on the baseline is pre-existing, exactly like a
+# baseline-red test failure. Before this change `timeout` skipped the gate
+# entirely and stayed a hard red no matter what the baseline did.
+printf '%s\n' "${timed_out_payload}" > "${current_dir}/review-test.json"
+rm -f "${base_dir}/review-test.json"
+printf '{"review test":{"status":"timeout","exit_code":124,"command":"homeboy review test sample --path .","structured_output":false}}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"review test":"timeout"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"review test":"baseline_red"}' "${result}" "a timeout that also times out on the baseline is pre-existing, not a candidate failure"
+
+# The important negative. A killed run reports FEWER failures than a healthy
+# baseline (0 here, versus 1), so a naive count comparison reads the timeout as
+# an improvement and marks it pass. A green gate for a suite that never
+# finished is worse than the false red this change removes.
+printf '%s\n' "${timed_out_payload}" > "${current_dir}/review-test.json"
+printf '{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}\n' > "${base_dir}/review-test.json"
+printf '{"review test":{"status":"fail","exit_code":1,"command":"homeboy review test sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"review test":"timeout"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"review test":"timeout"}' "${result}" "an incomplete run is never promoted to pass by comparing its truncated counts"
+
+# Against a healthy baseline a timeout is actionable and must keep blocking.
+# `inconclusive` would only warn, which is how a red gate becomes background
+# noise.
+printf '%s\n' "${timed_out_payload}" > "${current_dir}/review-test.json"
+rm -f "${base_dir}/review-test.json"
+printf '{}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"review test":"timeout"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"review test":"timeout"}' "${result}" "a timeout against a healthy baseline stays blocking rather than degrading to inconclusive"
+
+# A timeout must never be laundered into the vocabulary of test failures.
+for status in fail inconclusive pass; do
+  if [ "${result}" = "{\"review test\":\"${status}\"}" ]; then
+    printf 'FAIL: timeout was reclassified as %s\n' "${status}"
+    exit 1
+  fi
+done
+printf 'PASS: timeout is not reported as fail, pass, or inconclusive\n'
+
+# A timeout must read differently from a test failure in the PR comment, so a
+# reviewer can tell them apart without opening the run.
+#
+# Deliberately not guarded by `if [ -f ... ]`: a guard that quietly skips when
+# the path is wrong is how a check passes for weeks while asserting nothing.
+# If sections.sh moves or stops sourcing, this must fail loudly.
+ACTION_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SECTIONS="${ACTION_ROOT}/pr/comment/sections.sh"
+
+if [ ! -f "${SECTIONS}" ]; then
+  printf 'FAIL: expected PR comment renderer at %s\n' "${SECTIONS}"
+  exit 1
+fi
+
+render_status() {
+  GITHUB_ACTION_PATH="$(cd "${ACTION_ROOT}/.." && pwd)" \
+    bash -c 'source "$1"; "$2" "$3"' _ "${SECTIONS}" "$1" "$2"
+}
+
+timeout_icon="$(render_status status_icon timeout)"
+fail_icon="$(render_status status_icon fail)"
+timeout_label="$(render_status status_label timeout)"
+fail_label="$(render_status status_label fail)"
+
+# Prove the renderer actually ran before comparing, so an empty-vs-empty
+# comparison can never be mistaken for agreement.
+[ -n "${timeout_icon}" ] || { printf 'FAIL: status_icon timeout produced no output\n'; exit 1; }
+[ -n "${fail_icon}" ] || { printf 'FAIL: status_icon fail produced no output\n'; exit 1; }
+[ -n "${timeout_label}" ] || { printf 'FAIL: status_label timeout produced no output\n'; exit 1; }
+[ -n "${fail_label}" ] || { printf 'FAIL: status_label fail produced no output\n'; exit 1; }
+
+assert_equals 'distinct' \
+  "$([ "${timeout_icon}" != "${fail_icon}" ] && echo distinct || echo same)" \
+  "timeout renders a different icon (${timeout_icon}) from a test failure (${fail_icon})"
+assert_equals 'distinct' \
+  "$([ "${timeout_label}" != "${fail_label}" ] && echo distinct || echo same)" \
+  "timeout renders a different label (${timeout_label}) from a test failure (${fail_label})"
+
 printf 'All differential gate checks passed.\n'

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -66,7 +66,11 @@ append_review_report_section() {
 status_icon() {
   case "$1" in
     pass|passed) printf '%s\n' ':white_check_mark:' ;;
-    fail|failed|timeout) printf '%s\n' ':x:' ;;
+    fail|failed) printf '%s\n' ':x:' ;;
+    # Distinct from :x: on purpose. A reader scanning section icons must be
+    # able to tell "this change broke tests" from "the suite never finished"
+    # without opening the run.
+    timeout) printf '%s\n' ':hourglass_flowing_sand:' ;;
     baseline_red|inconclusive) printf '%s\n' ':warning:' ;;
     skipped) printf '%s\n' ':fast_forward:' ;;
     *) printf '%s\n' ':warning:' ;;


### PR DESCRIPTION
Refs Extra-Chill/homeboy#10639.

## Problem

`apply-differential-gate.py` skipped any command whose status was not exactly `"fail"`:

```python
if status != "fail":
    continue
```

`run-homeboy-commands.sh` already classifies exit 124 as `"timeout"` — correctly — so a timeout **never entered differential adjustment at all**. A candidate that ran out of clock stayed a hard red even when the baseline ran out of clock on the same commit range, which is precisely the case differential gating exists to rule out.

[Extra-Chill/homeboy run 30376771886](https://github.com/Extra-Chill/homeboy/actions/runs/30376771886) is that case exactly: the candidate phase burned 1502 s, the baseline phase burned 1501 s, and the gate blocked the PR anyway. Had the status been `"fail"` instead of `"timeout"`, the same run would have been downgraded to `baseline_red` and merely warned.

## Changes

**1. Admit `timeout` into the gate.** A timeout that reproduces on the baseline downgrades to `baseline_red`, like any other pre-existing failure.

**2. Guard it ahead of every count-based branch — this is the load-bearing part.** A killed run reports *fewer* failures than a healthy baseline, usually zero, because the child dies before writing its results sidecar. `test_count()` still returns `0` for it (the `failed` key is present), so `current <= base` reads `0 <= 1` as an improvement and marks the command **`pass`**.

That latent bug is not hypothetical. Deleting the guard and re-running the suite turns the recorded timeout fixture green:

```
FAIL: an incomplete run is never promoted to pass by comparing its truncated counts
expected: {"review test":"timeout"}
actual:   {"review test":"pass"}
```

A green gate for a suite that never finished is strictly worse than the false red this PR removes. `inconclusive` is wrong for the mirror-image reason — it only warns, and a timeout against a healthy baseline is actionable — so a timeout against a healthy baseline stays blocking.

**3. Distinct icon.** `status_label` already rendered `timed out`, but `status_icon` mapped `timeout` to the same `:x:` as a failure. A reviewer scanning section icons could not tell "this change broke tests" from "the suite never finished" without opening the run.

## Resulting behaviour

| candidate | baseline | before | after |
|---|---|---|---|
| timeout | timeout | `timeout` (blocks) | `baseline_red` (warns — pre-existing) |
| timeout | fail, 1 failure | `timeout` (blocks) | `timeout` (blocks; **not** silently `pass`) |
| timeout | healthy | `timeout` (blocks) | `timeout` (blocks; **not** `inconclusive`) |
| fail | * | unchanged | unchanged |

## Tests

Added to `scripts/core/test-apply-differential-gate.sh`, following the file's existing pattern. Fixtures are the shape Homeboy actually emits on timeout, recorded from job 90334340546: exit 124, the stderr timeout marker, and an all-zero counts summary.

Per the guidance that burned us on the post-merge audit gate, these **assert the classified result, not the command string**. The renderer checks are deliberately *not* wrapped in `if [ -f ... ]` — a guard that quietly skips on a moved path is how a check passes for weeks while asserting nothing — and each captured value is proven non-empty before comparison so an empty-vs-empty comparison cannot be mistaken for agreement.

Both changes are mutation-verified: reverting either one fails a specific named assertion. Full suite: **26 passed, 0 failed, 26 total**.

## Release

`Extra-Chill/homeboy` pins `ref: v2`, so **this PR does not take effect there until `v2` is re-pointed**. The companion Extra-Chill/homeboy#10639 PR is deliberately independent of that — it sets the budget through job-level `env:`, which reaches the composite action's `run:` steps without any action change — so the false reds stop immediately and this classification fix lands whenever a release is cut. Cutting that release is an operator action; I have not done it.

Extra-Chill/homeboy-action#303 remains open and unaddressed here: callers of the *reusable workflow* still have no way to configure the inner test budget, because they cannot attach `env:` to a job that calls one.

## Verification I could not do

No cargo on this host. Python and bash syntax checked, and the shell suite runs clean locally; CI is the gate.

## AI assistance

- Agent: chubes-bot (Claude Code)
- Used for: tracing the timeout path from `local_exec.rs` through the action shell, identifying the `status != "fail"` exclusion and the count-comparison trap, and mutation-testing both fixes.
