### PR TITLE
feat: surface action phase progress

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,14 @@ inputs:
     description: 'Maximum wall-clock time to terminate and verify a Homeboy command process group after command completion or timeout. Emits retained-log diagnostics and fails when cleanup cannot finish.'
     required: false
     default: '15'
+  phase-heartbeat-seconds:
+    description: 'Maximum interval between live phase-progress heartbeats.'
+    required: false
+    default: '60'
+  phase-budget-seconds:
+    description: 'Elapsed phase budget before Homeboy Action emits an owning-subsystem diagnostic.'
+    required: false
+    default: '300'
   import-observations:
     description: 'Download and import earlier homeboy-observations artifacts from the same workflow run before command execution. Import is best-effort and non-fatal.'
     required: false
@@ -250,6 +258,9 @@ outputs:
   pr-policy-report:
     description: 'Markdown summary from the PR policy gate'
     value: ${{ steps.pr-policy.outputs.report }}
+  phase-progress:
+    description: 'Path to the phase timing artifact for this action invocation.'
+    value: ${{ steps.phase-summary.outputs.phase-progress }}
 
 runs:
   using: 'composite'
@@ -262,7 +273,7 @@ runs:
       env:
         COMPONENT_NAME: ${{ inputs.component }}
         EXTENSION_INPUT: ${{ inputs.extension }}
-      run: bash ${{ github.action_path }}/scripts/setup/read-portable-config.sh
+      run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh run preparation -- bash ${{ github.action_path }}/scripts/setup/read-portable-config.sh
 
     # ── Phase 2: Resolve execution context ──
 
@@ -273,19 +284,23 @@ runs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         SCOPE_INPUT: ${{ inputs.scope }}
-      run: bash ${{ github.action_path }}/scripts/scope/resolve.sh
+      run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh run changed_scope_resolution -- bash ${{ github.action_path }}/scripts/scope/resolve.sh
 
     - name: Resolve commands
       id: resolve-commands
       shell: bash
       env:
         COMMANDS_INPUT: ${{ inputs.commands }}
-      run: bash ${{ github.action_path }}/scripts/core/resolve-commands.sh
+      run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh run changed_scope_resolution -- bash ${{ github.action_path }}/scripts/core/resolve-commands.sh
 
     # ── Phase 3: Install Homeboy ──
     # Homeboy installs before PHP/Node so we can use `homeboy component env`
     # to detect runtime requirements from the source files (e.g., WordPress
     # "Requires PHP" header).
+
+    - name: Start dependency/build setup timing
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh start dependency_build_setup
 
     - name: Install pre-built binary
       id: install-prebuilt
@@ -421,6 +436,11 @@ runs:
       shell: bash
       run: bash ${{ github.action_path }}/scripts/setup/auto-setup-environment.sh
 
+    - name: Finish dependency/build setup timing
+      if: always()
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh end dependency_build_setup
+
     # ── Phase 4b: SSH setup (for fleet/deploy) ──
 
     - name: Setup SSH
@@ -486,7 +506,14 @@ runs:
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
         HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
         HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF: true
+        HOMEBOY_ACTION_PHASE_HEARTBEAT_SECONDS: ${{ inputs.phase-heartbeat-seconds }}
+        HOMEBOY_ACTION_PHASE_BUDGET_SECONDS: ${{ inputs.phase-budget-seconds }}
       run: bash ${{ github.action_path }}/scripts/core/run-homeboy-commands.sh
+
+    - name: Start artifact publication timing
+      if: always()
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh start artifact_publication
 
     - name: Resolve artifact names
       id: artifact-names
