### PR TITLE
fix: preserve CLI and CI result provenance

### DIFF
--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -24,6 +24,10 @@ HOMEBOY_OUTPUT_DIR=$(mktemp -d)
 echo "HOMEBOY_OUTPUT_DIR=${HOMEBOY_OUTPUT_DIR}" >> "${GITHUB_ENV}"
 
 HOMEBOY_CI_RESULTS_DIR="${GITHUB_WORKSPACE:-$(pwd)}/homeboy-ci-results"
+if [ -L "${HOMEBOY_CI_RESULTS_DIR}" ] || { [ -e "${HOMEBOY_CI_RESULTS_DIR}" ] && [ ! -d "${HOMEBOY_CI_RESULTS_DIR}" ]; }; then
+  echo "::error::HOMEBOY_CI_RESULTS_DIR must be a real directory: ${HOMEBOY_CI_RESULTS_DIR}"
+  exit 1
+fi
 mkdir -p "${HOMEBOY_CI_RESULTS_DIR}"
 echo "HOMEBOY_CI_RESULTS_DIR=${HOMEBOY_CI_RESULTS_DIR}" >> "${GITHUB_ENV}"
 
@@ -47,10 +51,25 @@ for CMD in "${CMD_ARRAY[@]}"; do
 
   OUTPUT_STEM="$(command_output_stem "${CMD}")"
   if [ "$(printf '%s' "${CMD}" | awk '{print $1}')" = "bench" ]; then
-    OUTPUT_JSON="${HOMEBOY_CI_RESULTS_DIR}/bench.json"
+    CI_RESULT_JSON="${HOMEBOY_CI_RESULTS_DIR}/bench.json"
+    OUTPUT_JSON="${CI_RESULT_JSON}"
   else
+    CI_RESULT_JSON="${HOMEBOY_CI_RESULTS_DIR}/${OUTPUT_STEM}.json"
     OUTPUT_JSON="${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.json"
   fi
+
+  if [ -L "${HOMEBOY_CI_RESULTS_DIR}" ] || [ ! -d "${HOMEBOY_CI_RESULTS_DIR}" ]; then
+    echo "::error::HOMEBOY_CI_RESULTS_DIR must remain a real directory: ${HOMEBOY_CI_RESULTS_DIR}"
+    exit 1
+  fi
+  if [ -e "${CI_RESULT_JSON}" ] && [ ! -f "${CI_RESULT_JSON}" ] && [ ! -L "${CI_RESULT_JSON}" ]; then
+    echo "::error::homeboy ${CMD} result target must be a file: ${CI_RESULT_JSON}"
+    exit 1
+  fi
+  # Each command owns exactly one CI result target; remove only that target so
+  # a stale result cannot validate or be uploaded for this invocation.
+  rm -f "${CI_RESULT_JSON}"
+
   FULL_CMD="$(build_run_command "${CMD}" "${COMP_ID}" "${WORKSPACE}" "${OUTPUT_JSON}")"
 
   echo ""
@@ -72,13 +91,23 @@ for CMD in "${CMD_ARRAY[@]}"; do
   echo "::endgroup::"
 
   STRUCTURED_OUTPUT=true
-  if [ ! -s "${OUTPUT_JSON}" ] || ! valid_command_result_output "${OUTPUT_JSON}" "${CMD}" "${CMD_EXIT}"; then
+  if [ -L "${HOMEBOY_CI_RESULTS_DIR}" ] || [ ! -d "${HOMEBOY_CI_RESULTS_DIR}" ]; then
     STRUCTURED_OUTPUT=false
+    echo "::error::HOMEBOY_CI_RESULTS_DIR must remain a real directory: ${HOMEBOY_CI_RESULTS_DIR}"
+  elif [ -L "${CI_RESULT_JSON}" ] || { [ -e "${CI_RESULT_JSON}" ] && [ ! -f "${CI_RESULT_JSON}" ]; } || [ ! -s "${OUTPUT_JSON}" ] || ! valid_command_result_output "${OUTPUT_JSON}" "${CMD}" "${CMD_EXIT}"; then
+    STRUCTURED_OUTPUT=false
+    rm -f "${CI_RESULT_JSON}"
     echo "::error::homeboy ${CMD} did not write valid structured output to ${OUTPUT_JSON}"
   elif [ "$(printf '%s' "${CMD}" | awk '{print $1}')" = "bench" ]; then
     cp "${OUTPUT_JSON}" "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.json"
   else
