### PR TITLE
fix: assert a release published, instead of that it exists

### DIFF
--- a/scripts/release/github-release.sh
+++ b/scripts/release/github-release.sh
@@ -17,7 +17,19 @@ homeboy_should_verify_github_release() {
   esac
 }
 
-homeboy_verify_github_release_exists() {
+# Assert that a release actually SHIPPED — not merely that a release object
+# exists. `gh release view` exits 0 for an unpublished draft, so the old
+# existence check reported "Verified" for releases no consumer could ever
+# resolve. On 2026-07-28 four homeboy-action releases (v2.8.26, v2.8.27,
+# v2.9.0, v2.9.1) sat as drafts while the floating `v2` tag stayed frozen at
+# v2.8.25; `gh release view v2.9.1` exits 0 against every one of them.
+#
+# The publish state is the effect that matters: a draft never moves `v2`,
+# never triggers the post:release hook, and is invisible to `ref: v2`
+# consumers. So read `isDraft` and require it to be false. An unreadable or
+# unrecognized state fails closed — absence of evidence is not evidence of a
+# published release (homeboy#10685).
+homeboy_verify_github_release_published() {
   local release_tag="$1"
   local repository="$2"
 
@@ -48,12 +60,30 @@ homeboy_verify_github_release_exists() {
     return 1
   fi
 
-  if gh release view "${release_tag}" --repo "${repository}" >/dev/null 2>&1; then
-    echo "::notice::Verified GitHub Release ${repository}@${release_tag}"
-    return 0
+  local draft_state
+  if ! draft_state="$(gh release view "${release_tag}" --repo "${repository}" --json isDraft --jq '.isDraft' 2>/dev/null)"; then
+    echo "::error::GitHub Release not found after successful release: repo=${repository} tag=${release_tag}"
+    echo "::error::Expected 'gh release view ${release_tag} --repo ${repository}' to succeed."
+    return 1
   fi
 
-  echo "::error::GitHub Release not found after successful release: repo=${repository} tag=${release_tag}"
-  echo "::error::Expected 'gh release view ${release_tag} --repo ${repository}' to succeed."
-  return 1
+  draft_state="$(printf '%s' "${draft_state}" | tr -d '[:space:]')"
+
+  case "${draft_state}" in
+    false)
+      echo "::notice::Verified GitHub Release ${repository}@${release_tag} is published"
+      return 0
+      ;;
+    true)
+      echo "::error::GitHub Release ${repository}@${release_tag} exists but is still an unpublished DRAFT."
+      echo "::error::A draft release does not move floating tags, does not run post:release hooks, and is invisible to consumers pinning a released ref."
+      echo "::error::Publish it once its assets verify: gh release edit ${release_tag} --draft=false -R ${repository}"
+      return 1
+      ;;
+    *)
+      echo "::error::Could not determine the publish state of GitHub Release ${repository}@${release_tag} (read isDraft='${draft_state}')."
+      echo "::error::Refusing to report an unverified release as published."
+      return 1
+      ;;
+  esac
 }

--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -263,6 +263,20 @@ if [ "${DRY_RUN}" = "true" ]; then
   exit 0
 fi
 
+# `homeboy release` reporting success is not proof that the release shipped.
+# The github.release step creates a DRAFT and publishes it in a later call; if
+# that publish never lands, the tag exists over an unpublished draft and the
+# pipeline still looks green. Assert the published effect before announcing a
+# release. Skipped when this component's GitHub Release is created elsewhere
+# (--no-github-release), because then there is nothing for us to assert.
+if [ "${RELEASE_SKIP_GITHUB_RELEASE}" != "true" ]; then
+  if ! homeboy_verify_github_release_published "${TAG:-v${VERSION}}" "${GITHUB_REPOSITORY:-}"; then
+    write_release_outputs "${RELEASE_OUTPUT_FILE}" "false" "release-not-published"
+    rm -f "${RELEASE_OUTPUT_FILE}"
+    exit 1
+  fi
+fi
+
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "  Released ${TAG} (${BUMP_TYPE})"

--- a/scripts/release/test-github-release-verification.sh
+++ b/scripts/release/test-github-release-verification.sh
@@ -45,51 +45,76 @@ assert_failure_contains() {
   printf 'PASS: %s\n' "${label}"
 }
 
