### PR TITLE
fix: stop the differential gate laundering an equal-failure run into a green check

### DIFF
--- a/scripts/core/apply-differential-gate.py
+++ b/scripts/core/apply-differential-gate.py
@@ -122,19 +122,35 @@ def output_stem(command: str) -> str:
     return "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in command).strip("-") or "homeboy-output"
 
 
-def metric_for(command: str, directory: str) -> int | None:
+# How a metric was derived. The distinction is load-bearing for the zero guard
+# in main(): zero means opposite things depending on provenance.
+#
+#   SCOPED -- `changed_since.introduced_{findings,failures}`. A deliberate
+#             measurement of what *this change* introduced. Zero is the
+#             success case: the repository may be red, but the candidate added
+#             nothing to it. This is the entire point of changed-scope gating.
+#   TOTAL  -- a raw count of everything the command found. Zero here, on a
+#             command that nonetheless failed or timed out, is not a
+#             measurement of success; it means the failure went uncounted.
+SCOPED = "scoped"
+TOTAL = "total"
+
+
+def metric_for(command: str, directory: str) -> tuple[int | None, str | None]:
     base_command = quality_base_command(command)
     payload = read_json(os.path.join(directory, f"{output_stem(command)}.json"))
     scoped_count = changed_scope_introduced_count(base_command, payload)
     if scoped_count is not None:
-        return scoped_count
+        return scoped_count, SCOPED
     if base_command == "audit":
-        return audit_count(payload)
-    if base_command == "lint":
-        return lint_count(payload)
-    if base_command == "test":
-        return test_count(payload)
-    return None
+        value = audit_count(payload)
+    elif base_command == "lint":
+        value = lint_count(payload)
+    elif base_command == "test":
+        value = test_count(payload)
+    else:
+        return None, None
+    return (value, TOTAL) if value is not None else (None, None)
 
 
 def base_command_status(command: str, base_dir: str) -> dict[str, Any]:
@@ -189,8 +205,8 @@ def main() -> int:
 
         timed_out = status == "timeout"
 
-        current = metric_for(command, current_dir)
-        base = metric_for(command, base_dir)
+        current, current_kind = metric_for(command, current_dir)
+        base, _base_kind = metric_for(command, base_dir)
         base_metadata = base_command_status(command, base_dir)
         base_failed = command_failed(base_metadata)
         base_structured = base_metadata.get("structured_output") is True
@@ -232,17 +248,60 @@ def main() -> int:
             )
             continue
 
-        if current <= base:
-            adjusted[command] = "pass"
-            print(
-                f"::notice::Differential gate accepted {command}: current={current} base={base}",
-                file=sys.stderr,
-            )
-        else:
+        if current > base:
             print(
                 f"::error::Differential gate rejected {command}: current={current} base={base}",
                 file=sys.stderr,
             )
+            continue
+
+        # `current == base` with something still red is not an improvement, and
+        # `pass` is an actively false statement about it: it renders a green
+        # check with no annotation anywhere, so a command that is red on the
+        # base branch stays red forever because no run ever reports it.
+        # `baseline_red` says the true thing -- this is pre-existing -- and
+        # still only warns in enforce-final-status.sh, so no PR that was
+        # previously mergeable becomes blocked. See Extra-Chill/homeboy#10657.
+        if current == base and base > 0:
+            adjusted[command] = "baseline_red"
+            print(
+                f"::warning::Differential gate marked {command} baseline_red: "
+                f"{current} failure(s) reproduce unchanged on the baseline "
+                f"(current={current} base={base}). Nothing regressed, but nothing "
+                f"improved either -- this command is red on the base branch.",
+                file=sys.stderr,
+            )
+            continue
+
+        # Zero total findings on a command that failed or timed out is not a
+        # clean result; it is an uncounted failure. A killed run is the concrete
+        # case: the child dies before writing its results sidecar, `test_counts`
+        # still carries `failed: 0`, and `0 <= base` would read a suite that
+        # never finished as a clean sweep. Compile errors and harness crashes
+        # land here too -- the command failed for a reason the counts do not
+        # describe, so the counts cannot license a pass.
+        #
+        # A genuine "fixed the last failure" run cannot reach this branch: it
+        # exits 0, is classified `pass` upstream, and never enters the gate.
+        #
+        # SCOPED is deliberately exempt -- there, zero is the measurement, not
+        # the absence of one. See Extra-Chill/homeboy#10685.
+        if current == 0 and current_kind != SCOPED:
+            adjusted[command] = "inconclusive"
+            print(
+                f"::warning::Differential gate marked {command} inconclusive: the command "
+                f"failed but reported 0 findings/failures (base={base}), so its own failure "
+                f"is uncounted. An incomplete, killed, or non-reporting run is never "
+                f"accepted as an improvement.",
+                file=sys.stderr,
+            )
+            continue
+
+        adjusted[command] = "pass"
+        print(
+            f"::notice::Differential gate accepted {command}: current={current} base={base}",
+            file=sys.stderr,
+        )
 
     print(json.dumps(adjusted, separators=(",", ":")))
     return 0