-    cp "${OUTPUT_JSON}" "${HOMEBOY_CI_RESULTS_DIR}/${OUTPUT_STEM}.json"
+    if [ -L "${HOMEBOY_CI_RESULTS_DIR}" ] || [ ! -d "${HOMEBOY_CI_RESULTS_DIR}" ] || [ -L "${CI_RESULT_JSON}" ]; then
+      STRUCTURED_OUTPUT=false
+      rm -f "${CI_RESULT_JSON}"
+      echo "::error::homeboy ${CMD} result target is not safe to publish"
+    else
+      cp "${OUTPUT_JSON}" "${HOMEBOY_CI_RESULTS_DIR}/${OUTPUT_STEM}.json"
+    fi
   fi
 
   if [ "${CMD_EXIT}" -eq 0 ] && [ "${STRUCTURED_OUTPUT}" = true ]; then

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -77,6 +77,8 @@ for CMD in "${CMD_ARRAY[@]}"; do
     echo "::error::homeboy ${CMD} did not write valid structured output to ${OUTPUT_JSON}"
   elif [ "$(printf '%s' "${CMD}" | awk '{print $1}')" = "bench" ]; then
     cp "${OUTPUT_JSON}" "${HOMEBOY_OUTPUT_DIR}/${OUTPUT_STEM}.json"
+  else
+    cp "${OUTPUT_JSON}" "${HOMEBOY_CI_RESULTS_DIR}/${OUTPUT_STEM}.json"
   fi
 
   if [ "${CMD_EXIT}" -eq 0 ] && [ "${STRUCTURED_OUTPUT}" = true ]; then

--- a/scripts/core/test-run-homeboy-commands.sh
+++ b/scripts/core/test-run-homeboy-commands.sh
@@ -49,9 +49,20 @@ if ! grep -q 'FAILED (exit code 1)' "${TMP_DIR}/run.log"; then
   exit 1
 fi
 
-printf 'PASS: failed review test records a current-run failure\n'
+output_dir="$(grep '^HOMEBOY_OUTPUT_DIR=' "${TMP_DIR}/github-env" | cut -d= -f2-)"
+temporary_result="${output_dir}/review-test.json"
+ci_result="${TMP_DIR}/workspace/homeboy-ci-results/review-test.json"
+if ! jq -e . "${temporary_result}" >/dev/null 2>&1 \
+  || ! jq -e . "${ci_result}" >/dev/null 2>&1 \
+  || ! cmp -s "${temporary_result}" "${ci_result}"; then
+  printf 'FAIL: valid review test result is retained and mirrored to CI artifacts\n'
+  exit 1
+fi
+
+printf 'PASS: failed review test records a current-run failure and mirrors its valid result\n'
 
 for output_mode in missing malformed; do
+  rm -f "${TMP_DIR}/workspace/homeboy-ci-results/review-test.json"
   cat > "${TMP_DIR}/bin/homeboy" <<'SH'
 #!/usr/bin/env bash
 output=""
@@ -74,6 +85,10 @@ SH
   set -e
   if [ "${exit_code}" -ne 1 ] || ! grep -q '^results={"review test":"fail"}$' "${TMP_DIR}/${output_mode}-output" || ! grep -q 'did not write valid structured output' "${TMP_DIR}/${output_mode}.log"; then
     printf 'FAIL: zero-exit %s structured output fails closed\n' "${output_mode}"
+    exit 1
+  fi
+  if [ -e "${TMP_DIR}/workspace/homeboy-ci-results/review-test.json" ]; then
+    printf 'FAIL: %s output is advertised as a CI result\n' "${output_mode}"
     exit 1
   fi
 done
@@ -178,3 +193,34 @@ if ! grep -q 'TIMED OUT (exit code 124)' "${TMP_DIR}/timeout.log"; then
   exit 1
 fi
 printf 'PASS: timed out review test preserves actionable timeout classification\n'
+
+cat > "${TMP_DIR}/bin/homeboy" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$(dirname "${output}")"
+printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"bench","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}"
+SH
+chmod +x "${TMP_DIR}/bin/homeboy"
+
+PATH="${TMP_DIR}/bin:${PATH}" \
+GITHUB_ACTION_PATH="${ROOT_DIR}" \
+GITHUB_WORKSPACE="${TMP_DIR}/workspace" \
+GITHUB_OUTPUT="${TMP_DIR}/bench-output" \
+GITHUB_ENV="${TMP_DIR}/bench-env" \
+RESOLVED_COMMANDS='bench' \
+COMPONENT_NAME='homeboy-action' \
+bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/bench.log" 2>&1
+
+bench_output_dir="$(grep '^HOMEBOY_OUTPUT_DIR=' "${TMP_DIR}/bench-env" | cut -d= -f2-)"
+if ! cmp -s "${bench_output_dir}/bench.json" "${TMP_DIR}/workspace/homeboy-ci-results/bench.json"; then
+  printf 'FAIL: bench result does not retain its existing artifact and comment copies\n'
+  exit 1
+fi
+printf 'PASS: bench retains its existing artifact and comment copies without conflict\n'