+# The fake gh mirrors the real contract: `gh release view --json isDraft --jq
+# .isDraft` prints `true` for a draft and `false` for a published release, and
+# exits non-zero when no release exists. Tests assert the VERDICT the helper
+# reaches from that output, not the command string it happens to build — a
+# gate that asserts an invocation cannot notice that the invocation proves
+# nothing (homeboy#10685).
 write_fake_gh() {
   local exit_code="$1"
+  local stdout="${2:-}"
   cat >"${TMP_DIR}/gh" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" > "${TMP_DIR}/gh-args"
+printf '%s' '${stdout}'
 exit ${exit_code}
 EOF
   chmod +x "${TMP_DIR}/gh"
 }
 
-write_fake_gh 0
+# A published release is the only state that may pass.
+write_fake_gh 0 'false'
 PATH="${TMP_DIR}:${PATH}" assert_success \
-  "verifies existing GitHub Release" \
-  homeboy_verify_github_release_exists "v1.2.3" "Extra-Chill/homeboy-action"
+  "accepts a published GitHub Release" \
+  homeboy_verify_github_release_published "v1.2.3" "Extra-Chill/homeboy-action"
 
-if [ "$(cat "${TMP_DIR}/gh-args")" != "release view v1.2.3 --repo Extra-Chill/homeboy-action" ]; then
-  printf 'FAIL: gh release view arguments were not passed through correctly\n'
+if ! grep -q -- '--json isDraft' "${TMP_DIR}/gh-args"; then
+  printf 'FAIL: verification did not ask GitHub for the publish state\n'
   printf 'args: %s\n' "$(cat "${TMP_DIR}/gh-args")"
   exit 1
 fi
-printf 'PASS: gh release view receives tag and repo\n'
+printf 'PASS: verification reads the release publish state\n'
 
-write_fake_gh 1
+# THE REGRESSION THIS GUARDS: `gh release view` exits 0 for a draft, so an
+# existence check reported success for the four stranded homeboy-action
+# drafts that left the floating v2 tag frozen for two days.
+write_fake_gh 0 'true'
+PATH="${TMP_DIR}:${PATH}" assert_failure_contains \
+  "is still an unpublished DRAFT" \
+  "rejects a release that exists but was never published" \
+  homeboy_verify_github_release_published "v2.9.1" "Extra-Chill/homeboy-action"
+
+# Fail closed: an unreadable publish state is not a published release.
+write_fake_gh 0 ''
+PATH="${TMP_DIR}:${PATH}" assert_failure_contains \
+  "Could not determine the publish state" \
+  "refuses to pass when the publish state is unreadable" \
+  homeboy_verify_github_release_published "v1.2.3" "Extra-Chill/homeboy-action"
+
+write_fake_gh 1 ''
 PATH="${TMP_DIR}:${PATH}" assert_failure_contains \
   "GitHub Release not found after successful release: repo=Extra-Chill/homeboy-action tag=v9.9.9" \
   "fails clearly when GitHub Release is missing" \
-  homeboy_verify_github_release_exists "v9.9.9" "Extra-Chill/homeboy-action"
+  homeboy_verify_github_release_published "v9.9.9" "Extra-Chill/homeboy-action"
 
 HOMEBOY_VERIFY_GITHUB_RELEASE=false assert_success \
   "can skip verification for tag-only release consumers" \
-  homeboy_verify_github_release_exists "v1.2.3" "Extra-Chill/homeboy-action"
+  homeboy_verify_github_release_published "v1.2.3" "Extra-Chill/homeboy-action"
 
 HOMEBOY_VERIFY_GITHUB_RELEASE=maybe assert_failure_contains \
   "Invalid HOMEBOY_VERIFY_GITHUB_RELEASE value" \
   "rejects invalid verification configuration" \
-  homeboy_verify_github_release_exists "v1.2.3" "Extra-Chill/homeboy-action"
+  homeboy_verify_github_release_published "v1.2.3" "Extra-Chill/homeboy-action"
 
 assert_failure_contains \
   "release tag is empty" \
   "fails clearly when tag is empty" \