--- a/scripts/core/test-apply-differential-gate.sh
+++ b/scripts/core/test-apply-differential-gate.sh
@@ -38,7 +38,7 @@ assert_equals '{"review test":"baseline_red"}' "${result}" "red baseline without
 printf '{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}\n' > "${base_dir}/review-test.json"
 printf '{"review test":{"status":"fail","exit_code":1,"command":"homeboy review test sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
 result="$(python3 "${APPLY_GATE}" '{"review test":"fail"}' "${current_dir}" "${base_dir}")"
-assert_equals '{"review test":"pass"}' "${result}" "matching review test baseline failure count is accepted"
+assert_equals '{"review test":"baseline_red"}' "${result}" "a failure that reproduces unchanged on the baseline is baseline_red, not pass"
 
 printf '{"success":false,"data":{"test_counts":{"failed":2,"errors":0}}}\n' > "${current_dir}/review-test.json"
 printf '{"review test":{"status":"fail","exit_code":1,"command":"homeboy review test sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
@@ -49,7 +49,7 @@ printf '{"success":false,"data":{"lint_findings":[{},{}]}}\n' > "${current_dir}/
 printf '{"success":false,"data":{"lint_findings":[{},{}]}}\n' > "${base_dir}/review-lint.json"
 printf '{"review lint":{"status":"fail","exit_code":1,"command":"homeboy review lint sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
 result="$(python3 "${APPLY_GATE}" '{"review lint":"fail"}' "${current_dir}" "${base_dir}")"
-assert_equals '{"review lint":"pass"}' "${result}" "lint baseline count is compared"
+assert_equals '{"review lint":"baseline_red"}' "${result}" "lint baseline count is compared and an unchanged count is baseline_red"
 
 # --- Timeout classification (Extra-Chill/homeboy#10639) -----------------------
 #
@@ -137,5 +137,110 @@ assert_equals 'distinct' \
 assert_equals 'distinct' \
   "$([ "${timeout_label}" != "${fail_label}" ] && echo distinct || echo same)" \
   "timeout renders a different label (${timeout_label}) from a test failure (${fail_label})"