--- a/scripts/core/test-run-homeboy-commands.sh
+++ b/scripts/core/test-run-homeboy-commands.sh
@@ -62,7 +62,8 @@ fi
 printf 'PASS: failed review test records a current-run failure and mirrors its valid result\n'
 
 for output_mode in missing malformed; do
-  rm -f "${TMP_DIR}/workspace/homeboy-ci-results/review-test.json"
+  mkdir -p "${TMP_DIR}/workspace/homeboy-ci-results"
+  printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"review","success":true,"status":"succeeded","exit_code":0,"data":{"stale":true}}' > "${TMP_DIR}/workspace/homeboy-ci-results/review-test.json"
   cat > "${TMP_DIR}/bin/homeboy" <<'SH'
 #!/usr/bin/env bash
 output=""
@@ -92,7 +93,7 @@ SH
     exit 1
   fi
 done
-printf 'PASS: zero-exit missing and malformed structured output fail closed\n'
+printf 'PASS: stale non-bench results cannot satisfy missing or malformed current output\n'
 
 for envelope_mode in empty wrong-command inconsistent; do
   cat > "${TMP_DIR}/bin/homeboy" <<'SH'
@@ -205,9 +206,16 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 mkdir -p "$(dirname "${output}")"
-printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"bench","success":true,"status":"succeeded","exit_code":0,"data":{}}' > "${output}"
+if [ -e "${output}" ]; then
+  printf 'stale bench output was not removed\n' >&2
+  exit 99
+fi
+printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"bench","success":true,"status":"succeeded","exit_code":0,"data":{"current":true}}' > "${output}"
 SH
 chmod +x "${TMP_DIR}/bin/homeboy"
+
+mkdir -p "${TMP_DIR}/workspace/homeboy-ci-results"
+printf '%s\n' '{"schema":"homeboy/command-result/v3","command":"bench","success":true,"status":"succeeded","exit_code":0,"data":{"stale":true}}' > "${TMP_DIR}/workspace/homeboy-ci-results/bench.json"
 
 PATH="${TMP_DIR}/bin:${PATH}" \
 GITHUB_ACTION_PATH="${ROOT_DIR}" \
@@ -219,8 +227,52 @@ COMPONENT_NAME='homeboy-action' \
 bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/bench.log" 2>&1
 
 bench_output_dir="$(grep '^HOMEBOY_OUTPUT_DIR=' "${TMP_DIR}/bench-env" | cut -d= -f2-)"
-if ! cmp -s "${bench_output_dir}/bench.json" "${TMP_DIR}/workspace/homeboy-ci-results/bench.json"; then
-  printf 'FAIL: bench result does not retain its existing artifact and comment copies\n'
+if ! jq -e '.data.current == true' "${TMP_DIR}/workspace/homeboy-ci-results/bench.json" >/dev/null 2>&1 \
+  || ! cmp -s "${bench_output_dir}/bench.json" "${TMP_DIR}/workspace/homeboy-ci-results/bench.json"; then
+  printf 'FAIL: bench result does not replace stale output and retain its artifact and comment copies\n'
   exit 1
 fi