-  homeboy_verify_github_release_exists "" "Extra-Chill/homeboy-action"
+  homeboy_verify_github_release_published "" "Extra-Chill/homeboy-action"
 
 assert_failure_contains \
   "GITHUB_REPOSITORY is empty" \
   "fails clearly when repository is empty" \
-  homeboy_verify_github_release_exists "v1.2.3" ""
+  homeboy_verify_github_release_published "v1.2.3" ""
 
 printf 'All GitHub Release verification checks passed.\n'

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -91,7 +91,7 @@ assert_contains 'GIT_ASKPASS' "${RUN_RELEASE}" "run-release provides token auth 
 assert_not_contains 'git config user.name' "${RUN_RELEASE}" "run-release does not configure git identity directly"
 assert_not_contains 'git config --local' "${RUN_RELEASE}" "run-release does not configure git auth directly"
 assert_not_contains 'remote set-url origin' "${RUN_RELEASE}" "run-release does not rewrite origin to an authenticated URL"
-assert_not_contains 'homeboy_verify_github_release_exists "${TAG}" "${GITHUB_REPOSITORY:-}"' "${RUN_RELEASE}" "run-release does not verify GitHub Release before tag workflow creates it"
+assert_contains 'homeboy_verify_github_release_published' "${RUN_RELEASE}" "run-release asserts the release actually published before reporting success"
 assert_contains 'release-verify-github-release:' "${ROOT_DIR}/action.yml" "action exposes GitHub Release verification toggle"
 assert_contains 'HOMEBOY_VERIFY_GITHUB_RELEASE: ${{ inputs.release-verify-github-release }}' "${ROOT_DIR}/action.yml" "action passes verification toggle to release script"
 assert_contains 'id: artifact-names' "${ROOT_DIR}/action.yml" "action computes matrix-safe artifact names"

--- a/scripts/release/test-run-release-wrapper.sh
+++ b/scripts/release/test-run-release-wrapper.sh
@@ -160,10 +160,13 @@ JSON
 esac
 SH
 
+  # MOCK_RELEASE_DRAFT_STATE drives the publish-state read the wrapper uses to
+  # confirm a release actually shipped. Defaults to a published release.
   cat > "${BIN_DIR}/gh" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-if [ "$*" = "release view v2.1.0 --repo Extra-Chill/homeboy-action" ]; then
+if [ "$*" = "release view v2.1.0 --repo Extra-Chill/homeboy-action --json isDraft --jq .isDraft" ]; then
+  printf '%s\n' "${MOCK_RELEASE_DRAFT_STATE:-false}"
   exit 0
 fi
 echo "unexpected gh args: $*" >&2