+
+# --- Equal-failure laundering + zero-count invariant -------------------------
+# Extra-Chill/homeboy#10657 (pass synthesised from two failing runs) and
+# Extra-Chill/homeboy#10685 (a gate must never pass without having measured
+# something).
+#
+# Every case below feeds a recorded payload shape through the classifier and
+# asserts the resulting *verdict*. None of them assert a command string: the
+# post-merge audit gate passed for weeks while asserting only the command it
+# ran, which is how it scanned zero files undetected.
+
+# Reset both fixture dirs so no earlier case can leak a stale sidecar into a
+# later one and make it assert against a payload it did not write.
+gate_case() {
+  local label="$1" results="$2" current_payload="$3" base_payload="$4" base_status="$5" expected="$6"
+
+  rm -rf "${current_dir}" "${base_dir}"
+  mkdir -p "${current_dir}" "${base_dir}"
+
+  [ "${current_payload}" = "-" ] || printf '%s\n' "${current_payload}" > "${current_dir}/review-test.json"
+  [ "${base_payload}" = "-" ] || printf '%s\n' "${base_payload}" > "${base_dir}/review-test.json"
+  printf '%s\n' "${base_status}" > "${base_dir}/baseline-status.json"
+
+  local actual
+  actual="$(python3 "${APPLY_GATE}" "${results}" "${current_dir}" "${base_dir}")"
+
+  # Prove the classifier actually produced a verdict before comparing, so an
+  # empty-vs-empty comparison can never be mistaken for agreement.
+  if [ -z "${actual}" ]; then
+    printf 'FAIL: %s\nthe gate produced no output at all\n' "${label}"
+    exit 1
+  fi
+
+  assert_equals "${expected}" "${actual}" "${label}"
+
+  # The invariant this whole section exists to defend, asserted independently
+  # of the equality check above: nothing here may render a green check.
+  if [ "${expected}" != '{"review test":"pass"}' ] && [ "${actual}" = '{"review test":"pass"}' ]; then
+    printf 'FAIL: %s was laundered into pass\n' "${label}"
+    exit 1
+  fi
+}
+
+counts() { printf '{"success":false,"data":{"test_counts":{"failed":%s,"errors":0}}}' "$1"; }
+
+base_failed_structured='{"review test":{"status":"fail","exit_code":1,"command":"homeboy review test sample --path .","structured_output":true}}'
+
+# 1/1 -- the defect. Both phases completed and reported one real failure. This
+# is Extra-Chill/homeboy run 30380078587, which rendered a fully green check
+# over a test that was red on main for twelve hours across 23 consecutive runs.
+gate_case "1/1: an equal, non-zero failure count is baseline_red rather than a green check" \
+  '{"review test":"fail"}' "$(counts 1)" "$(counts 1)" "${base_failed_structured}" \
+  '{"review test":"baseline_red"}'
+
+# 1/0 -- a real regression must still block. Proves the split did not make the
+# gate permissive.
+gate_case "1/0: a candidate that adds a failure against a clean baseline still fails" \
+  '{"review test":"fail"}' "$(counts 1)" "$(counts 0)" "${base_failed_structured}" \
+  '{"review test":"fail"}'
+
+# 1/3 -- a genuine partial improvement is still accepted, so the split did not
+# make the gate over-strict either. This is the branch that, across the 81-run
+# window in #10657, fired exactly zero times.
+gate_case "1/3: a genuine reduction in failures is still accepted" \
+  '{"review test":"fail"}' "$(counts 1)" "$(counts 3)" "${base_failed_structured}" \
+  '{"review test":"pass"}'
+
+# 0/1 -- looks like "the PR fixed the last failure", but it cannot be. A run
+# that genuinely reaches zero failures exits 0, is classified `pass` upstream in
+# run-homeboy-commands.sh, and never enters the gate at all. Reaching this
+# branch means the command failed while reporting nothing, so the count does
+# not describe the failure and cannot license a pass.
+gate_case "0/1: a failing command that reports zero failures is uncounted, not improved" \
+  '{"review test":"fail"}' "$(counts 0)" "$(counts 1)" "${base_failed_structured}" \
+  '{"review test":"inconclusive"}'
+
+# 0/0 -- nothing was measured on either side. #10685: a comparison with no
+# findings on either side is never a pass.
+gate_case "0/0: a comparison in which neither side measured anything is never pass" \
+  '{"review test":"fail"}' "$(counts 0)" "$(counts 0)" "${base_failed_structured}" \
+  '{"review test":"inconclusive"}'
+
+# A killed run, classified `fail` rather than `timeout`. run-homeboy-commands.sh
+# only maps exit 124 to `timeout`; the SIGKILL/containment paths in
+# run-with-liveness-timeout.sh exit 125, and an OOM kill surfaces as 137. Those
+# land here as an ordinary `fail` carrying `failed: 0`, which is precisely the
+# shape #305's timeout guard does not cover.
+killed_as_fail='{"success":false,"data":{"exit_code":137,"failure":{"category":"infrastructure","phase":"test"},"raw_output":{"stderr_tail":"terminated child process group before returning failure evidence."},"test_counts":{"failed":0,"errors":0}}}'
+gate_case "a killed run reported as fail (exit 137, failed:0) is never promoted to pass" \
+  '{"review test":"fail"}' "${killed_as_fail}" "$(counts 1)" "${base_failed_structured}" \
+  '{"review test":"inconclusive"}'
+
+containment_kill='{"success":false,"data":{"exit_code":125,"test_counts":{"failed":0,"errors":0}}}'
+gate_case "a containment-kill run (exit 125, failed:0) is never promoted to pass" \
+  '{"review test":"fail"}' "${containment_kill}" "$(counts 4)" "${base_failed_structured}" \
+  '{"review test":"inconclusive"}'
+
+# Changed-scope gating must survive all of the above. Here zero is a real
+# measurement -- "this change introduced nothing" -- not an uncounted failure,
+# so it must still pass even though the repository is red and the raw counts
+# are non-zero. If the zero guard were applied blindly this would regress.
+scoped_clean='{"success":false,"data":{"test_counts":{"failed":3,"errors":1},"changed_since":{"introduced_failures":0}}}'
+gate_case "changed-scope zero introduced failures still passes against a red baseline" \
+  '{"review test":"fail"}' "${scoped_clean}" "$(counts 3)" "${base_failed_structured}" \
+  '{"review test":"pass"}'
 
 printf 'All differential gate checks passed.\n'

