### PR TITLE
fix: resolve the release branch on a detached HEAD instead of skipping green

### DIFF
--- a/scripts/release/run-release.sh
+++ b/scripts/release/run-release.sh
@@ -115,7 +115,59 @@ COMP_ID="$(resolve_component_id)"
 
 configure_git_push_auth
 
-CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+# Identify the branch HEAD is on.
+#
+# `git rev-parse --abbrev-ref HEAD` returns the LITERAL STRING "HEAD" on a
+# detached checkout, and `actions/checkout` detaches whenever it is given
+# `ref: <sha>` — the ordinary way a workflow pins every job to the commit that
+# triggered it. The guard below compared that literal against RELEASE_BRANCH,
+# concluded "not on main" for a commit that WAS main's tip, and exited 0 without
+# ever invoking `homeboy release`. No release-version was written, and the
+# calling workflow read that emptiness as "nothing to release" — green run,
+# every job skipped, 131 commits unreleased (Extra-Chill/homeboy#10703).
+#
+# When HEAD is detached, identify the branch by COMMIT IDENTITY instead. That is
+# also the property this guard actually cares about: not the name HEAD is
+# reachable under, but whether the commit being released is the release branch.
+#
+# This is deliberately NOT solved by RELEASE_HEAD. That variable also appends
+# `--head`, which tells homeboy to finish an already-versioned, already-tagged
+# HEAD and to skip version and changelog computation entirely. It answers "what
+# kind of release is this", not "where am I allowed to release from"; using it
+# to silence a branch check would skip the very work a dry run exists to do.
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+BRANCH_UNDETERMINABLE="false"
+
+if [ "${CURRENT_BRANCH}" = "HEAD" ]; then
+  DETACHED_SHA="$(git rev-parse HEAD 2>/dev/null || true)"
+  RELEASE_BRANCH_SHA=""
+  for candidate_ref in "refs/remotes/origin/${RELEASE_BRANCH}" "refs/heads/${RELEASE_BRANCH}"; do
+    RELEASE_BRANCH_SHA="$(git rev-parse -q --verify "${candidate_ref}" 2>/dev/null || true)"
+    [ -n "${RELEASE_BRANCH_SHA}" ] && break
+  done
+
+  if [ -z "${DETACHED_SHA}" ] || [ -z "${RELEASE_BRANCH_SHA}" ]; then
+    BRANCH_UNDETERMINABLE="true"
+  elif [ "${DETACHED_SHA}" = "${RELEASE_BRANCH_SHA}" ]; then
+    echo "::notice::HEAD is detached at the ${RELEASE_BRANCH} tip ${DETACHED_SHA:0:8} - releasing as ${RELEASE_BRANCH}"
+    CURRENT_BRANCH="${RELEASE_BRANCH}"
+  else
+    echo "::notice::HEAD is detached at ${DETACHED_SHA:0:8}, which is not the ${RELEASE_BRANCH} tip ${RELEASE_BRANCH_SHA:0:8}"
+  fi
+fi
+
+# UNKNOWN is not a measured negative (Extra-Chill/homeboy#10685). Exiting 0 here
+# would report "released=false" with a skip reason, which every caller reads as
+# "there was nothing to release" — a claim this script cannot support when it
+# could not even establish which branch it is on. Fail loudly instead, with a
+# reason that cannot be confused for a measurement.
+if [ "${RELEASE_HEAD}" != "true" ] && [ "${BRANCH_UNDETERMINABLE}" = "true" ]; then
+  echo "::error::Cannot determine whether HEAD is on ${RELEASE_BRANCH}: HEAD is detached and no ref for ${RELEASE_BRANCH} exists in this checkout. Fetch the branch (actions/checkout with fetch-depth: 0), or set release-head when finishing an already-tagged HEAD. Refusing to report 'nothing to release' for a state that was never measured."
+  write_output "released" "false"
+  write_output "skipped-reason" "branch-undeterminable"
+  exit 1
+fi
+
 if [ "${RELEASE_HEAD}" != "true" ] && [ "${CURRENT_BRANCH}" != "${RELEASE_BRANCH}" ]; then
   echo "::notice::Not on ${RELEASE_BRANCH} (current: ${CURRENT_BRANCH}) - skipping release"
   write_output "released" "false"

--- a/scripts/release/test-run-release-wrapper.sh
+++ b/scripts/release/test-run-release-wrapper.sh
@@ -71,7 +71,22 @@ if [ -n "${MOCK_GIT_LOG:-}" ]; then
 fi
 case "$1 $2" in
   "rev-parse --abbrev-ref")