@@ -182,6 +185,7 @@ run_wrapper() {
   HOMEBOY_AUTH_FILE="${HOMEBOY_AUTH_FILE}" \
   HOMEBOY_MOCK_SCENARIO="${HOMEBOY_MOCK_SCENARIO}" \
   HOMEBOY_SUPPORTS_CONFIRM_FLAG="${HOMEBOY_SUPPORTS_CONFIRM_FLAG:-true}" \
+  MOCK_RELEASE_DRAFT_STATE="${MOCK_RELEASE_DRAFT_STATE:-false}" \
   MOCK_GIT_LOG="${MOCK_GIT_LOG}" \
   RELEASE_DRY_RUN="${RELEASE_DRY_RUN:-false}" \
   RELEASE_SKIP_PUBLISH="${RELEASE_SKIP_PUBLISH:-false}" \
@@ -225,6 +229,28 @@ assert_output_line 'release-tag=v2.1.0' "${OUTPUT_FILE}" "release tag output is 
 assert_output_line 'release-bump-type=minor' "${OUTPUT_FILE}" "release bump type output is translated"
 assert_output_line 'bump-type=minor' "${OUTPUT_FILE}" "legacy step bump type output is preserved"
 assert_no_git_pull "wrapper does not run its own git pull (core owns tip-sync)"
+
+# THE STRANDED-DRAFT REGRESSION (homeboy#10685).
+# `homeboy release` can report success while its github.release step leaves an
+# unpublished draft over the pushed tag — that is exactly how homeboy-action
+# v2.8.26/v2.8.27/v2.9.0/v2.9.1 stranded on 2026-07-28 with the floating v2 tag
+# frozen. A green `homeboy release` is therefore NOT proof of a shipped
+# release, so the wrapper must independently assert the published state and go
+# red when it finds a draft.
+setup_fixture
+HOMEBOY_MOCK_SCENARIO="released"
+GH_TOKEN="secret123"
+MOCK_RELEASE_DRAFT_STATE="true"
+DRAFT_OUTPUT="$(run_wrapper 2>&1)" && {
+  printf 'FAIL: wrapper reported success over an unpublished draft release\n%s\n' "${DRAFT_OUTPUT}"
+  exit 1
+}
+printf 'PASS: successful homeboy release over an unpublished draft exits non-zero\n'
+assert_contains 'is still an unpublished DRAFT' "${DRAFT_OUTPUT}" "stranded draft is named in the CI annotation"
+assert_contains 'gh release edit v2.1.0 --draft=false' "${DRAFT_OUTPUT}" "operator repair command is printed next to the stranded draft"
+assert_output_line 'released=false' "${OUTPUT_FILE}" "stranded draft is not reported as released"
+assert_output_line 'skipped-reason=release-not-published' "${OUTPUT_FILE}" "stranded draft reports the release-not-published reason"
+unset MOCK_RELEASE_DRAFT_STATE
 
 setup_fixture
 HOMEBOY_MOCK_SCENARIO="skipped"


### PR DESCRIPTION
## What

`homeboy_verify_github_release_exists` asked `gh release view` whether a release object existed. **That command exits 0 for an unpublished draft**, so the one gate meant to confirm a release shipped could not distinguish a shipped release from a stranded one.

It never got the chance to be wrong. The helper was defined, unit-tested, and `source`d by `run-release.sh` — but **no production path ever called it**, and `test-release-workflow.sh:94` actively asserted that `run-release.sh` does *not* call it. homeboy-action had no post-release publish verification at all.

## Evidence

Four releases cut 2026-07-28 are still drafts, freezing the floating `v2` tag at v2.8.25 and leaving #302, #305, #306, #307 dark:

| tag | state | created | run / job | release-step outcome |
|---|---|---|---|---|
| v2.8.26 | Draft | 10:16:59Z | [30349974954](https://github.com/Extra-Chill/homeboy-action/actions/runs/30349974954) / 90245336671 | `gh api release metadata exited with status 1` |
| v2.8.27 | Draft | 17:59:40Z | [30385222408](https://github.com/Extra-Chill/homeboy-action/actions/runs/30385222408) / 90363180269 | same |
| v2.9.0 | Draft | 23:01:39Z | [30406472323](https://github.com/Extra-Chill/homeboy-action/actions/runs/30406472323) / 90433354570 | same |
| v2.9.1 | Draft | 23:30:38Z | [30408035856](https://github.com/Extra-Chill/homeboy-action/actions/runs/30408035856) / 90438190017 | same |

Every one of them satisfies the old check today:

```
$ gh release view v2.9.1 --repo Extra-Chill/homeboy-action; echo $?
0
$ gh release view v2.9.1 --repo Extra-Chill/homeboy-action --json isDraft
{"isDraft":true}
```

## Change

- Read `isDraft` and require `false`. A draft fails with the operator repair command (`gh release edit <tag> --draft=false`); an unreadable state **fails closed**.
- Call it from `run-release.sh` on the success path. `homeboy release` reporting success is not proof the `github.release` step finished publishing — that is precisely the failure mode above.
- Skipped when `RELEASE_SKIP_GITHUB_RELEASE=true`, where there is nothing for us to assert.

## Verification discipline

Tests assert the **verdict reached from gh's output**, not the command string built to get it. The prior test asserted `"release view v1.2.3 --repo ..."` — a gate that asserts its own invocation cannot notice that the invocation proves nothing. Added wrapper-level coverage where a *successful* `homeboy release` over a draft must exit non-zero.

`bash scripts/run-tests.sh` → **28 passed, 0 failed**.

## Scope

This makes the stranding **visible and red**; it does not fix the publisher. The underlying `gh api release metadata` failure lives in `homeboy`'s `github.release` executor and is shared by both repos — see the accompanying report.

Refs #10685