--- a/scripts/core/test-differential-gate.py
+++ b/scripts/core/test-differential-gate.py
@@ -43,9 +43,9 @@ def main() -> None:
         write_json(base / "audit.json", {"success": False, "data": {"summary": {"outliers_found": 5}}})
         write_json(current / "audit.json", {"success": False, "data": {"summary": {"outliers_found": 5}}})
         assert_equal(
-            {"audit": "pass"},
+            {"audit": "baseline_red"},
             run_gate({"audit": "fail"}, current, base),
-            "audit failure passes when outliers do not increase",
+            "audit failure that reproduces unchanged on the baseline is baseline_red",
         )
 
         write_json(current / "audit.json", {"success": False, "data": {"summary": {"outliers_found": 6}}})
@@ -74,9 +74,9 @@ def main() -> None:
         write_json(base / "test.json", {"success": False, "data": {"test_counts": {"failed": 2, "errors": 1}}})
         write_json(current / "test.json", {"success": False, "data": {"test_counts": {"failed": 2, "errors": 1}}})
         assert_equal(
-            {"test": "pass"},
+            {"test": "baseline_red"},
             run_gate({"test": "fail"}, current, base),
-            "test failure passes when failures do not increase",
+            "test failure that reproduces unchanged on the baseline is baseline_red",
         )
 
         write_json(current / "test.json", {"success": False, "data": {"test_counts": {"failed": 3, "errors": 1}}})

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -18,10 +18,15 @@ cd "${ROOT_DIR}"
 
 per_test_timeout="${HOMEBOY_ACTION_TEST_TIMEOUT_SECONDS:-600}"
 
-mapfile -t tests < <(find scripts -mindepth 2 -maxdepth 2 -name 'test-*.sh' -type f | sort)
+# Both suffixes are collected on purpose. `test-differential-gate.py` sat in
+# this tree unreferenced by any runner or workflow, so it never executed once;
+# its assertions had silently drifted to encode the exact `pass`-from-two-
+# failures behaviour that Extra-Chill/homeboy#10657 reports, and nothing caught
+# it. A test file that no runner picks up is indistinguishable from no test.
+mapfile -t tests < <(find scripts -mindepth 2 -maxdepth 2 \( -name 'test-*.sh' -o -name 'test-*.py' \) -type f | sort)
 
 if [ "${#tests[@]}" -eq 0 ]; then
-  echo "::error::No action test scripts found under scripts/*/test-*.sh"
+  echo "::error::No action test scripts found under scripts/*/test-*.{sh,py}"
   exit 1
 fi
 
@@ -31,7 +36,10 @@ failed_tests=()
 for test in "${tests[@]}"; do
   echo "::group::${test}"
   start="$(date +%s)"