@@ -542,6 +569,11 @@ runs:
         path: homeboy-observations/**
         if-no-files-found: ignore
 
+    - name: Finish artifact publication timing
+      if: always()
+      shell: bash
+      run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh end artifact_publication
+
     - name: Run baseline Homeboy commands
       id: run-baseline-commands
       continue-on-error: true
@@ -561,6 +593,8 @@ runs:
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
         HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
         HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF: true
+        HOMEBOY_ACTION_PHASE_HEARTBEAT_SECONDS: ${{ inputs.phase-heartbeat-seconds }}
+        HOMEBOY_ACTION_PHASE_BUDGET_SECONDS: ${{ inputs.phase-budget-seconds }}
       run: bash ${{ github.action_path }}/scripts/core/run-baseline-commands.sh
 
     # ── Phase 6: Results and reporting ──
@@ -573,7 +607,7 @@ runs:
         FIRST_RESULTS: ${{ steps.run-commands.outputs.results }}
         COMMANDS: ${{ steps.resolve-commands.outputs.resolved-commands }}
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
-      run: bash ${{ github.action_path }}/scripts/core/select-final-results.sh
+      run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh run finding_reconciliation -- bash ${{ github.action_path }}/scripts/core/select-final-results.sh
 
     - name: Generate failure digest
       if: |
@@ -710,3 +744,20 @@ runs:
         COMPONENT_NAME: ${{ inputs.component }}
         BINARY_SOURCE: ${{ steps.resolve-binary.outputs.binary-source }}
       run: bash ${{ github.action_path }}/scripts/issues/auto-file-categorized-issues.sh
+
+    - name: Publish phase timing summary
+      id: phase-summary
+      if: always()
+      shell: bash
+      run: |
+        bash ${{ github.action_path }}/scripts/core/phase-progress.sh start cleanup
+        bash ${{ github.action_path }}/scripts/core/phase-progress.sh end cleanup
+        bash ${{ github.action_path }}/scripts/core/phase-progress.sh summary
+
+    - name: Upload Homeboy phase timings
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: homeboy-phase-progress-${{ github.job }}-${{ runner.os }}
+        path: ${{ steps.phase-summary.outputs.phase-progress }}
+        if-no-files-found: warn

--- a/scripts/core/phase-progress.sh
+++ b/scripts/core/phase-progress.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+phase_progress_file() {
+  printf '%s\n' "${HOMEBOY_ACTION_PHASE_PROGRESS_FILE:-${RUNNER_TEMP:-/tmp}/homeboy-action-phase-progress-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-local}.jsonl}"
+}
+
+phase_run_ref() {
+  if [ -n "${GITHUB_RUN_ID:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    printf 'github://%s/actions/runs/%s#%s\n' "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}" "${GITHUB_JOB:-action}"
+  else
+    printf 'homeboy-action://local/%s\n' "${GITHUB_JOB:-action}"
+  fi
+}
+
+phase_owner() {
+  case "$1" in
+    preparation|changed_scope_resolution) printf 'action context setup\n' ;;
+    dependency_build_setup) printf 'action dependency/build setup\n' ;;
+    command_execution) printf 'Homeboy command runner\n' ;;
+    finding_reconciliation) printf 'action result reconciliation\n' ;;
+    artifact_publication) printf 'action artifact publication\n' ;;
+    cleanup) printf 'action cleanup\n' ;;
+    *) printf 'Homeboy Action\n' ;;
+  esac
+}
+
+phase_reproduction_command() {
+  if [ -n "${GITHUB_RUN_ID:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    printf 'gh run view %s --repo %s --log\n' "${GITHUB_RUN_ID}" "${GITHUB_REPOSITORY}"
+  else
+    printf 'bash scripts/core/run-homeboy-commands.sh\n'
+  fi
+}
+
+phase_validate_positive() {
+  local name="$1" value="$2"
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    printf '::error::%s must be a positive integer; received %q.\n' "${name}" "${value}"
+    exit 2
+  fi
+}
+
+phase_append() {
+  local phase="$1" event="$2" status="$3" elapsed_seconds="$4"
+  local file owner reproduction
+  file="$(phase_progress_file)"
+  owner="$(phase_owner "${phase}")"
+  reproduction="$(phase_reproduction_command)"
+  mkdir -p "$(dirname "${file}")"
+  jq -cn \
+    --arg schema 'homeboy/action-phase-progress-event/v1' \
+    --arg run_ref "$(phase_run_ref)" \
+    --arg phase "${phase}" \
+    --arg event "${event}" \
+    --arg status "${status}" \
+    --arg owner "${owner}" \
+    --arg reproduction_command "${reproduction}" \
+    --argjson at_seconds "$(date +%s)" \
+    --argjson elapsed_seconds "${elapsed_seconds}" \
+    '{schema:$schema,run_ref:$run_ref,phase:$phase,event:$event,status:$status,owner:$owner,reproduction_command:$reproduction_command,at_seconds:$at_seconds,elapsed_seconds:$elapsed_seconds}' \
+    >> "${file}"
+}
+
+phase_last_start() {
+  local phase="$1" file="$2"
+  [ -f "${file}" ] || return 1
+  jq -sr --arg phase "${phase}" '[.[] | select(.phase == $phase and .event == "started") | .at_seconds] | last // empty' "${file}"
+}
+
+phase_start() {
+  local phase="$1"
+  phase_append "${phase}" started running 0
+  printf '::notice title=Homeboy phase::%s started; run %s.\n' "${phase}" "$(phase_run_ref)"
+}
+
+phase_end() {
+  local phase="$1" status="${2:-completed}"
+  local file started now elapsed
+  file="$(phase_progress_file)"
+  now="$(date +%s)"
+  started="$(phase_last_start "${phase}" "${file}" || true)"
+  elapsed=0
+  if [[ "${started}" =~ ^[0-9]+$ ]]; then
+    elapsed="$(( now - started ))"
+  else
+    status=skipped
+  fi
+  phase_append "${phase}" completed "${status}" "${elapsed}"
+  printf '::notice title=Homeboy phase::%s %s after %ss; run %s.\n' "${phase}" "${status}" "${elapsed}" "$(phase_run_ref)"
+}
+
+phase_run() {
+  local phase="$1"
+  shift
+  [ "${1:-}" = '--' ] && shift
+  [ "$#" -gt 0 ] || { printf 'phase-progress run requires a command\n' >&2; exit 2; }
+
+  local heartbeat_seconds="${HOMEBOY_ACTION_PHASE_HEARTBEAT_SECONDS:-60}"
+  local budget_seconds="${HOMEBOY_ACTION_PHASE_BUDGET_SECONDS:-300}"
+  phase_validate_positive HOMEBOY_ACTION_PHASE_HEARTBEAT_SECONDS "${heartbeat_seconds}"
+  phase_validate_positive HOMEBOY_ACTION_PHASE_BUDGET_SECONDS "${budget_seconds}"
+
+  phase_start "${phase}"
+  local started pid heartbeat_pid exit_code=0
+  started="$(date +%s)"
+  "$@" &
+  pid=$!
+  (
+    local elapsed=0 over_budget=false
+    while kill -0 "${pid}" 2>/dev/null; do
+      sleep "${heartbeat_seconds}"
+      if kill -0 "${pid}" 2>/dev/null; then
+        elapsed="$(( $(date +%s) - started ))"
+        printf '::notice title=Homeboy phase heartbeat::%s running for %ss; run %s.\n' "${phase}" "${elapsed}" "$(phase_run_ref)"
+        if [ "${elapsed}" -ge "${budget_seconds}" ] && [ "${over_budget}" = false ]; then
+          over_budget=true
+          printf '::warning title=Homeboy phase budget exceeded::%s exceeded its %ss budget; owner: %s. Reproduce: %s\n' "${phase}" "${budget_seconds}" "$(phase_owner "${phase}")" "$(phase_reproduction_command)"
+        fi
+      fi
+    done
+  ) &
+  heartbeat_pid=$!
+  set +e
+  wait "${pid}"
+  exit_code=$?
+  set -e
+  kill "${heartbeat_pid}" 2>/dev/null || true
+  wait "${heartbeat_pid}" 2>/dev/null || true
+  if [ "${exit_code}" -eq 0 ]; then
+    phase_end "${phase}" completed
+  else
+    phase_end "${phase}" failed
+  fi
+  return "${exit_code}"
+}
+
+phase_summary() {
+  local file output_dir output
+  file="$(phase_progress_file)"
+  output_dir="${HOMEBOY_CI_RESULTS_DIR:-${GITHUB_WORKSPACE:-$(pwd)}/homeboy-ci-results}"
+  output="${output_dir}/phase-progress.json"
+  mkdir -p "${output_dir}"
+  if [ ! -f "${file}" ]; then
+    : > "${file}"
+  fi
+  jq -s --arg run_ref "$(phase_run_ref)" '
+    [ .[] | select(.event == "completed") ] as $phases
+    | {
+        schema: "homeboy/action-phase-progress/v1",
+        run_ref: $run_ref,
+        phases: $phases,
+        slowest_phases: ($phases | sort_by(-.elapsed_seconds, .phase) | .[:3])
+      }
+  ' "${file}" > "${output}"
+
+  local summary_file="${GITHUB_STEP_SUMMARY:-}"
+  if [ -n "${summary_file}" ]; then
+    {
+      printf '### Homeboy Action Phase Timings\n\n'
+      printf 'Run: `%s`\n\n' "$(phase_run_ref)"
+      printf '| Phase | Status | Elapsed | Owner |\n| --- | --- | ---: | --- |\n'
+      jq -r '.phases[] | "| `\(.phase)` | \(.status) | \(.elapsed_seconds)s | \(.owner) |"' "${output}"
+      printf '\nThree slowest phases:\n'
+      jq -r '.slowest_phases[] | "- `\(.phase)` - \(.elapsed_seconds)s (\(.owner))"' "${output}"
+    } >> "${summary_file}"
+  fi
+  printf 'phase-progress=%s\n' "${output}" >> "${GITHUB_OUTPUT:-/dev/null}"
+  printf '::notice title=Homeboy phase timings::published %s for run %s.\n' "${output}" "$(phase_run_ref)"
+}
+
+case "${1:-}" in
+  start) phase_start "${2:?phase required}" ;;
+  end) phase_end "${2:?phase required}" "${3:-completed}" ;;
+  run) shift; phase_run "$@" ;;
+  summary) phase_summary ;;
+  *)
+    printf 'Usage: %s {start|end|run|summary} ...\n' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -71,9 +71,10 @@ for CMD in "${BASELINE_RUN_COMMANDS[@]}"; do
 
   echo "::group::${GROUP_PREFIX} ${CMD}"
   set +e
-  bash "${GITHUB_ACTION_PATH}/scripts/core/run-with-liveness-timeout.sh" \
-    --log-file "${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.log" \
-    "baseline homeboy ${CMD}" bash -c "${FULL_CMD}"
+  bash "${GITHUB_ACTION_PATH}/scripts/core/phase-progress.sh" run command_execution -- \
+    bash "${GITHUB_ACTION_PATH}/scripts/core/run-with-liveness-timeout.sh" \
+      --log-file "${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.log" \
+      "baseline homeboy ${CMD}" bash -c "${FULL_CMD}"
   CMD_EXIT=$?
   cat "${BASE_OUTPUT_DIR}/${OUTPUT_STEM}.log"
   set -e

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -62,9 +62,10 @@ for CMD in "${CMD_ARRAY[@]}"; do
   echo "::group::${GROUP_PREFIX} ${CMD}"
   CMD_EXIT=0
   set +e
-  bash "${GITHUB_ACTION_PATH}/scripts/core/run-with-liveness-timeout.sh" \
-    --log-file "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log" \
-    "homeboy ${CMD}" bash -c "${FULL_CMD}"
+  bash "${GITHUB_ACTION_PATH}/scripts/core/phase-progress.sh" run command_execution -- \
+    bash "${GITHUB_ACTION_PATH}/scripts/core/run-with-liveness-timeout.sh" \
+      --log-file "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log" \
+      "homeboy ${CMD}" bash -c "${FULL_CMD}"
   CMD_EXIT=$?
   cat "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.log"
   set -e

--- a/scripts/core/test-phase-progress.sh
+++ b/scripts/core/test-phase-progress.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROGRESS="${ROOT_DIR}/scripts/core/phase-progress.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+set +e
+GITHUB_REPOSITORY='Extra-Chill/homeboy' \
+GITHUB_RUN_ID='1234' \
+GITHUB_JOB='test' \
+GITHUB_OUTPUT="${TMP_DIR}/output" \
+GITHUB_STEP_SUMMARY="${TMP_DIR}/summary" \
+HOMEBOY_CI_RESULTS_DIR="${TMP_DIR}/results" \
+HOMEBOY_ACTION_PHASE_PROGRESS_FILE="${TMP_DIR}/phases.jsonl" \
+HOMEBOY_ACTION_PHASE_HEARTBEAT_SECONDS=1 \
+HOMEBOY_ACTION_PHASE_BUDGET_SECONDS=1 \
+bash "${PROGRESS}" run command_execution -- bash -c 'sleep 2' >"${TMP_DIR}/run.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "${exit_code}" -ne 0 ]; then
+  printf 'FAIL: delayed phase exits %s\n' "${exit_code}"
+  exit 1
+fi
+if ! grep -q 'phase heartbeat.*command_execution running' "${TMP_DIR}/run.log"; then
+  printf 'FAIL: delayed phase did not emit a heartbeat before completion\n'
+  exit 1
+fi
+if ! grep -q 'phase budget exceeded.*Homeboy command runner' "${TMP_DIR}/run.log"; then
+  printf 'FAIL: delayed phase did not name an owning subsystem after its budget\n'
+  exit 1
+fi
+
+GITHUB_REPOSITORY='Extra-Chill/homeboy' \
+GITHUB_RUN_ID='1234' \
+GITHUB_JOB='test' \
+GITHUB_OUTPUT="${TMP_DIR}/output" \
+GITHUB_STEP_SUMMARY="${TMP_DIR}/summary" \
+HOMEBOY_CI_RESULTS_DIR="${TMP_DIR}/results" \
+HOMEBOY_ACTION_PHASE_PROGRESS_FILE="${TMP_DIR}/phases.jsonl" \
+bash "${PROGRESS}" summary >/dev/null
+
+if ! jq -e '.run_ref == "github://Extra-Chill/homeboy/actions/runs/1234#test" and .slowest_phases[0].phase == "command_execution"' "${TMP_DIR}/results/phase-progress.json" >/dev/null; then
+  printf 'FAIL: phase artifact does not preserve the stable run ref and slowest phase\n'
+  exit 1
+fi
+if ! grep -q 'Three slowest phases' "${TMP_DIR}/summary"; then
+  printf 'FAIL: phase summary does not report the slowest phases\n'
+  exit 1
+fi
+printf 'PASS: delayed phase emits live progress before terminal timing evidence\n'


### PR DESCRIPTION
Closes Extra-Chill/homeboy#10634.

## Summary
- Emit live lifecycle transitions and bounded heartbeats with stable GitHub run references.
- Record phase timing evidence, render the three slowest phases in the job summary, and upload the JSON artifact.
- Report phase-budget ownership and a reproduction command; cover delayed progress deterministically.

## Verification
- `bash -n` on changed shell scripts
- YAML parse of `action.yml`
- `git diff --check`
- Local test suites and builds were intentionally not run per instruction; Homeboy Action CI is authoritative.

## AI Assistance
OpenCode using `openai/gpt-5.6-sol` implemented the phase-progress contract, shell coverage, and static verification. Chris Huber remains responsible for the final change.