-printf 'PASS: bench retains its existing artifact and comment copies without conflict\n'
+printf 'PASS: bench requires current output and retains its artifact and comment copies\n'
+
+mkdir -p "${TMP_DIR}/symlink-workspace" "${TMP_DIR}/outside-results"
+printf 'outside sentinel\n' > "${TMP_DIR}/outside-results/sentinel"
+ln -s "${TMP_DIR}/outside-results" "${TMP_DIR}/symlink-workspace/homeboy-ci-results"
+
+set +e
+PATH="${TMP_DIR}/bin:${PATH}" \
+GITHUB_ACTION_PATH="${ROOT_DIR}" \
+GITHUB_WORKSPACE="${TMP_DIR}/symlink-workspace" \
+GITHUB_OUTPUT="${TMP_DIR}/symlink-dir-output" \
+GITHUB_ENV="${TMP_DIR}/symlink-dir-env" \
+RESOLVED_COMMANDS='bench' \
+COMPONENT_NAME='homeboy-action' \
+bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/symlink-dir.log" 2>&1
+exit_code=$?
+set -e
+
+if [ "${exit_code}" -ne 1 ] || ! grep -q 'must be a real directory' "${TMP_DIR}/symlink-dir.log" || ! grep -qx 'outside sentinel' "${TMP_DIR}/outside-results/sentinel"; then
+  printf 'FAIL: symlinked CI results directory fails closed without touching its target\n'
+  exit 1
+fi
+printf 'PASS: symlinked CI results directory fails closed without touching its target\n'
+
+mkdir -p "${TMP_DIR}/target-symlink-workspace/homeboy-ci-results"
+printf 'outside result sentinel\n' > "${TMP_DIR}/outside-results/bench.json"
+ln -s "${TMP_DIR}/outside-results/bench.json" "${TMP_DIR}/target-symlink-workspace/homeboy-ci-results/bench.json"
+
+PATH="${TMP_DIR}/bin:${PATH}" \
+GITHUB_ACTION_PATH="${ROOT_DIR}" \
+GITHUB_WORKSPACE="${TMP_DIR}/target-symlink-workspace" \
+GITHUB_OUTPUT="${TMP_DIR}/symlink-target-output" \
+GITHUB_ENV="${TMP_DIR}/symlink-target-env" \
+RESOLVED_COMMANDS='bench' \
+COMPONENT_NAME='homeboy-action' \
+bash "${ROOT_DIR}/scripts/core/run-homeboy-commands.sh" >"${TMP_DIR}/symlink-target.log" 2>&1
+
+if [ -L "${TMP_DIR}/target-symlink-workspace/homeboy-ci-results/bench.json" ] \
+  || ! jq -e '.data.current == true' "${TMP_DIR}/target-symlink-workspace/homeboy-ci-results/bench.json" >/dev/null 2>&1 \
+  || ! grep -qx 'outside result sentinel' "${TMP_DIR}/outside-results/bench.json"; then
+  printf 'FAIL: symlinked CI result target is replaced without writing outside the workspace\n'
+  exit 1
+fi
+printf 'PASS: symlinked CI result target is replaced without writing outside the workspace\n'

--- a/scripts/setup/capture-tooling-metadata.sh
+++ b/scripts/setup/capture-tooling-metadata.sh
@@ -4,21 +4,6 @@ set -euo pipefail
 
 HOMEBOY_CLI_VERSION="$(homeboy --version 2>/dev/null || echo 'unknown')"
 
-# Annotate dev builds with commit hash so CI logs distinguish
-# "0.74.1 release" from "0.74.1+abc1234 built from HEAD"
-if [ -d ".git" ]; then
-  HEAD_SHORT="$(git rev-parse --short HEAD 2>/dev/null || true)"
-  HEAD_FULL="$(git rev-parse HEAD 2>/dev/null || true)"
-  if [ -n "${HEAD_SHORT}" ]; then
-    VERSION_NUM="${HOMEBOY_CLI_VERSION#homeboy }"
-    TAG_COMMIT="$(git rev-parse "v${VERSION_NUM}" 2>/dev/null || true)"
-    if [ -n "${TAG_COMMIT}" ] && [ "${TAG_COMMIT}" != "${HEAD_FULL}" ]; then
-      HOMEBOY_CLI_VERSION="${HOMEBOY_CLI_VERSION}+${HEAD_SHORT}"
-    fi
-  fi
-  echo "HOMEBOY_CLI_HEAD_SHA=${HEAD_FULL}" >> "${GITHUB_ENV}"
-fi
-
 # v2: use PORTABLE_EXTENSION (inferred from homeboy.json) as primary,
 # fall back to EXTENSION_ID input for backward compat
 EXTENSION_ID_EFFECTIVE="${PORTABLE_EXTENSION:-${EXTENSION_ID:-auto}}"

--- a/scripts/setup/test-capture-tooling-metadata.sh
+++ b/scripts/setup/test-capture-tooling-metadata.sh
@@ -18,6 +18,19 @@ assert_contains() {
   printf 'PASS: %s\n' "${label}"
 }
 
+assert_line() {
+  local line="$1"
+  local file="$2"
+  local label="$3"
+
+  if ! grep -Fxq -- "${line}" "${file}"; then
+    printf 'FAIL: %s\nmissing exact line: %s\n' "${label}" "${line}"
+    exit 1
+  fi
+
+  printf 'PASS: %s\n' "${label}"
+}
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
@@ -32,6 +45,15 @@ chmod +x "${TMP_DIR}/bin/homeboy"
 
 printf 'abc1234\n' > "${TMP_DIR}/home/.config/homeboy/extensions/wordpress/.source-revision"
 