-  timeout "${per_test_timeout}" bash "${test}"
+  case "${test}" in
+    *.py) timeout "${per_test_timeout}" python3 "${test}" ;;
+    *) timeout "${per_test_timeout}" bash "${test}" ;;
+  esac
   status=$?
   elapsed=$(( $(date +%s) - start ))
   echo "::endgroup::"


### PR DESCRIPTION
Refs Extra-Chill/homeboy#10657, Extra-Chill/homeboy#10685.

## Problem

`apply-differential-gate.py` collapsed two different states into one branch:

```python
if current <= base:
    adjusted[command] = "pass"
    ...::notice::...
```

`current < base` is a genuine improvement. `current == base` with both non-zero is nothing improving while something is red — and `pass` emits a `::notice::`, which renders a **✅**. `baseline_red` at least emits a `::warning::` and renders ⚠️. `enforce-final-status.sh` has no branch for a `pass`, so a synthesised one is indistinguishable from a clean run, and a command red on the base branch stays red forever because no run ever reports it.

## Independently reconfirmed the numbers

I re-harvested the window in #10657 (2026-07-27T18:43Z → 2026-07-28T17:15Z) rather than trusting the issue. 281 workflow runs, 95 `homeboy / Test` jobs, 93 logs retrievable, pulled from `/repos/{owner}/{repo}/actions/jobs/{id}/logs` — **not** `gh run view --log`, which truncates and drops whole baseline phases.

| gate outcome | count |
|---|---|
| `pass` | **53** |
| `baseline_red` | 9 |
| `inconclusive` | 2 |
| `rejected` (blocks) | **0** |

**All 53 `pass` outcomes were `current=1 base=1`.** The improvement branch this code exists to reward fired zero times in 23 hours. 52 of those 53 runs concluded `success`.

Only correction to the issue: `inconclusive` was 2, not 1 (wider job set — 93 vs 81). The load-bearing figures are exact.

## Changes