+    # Returns the literal string "HEAD" on a detached checkout, which is
+    # exactly what `actions/checkout` with `ref: <sha>` produces.
     echo "${MOCK_BRANCH:-main}"
+    ;;
+  "rev-parse HEAD")
+    # Commit identity of the detached HEAD. Empty models a checkout so broken
+    # that even this fails.
+    [ -n "${MOCK_HEAD_SHA:-}" ] || exit 1
+    echo "${MOCK_HEAD_SHA}"
+    ;;
+  "rev-parse -q")
+    # `git rev-parse -q --verify <ref>`. Empty MOCK_RELEASE_BRANCH_SHA models a
+    # checkout with no ref for the release branch (e.g. a shallow clone), which
+    # is the genuinely undeterminable case.
+    [ -n "${MOCK_RELEASE_BRANCH_SHA:-}" ] || exit 1
+    echo "${MOCK_RELEASE_BRANCH_SHA}"
     ;;
   "symbolic-ref --short")
     echo "origin/${MOCK_DEFAULT_BRANCH:-main}"
@@ -189,6 +204,8 @@ run_wrapper() {
   RELEASE_HEAD="${RELEASE_HEAD:-false}" \
   RELEASE_FROM_ARTIFACTS="${RELEASE_FROM_ARTIFACTS:-}" \
   MOCK_BRANCH="${MOCK_BRANCH:-main}" \
+  MOCK_HEAD_SHA="${MOCK_HEAD_SHA:-}" \
+  MOCK_RELEASE_BRANCH_SHA="${MOCK_RELEASE_BRANCH_SHA:-}" \
   GH_TOKEN="${GH_TOKEN:-}" \
   bash "${RUN_RELEASE}"
 }
@@ -293,6 +310,11 @@ assert_output_line 'release-version=2.1.0' "${OUTPUT_FILE}" "dry-run preserves p
 assert_output_line 'release-tag=v2.1.0' "${OUTPUT_FILE}" "dry-run preserves planned tag"
 assert_output_line 'release-bump-type=minor' "${OUTPUT_FILE}" "dry-run preserves planned bump"
 assert_output_line 'skipped-reason=dry-run' "${OUTPUT_FILE}" "dry-run reason is action glue"
+# RELEASE_DRY_RUN leaked into every test below this point — each `run_wrapper`
+# defaults it with `${RELEASE_DRY_RUN:-false}`, so once set it stays set for the
+# rest of the file. The later assertions happened not to depend on it, so
+# nothing caught it. Unset it so each block starts from the documented default.
+unset RELEASE_DRY_RUN
 
 # Extra-Chill/homeboy#10441: a release that fails a step returns the v3
 # envelope, which has no `.error`. Reading only `.error.message` printed
@@ -332,5 +354,102 @@ if [ "${LEGACY_EXIT}" -eq 0 ]; then
 fi
 printf 'PASS: legacy failure exits non-zero\n'
 assert_contains 'Release failed: mock failure' "${LEGACY_OUTPUT}" "legacy .error.message envelope still reports its message"