+mkdir "${TMP_DIR}/consumer"
+git -C "${TMP_DIR}/consumer" init -q
+git -C "${TMP_DIR}/consumer" config user.email "test@example.com"
+git -C "${TMP_DIR}/consumer" config user.name "Test User"
+printf 'unrelated consumer revision\n' > "${TMP_DIR}/consumer/README"
+git -C "${TMP_DIR}/consumer" add README
+git -C "${TMP_DIR}/consumer" commit -qm 'test consumer revision'
+consumer_head="$(git -C "${TMP_DIR}/consumer" rev-parse HEAD)"
+
 export PATH="${TMP_DIR}/bin:${PATH}"
 export HOME="${TMP_DIR}/home"
 export PORTABLE_EXTENSION="wordpress"
@@ -41,16 +63,23 @@ export ACTION_REPOSITORY="Extra-Chill/homeboy-action"
 export GITHUB_ENV="${TMP_DIR}/github-env"
 export GITHUB_OUTPUT="${TMP_DIR}/github-output"
 
-( cd "${TMP_DIR}" && bash "${ROOT_DIR}/scripts/setup/capture-tooling-metadata.sh" ) > "${TMP_DIR}/metadata.log"
+( cd "${TMP_DIR}/consumer" && bash "${ROOT_DIR}/scripts/setup/capture-tooling-metadata.sh" ) > "${TMP_DIR}/metadata.log"
 
+assert_line "HOMEBOY_CLI_VERSION=homeboy 9.9.9" "${GITHUB_ENV}" "CLI version is preserved exactly outside the action repository"
 assert_contains "HOMEBOY_EXTENSION_REVISION=abc1234" "${GITHUB_ENV}" "source revision file is exported"
+assert_contains "HOMEBOY_ACTION_REF=v2" "${GITHUB_ENV}" "action ref is exported"
+assert_contains "HOMEBOY_ACTION_REPOSITORY=Extra-Chill/homeboy-action" "${GITHUB_ENV}" "action repository is exported"
 assert_contains "- Extension revision: abc1234" "${TMP_DIR}/metadata.log" "source revision file is logged"
+
+if grep -Fq -- "${consumer_head}" "${GITHUB_ENV}" || grep -Fq -- 'HOMEBOY_CLI_HEAD_SHA=' "${GITHUB_ENV}"; then
+  printf 'FAIL: consumer Git HEAD is not advertised as CLI provenance\n'
+  exit 1
+fi
+printf 'PASS: consumer Git HEAD does not alter or become CLI provenance\n'
 
 # Tooling identity output for failed-SHA marker keying (homeboy-action#257).
 # The raw version string "homeboy 9.9.9" contains a space, which is hostile to
-# GitHub cache keys; the sanitizer must collapse it to a '-'. A dev build would
-# add a '+sha' suffix — also sanitized — so any tooling change yields a fresh,
-# cache-key-safe identity token.
+# GitHub cache keys; the sanitizer must collapse it to a '-'.
 assert_contains "homeboy-version=homeboy 9.9.9" "${GITHUB_OUTPUT}" "resolved homeboy version is exposed verbatim as a step output"
 assert_contains "tooling-identity=homeboy-9.9.9-abc1234" "${GITHUB_OUTPUT}" "tooling identity combines sanitized version + extension revision into a cache-key-safe token"
 


### PR DESCRIPTION
## Summary
- preserve the exact Homeboy CLI version without deriving a suffix or provenance from the consumer checkout
- mirror validated non-bench command envelopes into the existing CI-results artifact directory while retaining temporary results for PR comments
- clear only each command’s expected CI result target before execution, so stale output cannot satisfy current validation
- reject symlinked CI-result directories and safely replace symlinked result targets within the workspace
- add regressions for consumer checkout isolation, invalid outputs, stale results, mirrored review results, bench behavior, and symlink safety

Fixes #304
Fixes #310

## Validation
- `bash scripts/setup/test-capture-tooling-metadata.sh`
- `bash scripts/core/test-run-homeboy-commands.sh`
- `git diff --check`
- `shellcheck -e SC1091,SC2129 scripts/setup/capture-tooling-metadata.sh scripts/setup/test-capture-tooling-metadata.sh scripts/core/run-homeboy-commands.sh scripts/core/test-run-homeboy-commands.sh`

`scripts/run-tests.sh` could not execute locally because macOS lacks GNU `timeout`; all tests stopped before invocation with exit 127.

## AI Assistance
- Model: `openai/gpt-5.6-terra` (the requested `openai/gpt-5.6-sol` label does not match the active runtime)
- Tool: OpenCode
- Usage: inspected the existing implementation and issue reports, implemented and reviewed the scoped shell changes, and ran focused validation. Chris Huber remains responsible for the change.