**1. Split the comparison** (#10657): `current > base` → reject; `current == base && base > 0` → `baseline_red`; otherwise → `pass`. `baseline_red` still only warns in `enforce-final-status.sh:62`, so **nothing that was mergeable becomes blocked** — the change only stops a persistent failure rendering as green.

**2. Never pass on an uncounted failure** (#10685). A killed run reports `failed: 0`, so `0 <= base` read a suite that never finished as a clean sweep. #305 closed this for `status == "timeout"`, but `run-homeboy-commands.sh` maps **only exit 124** to `timeout`; the SIGKILL/containment paths in `run-with-liveness-timeout.sh` exit **125**, and an OOM kill surfaces as **137**. Those arrive as an ordinary `fail` carrying `failed: 0` and walked straight into `pass`. Demonstrated against the real script:

```
WITHOUT GUARD  exit137 killed vs base=1 -> {"review test":"pass"}
WITHOUT GUARD  exit125 killed vs base=4 -> {"review test":"pass"}
WITH GUARD     exit137 killed vs base=1 -> {"review test":"inconclusive"}
WITH GUARD     exit125 killed vs base=4 -> {"review test":"inconclusive"}
```

**3. Metric provenance, because the blunt version of (2) is wrong.** `metric_for` now returns `(count, kind)`. A `SCOPED` count (`changed_since.introduced_{findings,failures}`) means "what this change introduced" — zero there is the *success* measurement and must still pass against a red repo. A `TOTAL` count of zero on a command that nonetheless failed means the failure went uncounted. Applying the zero guard blindly breaks changed-scope gating, which `test-differential-gate.py` already covers; that test is what caught it.

**4. `test-differential-gate.py` had never run.** It is referenced by no runner and no workflow — `run-tests.sh` globbed only `test-*.sh`. Its assertions had drifted to encode the exact `pass`-from-two-failures behaviour being reported here, and nothing caught it. `run-tests.sh` now collects `test-*.py` too and dispatches on extension. Suite goes 26 → 27.

## Correction to the proposed fix

The issue proposes `if current < base or base == 0: pass`. The `base == 0` clause is unsafe: with `current <= base` and `base == 0`, `current` is also `0`, so it green-lights the 0/0 case — a failing command where **neither side measured anything**, which is precisely what #10685 forbids. This PR drops that clause; `base == 0` reaches `pass` only via `current < base`, which `current == 0` cannot satisfy.

## Fixture matrix

Recorded payload shapes through the classifier, asserting the resulting **verdict** — never a command string.

| case | verdict | what it proves |
|---|---|---|
| `1/1` | `baseline_red` | the defect: an equal non-zero count no longer renders green |
| `1/0` | `fail` | a real regression still blocks — the split is not permissive |
| `1/3` | `pass` | a genuine reduction is still accepted — not over-strict |
| `0/1` | `inconclusive` | a failing command reporting zero failures is uncounted, not improved |
| `0/0` | `inconclusive` | no measurement on either side is never a pass |
| killed, exit 137, `failed:0` vs base 1 | `inconclusive` | OOM kill cannot reach `pass` |
| killed, exit 125, `failed:0` vs base 4 | `inconclusive` | containment kill cannot reach `pass` |
| scoped `introduced_failures:0`, raw 3/4 vs base 3 | `pass` | changed-scope gating survives the zero guard |

**`0/1` deliberately deviates from "genuine improvement → pass".** A run that genuinely reaches zero failures exits 0, is classified `pass` in `run-homeboy-commands.sh:81`, and never enters the gate. The only way to observe `current == 0` here is a command that failed while reporting nothing — an uncounted failure. Treating it as an improvement is the killed-run hole. `1/3` is the fixture that proves genuine improvements still pass.

`inconclusive` (warn, non-blocking) is chosen over `fail` to preserve the "blocks nothing that isn't already blocked" property. It satisfies "never `pass`" without red-walling the repo.

`gate_case` resets both fixture dirs per case so no stale sidecar leaks forward, fails loudly if the gate produces empty output, and re-asserts "not `pass`" independently of the equality check.

## Mutation testing

Every change fails a specific named assertion when reverted:

| mutation | assertion that fails |
|---|---|
| collapse the `baseline_red` split | `1/1 ... is baseline_red rather than a green check` — actual `pass`; also `audit failure that reproduces unchanged...` |
| remove the zero guard | `0/1: a failing command that reports zero failures is uncounted` — actual `pass` |
| apply the zero guard ignoring provenance | `changed-scope zero introduced failures still passes against a red baseline` — actual `inconclusive` |
| revert the runner glob | suite silently drops to 26 tests |

Full suite: **27 passed, 0 failed, 27 total.**

## Release

`Extra-Chill/homeboy` pins `ref: v2`, and **`v2` currently resolves to `66fb512` (v2.8.25)** — now *three* releases behind `main` (v2.8.26, v2.8.27, and v2.9.0, which was cut during this work). `v2` therefore does not yet carry #305's timeout classification either.

**A merge to `main` does nothing in `homeboy` until `v2` is re-pointed. A release/tag IS required for this fix to take effect.** Cutting it is an operator action; I have not done it.

Worth flagging separately: `v2` did not move when v2.8.26, v2.8.27, or v2.9.0 were released, so the floating major tag appears not to be re-pointed by the release process at all. Every action fix merged since v2.8.25 is currently undeployed.

## Residual, not fixed here

- `current < base` with `current > 0` still returns `pass` — a PR reducing 3 failures to 1 gets a green check with one test still red. Same class of defect, wider blast radius; deliberately out of scope.
- A `SCOPED` current is compared against a `TOTAL` base (`test-differential-gate.py:58-72` encodes this deliberately). It is sound at `introduced == 0`, but at `introduced > 0` it compares 2-introduced against 5-total and passes. Worth its own issue.

## Verification I could not do

No cargo on this host, and this is an action repo. Python compiled, bash syntax-checked, full shell suite green locally; `shellcheck` is not installed here. CI is the gate.

## AI assistance

- Agent: chubes-bot (Claude Code)
- Used for: re-harvesting 93 CI job logs via the jobs endpoint to reconfirm the 53/9/0 counts, tracing the exit-code paths from `run-with-liveness-timeout.sh` into gate classification, and mutation-testing each change.