+
+
+# ── Detached HEAD (Extra-Chill/homeboy#10703) ──
+#
+# `actions/checkout` with `ref: <sha>` detaches HEAD, so
+# `git rev-parse --abbrev-ref HEAD` returns the LITERAL string "HEAD". The
+# branch guard compared that to RELEASE_BRANCH, decided "not on main" for a
+# commit that WAS main's tip, and exited 0 without invoking homeboy. The caller
+# read the missing release-version as "nothing to release" and skipped every
+# job while reporting success — for 131 commits.
+#
+# These assert the EFFECT: what the wrapper decides and whether homeboy ran at
+# all, not which strings the script contains.
+
+# HEAD detached AT the release branch tip: this IS main. Release must proceed.
+setup_fixture
+HOMEBOY_MOCK_SCENARIO="released"
+MOCK_BRANCH="HEAD"
+MOCK_HEAD_SHA="86c1afc9b8db41ef029345a1b47201d95563942e"
+MOCK_RELEASE_BRANCH_SHA="86c1afc9b8db41ef029345a1b47201d95563942e"
+GH_TOKEN="secret123"
+DETACHED_OUTPUT="$(run_wrapper 2>&1)"
+assert_contains 'releasing as main' "${DETACHED_OUTPUT}" "detached HEAD at the tip is recognised as the release branch"
+assert_not_contains 'skipping release' "${DETACHED_OUTPUT}" "detached HEAD at the tip must not be skipped as wrong-branch"
+# The load-bearing assertion: homeboy actually RAN. The bug's signature is that
+# it never did, so no args file existed and no version was ever computed.
+if [ ! -f "${HOMEBOY_ARGS_FILE}" ]; then
+  printf 'FAIL: homeboy release was never invoked from a detached HEAD at the release branch tip\n%s\n' "${DETACHED_OUTPUT}"
+  exit 1
+fi
+printf 'PASS: homeboy release is invoked from a detached HEAD at the release branch tip\n'
+assert_output_line 'release-version=2.1.0' "${OUTPUT_FILE}" "detached HEAD at the tip still computes a version"
+assert_not_contains '--head' "$(cat "${HOMEBOY_ARGS_FILE}")" "resolving the branch must NOT smuggle in --head, which would skip version computation"
+unset MOCK_BRANCH MOCK_HEAD_SHA MOCK_RELEASE_BRANCH_SHA
+
+# HEAD detached at some OTHER commit: genuinely not the release branch. This is
+# a measured negative, so the quiet skip is correct and must be preserved.
+setup_fixture
+HOMEBOY_MOCK_SCENARIO="released"
+MOCK_BRANCH="HEAD"
+MOCK_HEAD_SHA="1111111111111111111111111111111111111111"
+MOCK_RELEASE_BRANCH_SHA="2222222222222222222222222222222222222222"
+GH_TOKEN="secret123"
+set +e
+OTHER_OUTPUT="$(run_wrapper 2>&1)"
+OTHER_EXIT=$?
+set -e
+if [ "${OTHER_EXIT}" -ne 0 ]; then
+  printf 'FAIL: a determinable non-release commit must skip quietly, not fail\n%s\n' "${OTHER_OUTPUT}"
+  exit 1
+fi
+printf 'PASS: a determinable non-release commit skips quietly\n'
+assert_output_line 'skipped-reason=wrong-branch' "${OUTPUT_FILE}" "a commit that is not the release branch tip is still wrong-branch"
+if [ -f "${HOMEBOY_ARGS_FILE}" ]; then
+  printf 'FAIL: homeboy must not run for a commit that is not the release branch\n'
+  exit 1
+fi
+printf 'PASS: homeboy does not run for a commit that is not the release branch\n'
+unset MOCK_BRANCH MOCK_HEAD_SHA MOCK_RELEASE_BRANCH_SHA
+
+# HEAD detached and NO ref for the release branch exists: the branch cannot be
+# determined at all. Extra-Chill/homeboy#10685 — absence of evidence must never
+# be evidence of success. This must FAIL, with a reason that cannot be mistaken
+# for a measurement, rather than exit 0 as "wrong-branch".
+setup_fixture
+HOMEBOY_MOCK_SCENARIO="released"
+MOCK_BRANCH="HEAD"
+MOCK_HEAD_SHA="86c1afc9b8db41ef029345a1b47201d95563942e"
+MOCK_RELEASE_BRANCH_SHA=""
+GH_TOKEN="secret123"
+set +e
+UNKNOWN_OUTPUT="$(run_wrapper 2>&1)"
+UNKNOWN_EXIT=$?
+set -e
+if [ "${UNKNOWN_EXIT}" -eq 0 ]; then
+  printf 'FAIL: an undeterminable branch must not exit 0 — that is how "unknown" becomes "nothing to release"\n%s\n' "${UNKNOWN_OUTPUT}"
+  exit 1
+fi
+printf 'PASS: an undeterminable branch exits non-zero\n'
+assert_contains '::error::' "${UNKNOWN_OUTPUT}" "an undeterminable branch is loud"
+assert_output_line 'skipped-reason=branch-undeterminable' "${OUTPUT_FILE}" "an undeterminable branch reports a reason distinct from the measured wrong-branch"
+assert_not_contains 'skipped-reason=wrong-branch' "$(cat "${OUTPUT_FILE}")" "unknown must never be reported as the measured wrong-branch negative"
+unset MOCK_BRANCH MOCK_HEAD_SHA MOCK_RELEASE_BRANCH_SHA
+
+# release-head still bypasses the branch guard entirely: it finishes an
+# already-tagged HEAD, where the branch is irrelevant by construction.
+setup_fixture
+HOMEBOY_MOCK_SCENARIO="released"
+RELEASE_HEAD="true"
+MOCK_BRANCH="HEAD"
+MOCK_HEAD_SHA=""
+MOCK_RELEASE_BRANCH_SHA=""
+GH_TOKEN="secret123"
+run_wrapper >/dev/null 2>&1
+assert_contains '--head' "$(cat "${HOMEBOY_ARGS_FILE}")" "release-head still finishes an already-tagged HEAD without a resolvable branch"
+assert_output_line 'released=true' "${OUTPUT_FILE}" "release-head is unaffected by branch resolution"
+unset RELEASE_HEAD MOCK_BRANCH MOCK_HEAD_SHA MOCK_RELEASE_BRANCH_SHA
 
 printf 'All run-release wrapper checks passed.\n'


### PR DESCRIPTION
Durable half of Extra-Chill/homeboy#10703. Immediate half: Extra-Chill/homeboy#10706.

## The bug

`git rev-parse --abbrev-ref HEAD` returns the **literal string `HEAD`** on a detached checkout, and `actions/checkout` detaches whenever it is given `ref: <sha>` — the ordinary way a workflow pins every job to the commit that triggered it.

`run-release.sh:118-124` compared that literal against `RELEASE_BRANCH`, concluded "not on main" for a commit that **was** main's tip, and `exit 0` **before `homeboy release` was ever invoked**. No `release-version` was written, so the calling workflow read the emptiness as "nothing to release" — a green run with every job skipped. On `Extra-Chill/homeboy` that held back **131 commits**, 86 of them conventional `fix:`/`feat:`.

Evidence — run 30410721084, job 90446396775, line 3377:

```
##[notice]Not on main (current: HEAD) - skipping release
```

`(current: HEAD)` is the variable rendered verbatim. `grep -rn "skipping release"` matches only `run-release.sh:120`, so the path is unambiguous.

## The fix

When HEAD is detached, identify the branch by **commit identity**: is HEAD the tip of the release branch? That is the property this guard actually cares about — not the name HEAD happens to be reachable under.

- detached **at** the release branch tip -> this *is* the release branch, proceed
- detached at **some other** commit -> genuinely not the release branch, skip quietly as `wrong-branch` (unchanged)
- detached with **no ref** for the release branch (shallow clone) -> **`branch-undeterminable`, exit 1**

That last case is the #10685 invariant. Exiting 0 with `released=false` tells every caller "there was nothing to release" — a claim this script cannot support when it could not establish which branch it is on. Absence of evidence must not be evidence of success.

## Why not just set `RELEASE_HEAD`

`RELEASE_HEAD` conflates two unrelated concerns: it bypasses the branch guard (lines 119/131) **and** appends `--head` (line 182). `--head` means "finish an already-versioned, already-tagged HEAD" and **skips version and changelog computation**. It answers *what kind of release is this*, not *where am I allowed to release from*. Using it to silence a branch check would skip the very work a dry run exists to do. A test asserts the branch resolution does not smuggle `--head` in.

Consumers already setting `release-head` are unaffected — the guard is still bypassed wholesale for them.

## Blast radius

Only **SHA-detached** checkouts change behaviour. A checkout on a real feature branch still resolves a real name from `--abbrev-ref` and skips quietly exactly as before. Of the detached cases, only the genuinely unresolvable one newly errors.

## Verification

`bash scripts/run-tests.sh` -> **28 passed, 0 failed, 28 total**, including `scripts/release/test-run-release-wrapper.sh` (collected by the `scripts/*/test-{*.sh,*.py}` glob).

Nine new assertions, all asserting **effects** — chiefly *did `homeboy release` actually run*, since the bug's signature is that it never did:

```
PASS: detached HEAD at the tip is recognised as the release branch
PASS: detached HEAD at the tip must not be skipped as wrong-branch
PASS: homeboy release is invoked from a detached HEAD at the release branch tip
PASS: detached HEAD at the tip still computes a version
PASS: resolving the branch must NOT smuggle in --head, which would skip version computation
PASS: a determinable non-release commit skips quietly
PASS: homeboy does not run for a commit that is not the release branch
PASS: an undeterminable branch exits non-zero
PASS: unknown must never be reported as the measured wrong-branch negative
```

**Mutation-tested**: restoring the one-line `CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"` guard makes the suite exit 1 at the first detached assertion.

## Incidental test-hygiene fix

`RELEASE_DRY_RUN="true"` was set at line 302 and **never unset**. Because `run_wrapper` defaults it with `${RELEASE_DRY_RUN:-false}`, every test after it silently ran in dry-run mode; the later assertions happened not to depend on it, so nothing caught it. My new `released=true` assertion did. Now unset after the dry-run block.

## Deployment

**This PR does not take effect for `Extra-Chill/homeboy` until `v2` is re-pointed.** `v2` is frozen at `66fb512` (v2.8.25, Jul 26) because this repo's own releases — v2.8.26, v2.8.27, v2.9.0, v2.9.1 — are all stranded Drafts. The guard is byte-identical between `v2^{commit}` and `origin/main`, confirming nothing here has shipped. Extra-Chill/homeboy#10706 is written to stand alone so the release pipeline unblocks without waiting on that tag move.
