### PR TITLE
feat: make differential quality phases restartable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,14 +164,14 @@ on:
         required: false
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
   issues: write
 
 jobs:
-  build:
-    name: Build
-    if: inputs.build-command != ''
+  binary:
+    name: Prepare candidate Homeboy binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -196,14 +196,33 @@ jobs:
           key: ${{ runner.os }}-cargo-ci-${{ hashFiles('Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-ci-
 
-      - name: Build Homeboy binary
+      - name: Build candidate Homeboy binary
+        if: inputs.build-command != ''
         run: ${{ inputs.build-command }}
 
-      - name: Upload Homeboy binary
+      - name: Check out Homeboy Action
+        uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy-action
+          ref: ${{ inputs.action-ref }}
+          path: .homeboy-action
+
+      - name: Materialize candidate Homeboy binary
+        uses: ./.homeboy-action
+        with:
+          commands: __prepare__
+          prepare-only: 'true'
+          version: ${{ inputs.version }}
+          source: ${{ inputs.source }}
+          binary-path: ${{ inputs.build-command != '' && inputs.build-artifact-path || inputs.binary-path }}
+          rust-toolchain: ${{ inputs.rust-toolchain }}
+          auto-setup: 'false'
+
+      - name: Upload candidate Homeboy binary
         uses: actions/upload-artifact@v4
         with:
-          name: homeboy-binary
-          path: ${{ inputs.build-artifact-path }}
+          name: homeboy-candidate-binary-${{ github.run_attempt }}
+          path: /usr/local/bin/homeboy
           retention-days: 1
 
   plan:
@@ -217,6 +236,7 @@ jobs:
         shell: bash
         env:
           COMMANDS: ${{ inputs.commands }}
+          BASELINE_COMMANDS: ${{ inputs.baseline-commands }}
         run: |
           declare -A selected_commands=()
           unknown_commands=()
@@ -249,12 +269,30 @@ jobs:
 
           rows=()
           add_row() {
+            artifact_key="$(printf '%s' "$1" | sha256sum | cut -c1-16)"
             rows+=("$(jq -cn \
               --arg command "$1" \
               --arg title "$2" \
               --arg section_key "$3" \
               --arg section_title "$4" \
-              '{command:$command,title:$title,section_key:$section_key,section_title:$section_title}')")
+              --arg baseline "$5" \
+              --arg artifact_key "${artifact_key}" \
+              '{command:$command,title:$title,section_key:$section_key,section_title:$section_title,baseline:$baseline,artifact_key:$artifact_key}')")
+          }
+
+          baseline_for() {
+             local command="$1" requested
+             case "${BASELINE_COMMANDS}" in
+               none) printf '%s\n' false; return ;;
+               auto)
+                 case "${command}" in review\ audit|review\ lint|review\ test|audit|lint|test) printf '%s\n' true ;; *) printf '%s\n' false ;; esac
+                 return ;;
+             esac
+             IFS=',' read -ra requested <<< "${BASELINE_COMMANDS}"
+             for requested in "${requested[@]}"; do
+               [ "$(printf '%s' "${requested}" | xargs)" = "${command}" ] && { printf '%s\n' true; return; }
+             done
+             printf '%s\n' false
           }
 
           title_for() {
@@ -277,7 +315,8 @@ jobs:
           for base in audit lint test refactor bench; do
             if [ -n "${selected_commands[${base}]:-}" ]; then
               title="$(title_for "${base}")"
-              add_row "${selected_commands[${base}]}" "${title}" "${base}" "${title}"
+              command="${selected_commands[${base}]}"
+              add_row "${command}" "${title}" "${base}" "${title}" "$(baseline_for "${command}")"
             fi
           done
 
@@ -285,16 +324,16 @@ jobs:
             base="${command%% *}"
             title="$(title_for "${base:-homeboy}")"
             section_key="$(section_key_for "${command}")"
-            add_row "${command}" "${title}" "${section_key:-homeboy}" "${title}"
+            add_row "${command}" "${title}" "${section_key:-homeboy}" "${title}" false
           done
 
           matrix="$(printf '%s\n' "${rows[@]}" | jq -sc '{include:.}')"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
 
-  quality:
-    name: ${{ matrix.title }}
-    needs: [build, plan]
-    if: ${{ always() && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
+  candidate:
+    name: Candidate ${{ matrix.title }}
+    needs: [binary, plan]
+    if: ${{ always() && needs.binary.result == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -305,42 +344,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
-      - name: Download built Homeboy binary
-        if: inputs.build-command != ''
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BUILD_ARTIFACT_FILE: ${{ inputs.build-artifact-file }}
-        run: |
-          gh run download "${GITHUB_RUN_ID}" --name homeboy-binary --dir .homeboy-bin
-          if [ ! -f ".homeboy-bin/${BUILD_ARTIFACT_FILE}" ]; then
-            echo "::error::Build artifact 'homeboy-binary/${BUILD_ARTIFACT_FILE}' was not downloaded from run ${GITHUB_RUN_ID}. The upstream Build job may have failed, been skipped, or not uploaded the artifact. This is a CI plumbing issue, not a code finding. Verify the Build job succeeded and that this workflow grants the 'actions: read' permission."
-            exit 1
-          fi
-          echo "Downloaded homeboy binary to .homeboy-bin/${BUILD_ARTIFACT_FILE}"
-
-      - name: Resolve Homeboy binary path
-        id: binary-path
-        shell: bash
-        env:
-          BUILD_COMMAND: ${{ inputs.build-command }}
-          BUILD_ARTIFACT_FILE: ${{ inputs.build-artifact-file }}
-          BINARY_PATH: ${{ inputs.binary-path }}
-        run: |
-          if [ -n "${BUILD_COMMAND}" ]; then
-            path=".homeboy-bin/${BUILD_ARTIFACT_FILE}"
-            chmod +x "${path}"
-            echo "value=${path}" >> "${GITHUB_OUTPUT}"
-          else
-            echo "value=${BINARY_PATH}" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Check out Homeboy Action
         uses: actions/checkout@v4
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ inputs.action-ref }}
           path: .homeboy-action
+
+      - name: Download candidate Homeboy binary
+        id: candidate-binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
 
       - name: Generate GitHub App token
         id: app-token
@@ -350,11 +365,13 @@ jobs:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: ./.homeboy-action
+      - id: phase
+        continue-on-error: true
+        uses: ./.homeboy-action
         with:
           version: ${{ inputs.version }}
           source: ${{ inputs.source }}
-          binary-path: ${{ steps.binary-path.outputs.value }}
+          binary-path: ${{ steps.candidate-binary.outputs.binary-path }}
           rust-toolchain: ${{ inputs.rust-toolchain }}
           extension: ${{ inputs.extension }}
           extension-source: ${{ inputs.extension-source }}
@@ -371,18 +388,236 @@ jobs:
           auto-setup: ${{ inputs.auto-setup }}
           php-version: ${{ inputs.php-version }}
           node-version: ${{ inputs.node-version }}
+          # Preserve differential scope semantics (full audit/test, changed
+          # lint) while deferring the baseline to its independent job.
           differential-gating: ${{ inputs.differential-gating }}
-          baseline-commands: ${{ inputs.baseline-commands }}
+          baseline-commands: none
           observation-window: ${{ inputs.observation-window }}
           execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
           cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           app-token: ${{ steps.app-token.outputs.token || github.token }}
-          auto-issue: ${{ inputs.auto-issue }}
           comment-key: ${{ inputs.comment-key }}
           comment-section-key: ${{ inputs.comment-section-key || matrix.section_key }}
           comment-section-title: ${{ inputs.comment-section-title || matrix.section_title }}
-          pr-comment: ${{ inputs.pr-comment }}
-          pr-policy: ${{ inputs.pr-policy }}
-          pr-open-policy: ${{ inputs.pr-open-policy }}
-          pr-policy-merge: ${{ inputs.pr-policy-merge }}
-          pr-policy-merge-method: ${{ inputs.pr-policy-merge-method }}
+          pr-comment: 'false'
+          auto-issue: 'false'
+          pr-policy: ''
+          pr-open-policy: ''
+          pr-policy-merge: 'false'
+
+      - name: Write candidate phase provenance
+        if: always()
+        shell: bash
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+          COMMAND: ${{ matrix.command }}
+          COMPONENT: ${{ steps.phase.outputs.component }}
+          CLI_REVISION: ${{ steps.phase.outputs.homeboy-version }}
+          RESULTS: ${{ steps.phase.outputs.results }}
+          ACTION_REF: ${{ inputs.action-ref }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          BINARY_SHA256: ${{ steps.candidate-binary.outputs.binary-sha256 }}
+        run: |
+          mkdir -p differential-phase/candidate
+          action_revision="$(git -C .homeboy-action rev-parse HEAD)"
+          results="${RESULTS:-{}}"
+          jq -cn --arg phase candidate --arg repository "${REPOSITORY}" --arg candidate_sha "${CANDIDATE_SHA}" --arg base_sha "${BASE_SHA}" --arg checkout_sha "${CANDIDATE_SHA}" --arg command "${COMMAND}" --arg component "${COMPONENT}" --arg action_revision "${action_revision}" --arg cli_revision "${CLI_REVISION}" --arg binary_sha256 "${BINARY_SHA256}" --argjson run_attempt "${RUN_ATTEMPT}" --argjson results "${results}" '{phase:$phase,repository:$repository,candidate_sha:$candidate_sha,base_sha:$base_sha,checkout_sha:$checkout_sha,command:$command,component:$component,action_revision:$action_revision,cli_revision:$cli_revision,binary_sha256:$binary_sha256,run_attempt:$run_attempt,results:$results}' > differential-phase/candidate/manifest.json
+          cp -R homeboy-ci-results differential-phase/candidate/homeboy-ci-results 2>/dev/null || mkdir -p differential-phase/candidate/homeboy-ci-results
+
+      - name: Upload candidate phase evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: homeboy-differential-candidate-${{ matrix.artifact_key }}-${{ github.run_attempt }}
+          path: differential-phase
+          if-no-files-found: warn
+
+  baseline:
+    name: Baseline ${{ matrix.title }}
+    needs: [binary, plan]
+    if: ${{ always() && needs.binary.result == 'success' && github.event_name == 'pull_request' && inputs.differential-gating == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+      - uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy-action
+          ref: ${{ inputs.action-ref }}
+          path: .homeboy-action
+      - name: Download candidate Homeboy binary
+        id: candidate-binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
+      - id: phase
+        if: matrix.baseline == 'true'
+        continue-on-error: true
+        uses: ./.homeboy-action
+        with:
+          version: ${{ inputs.version }}
+          binary-path: ${{ steps.candidate-binary.outputs.binary-path }}
+          rust-toolchain: ${{ inputs.rust-toolchain }}
+          extension: ${{ inputs.extension }}
+          extension-source: ${{ inputs.extension-source }}
+          commands: ${{ matrix.command }}
+          expected-commands: ${{ inputs.expected-commands || inputs.commands }}
+          component: ${{ inputs.component }}
+          args: ${{ inputs.args }}
+          scope: ${{ inputs.scope }}
+          auto-setup: ${{ inputs.auto-setup }}
+          php-version: ${{ inputs.php-version }}
+          node-version: ${{ inputs.node-version }}
+          differential-gating: 'true'
+          baseline-commands: none
+          execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
+          cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
+          pr-comment: 'false'
+          auto-issue: 'false'
+      - name: Write baseline phase provenance
+        if: always() && matrix.baseline == 'true'
+        shell: bash
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          COMMAND: ${{ matrix.command }}
+          COMPONENT: ${{ steps.phase.outputs.component }}
+          CLI_REVISION: ${{ steps.phase.outputs.homeboy-version }}
+          RESULTS: ${{ steps.phase.outputs.results }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          BINARY_SHA256: ${{ steps.candidate-binary.outputs.binary-sha256 }}
+        run: |
+          mkdir -p differential-phase/baseline
+          action_revision="$(git -C .homeboy-action rev-parse HEAD)"
+          results="${RESULTS:-{}}"
+          jq -cn --arg phase baseline --arg repository "${REPOSITORY}" --arg candidate_sha "${CANDIDATE_SHA}" --arg base_sha "${BASE_SHA}" --arg checkout_sha "${BASE_SHA}" --arg command "${COMMAND}" --arg component "${COMPONENT}" --arg action_revision "${action_revision}" --arg cli_revision "${CLI_REVISION}" --arg binary_sha256 "${BINARY_SHA256}" --argjson run_attempt "${RUN_ATTEMPT}" --argjson results "${results}" '{phase:$phase,repository:$repository,candidate_sha:$candidate_sha,base_sha:$base_sha,checkout_sha:$checkout_sha,command:$command,component:$component,action_revision:$action_revision,cli_revision:$cli_revision,binary_sha256:$binary_sha256,run_attempt:$run_attempt,results:$results}' > differential-phase/baseline/manifest.json
+          cp -R homeboy-ci-results differential-phase/baseline/homeboy-ci-results 2>/dev/null || mkdir -p differential-phase/baseline/homeboy-ci-results
+      - name: Upload baseline phase evidence
+        if: always() && matrix.baseline == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: homeboy-differential-baseline-${{ matrix.artifact_key }}-${{ github.run_attempt }}
+          path: differential-phase
+          if-no-files-found: warn
+
+  reconcile:
+    # This is the sole verdict and retains the established required-check name.
+    name: ${{ matrix.title }}
+    needs: [candidate, baseline, plan]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy-action
+          ref: ${{ inputs.action-ref }}
+          path: .homeboy-action
+      - name: Download candidate Homeboy binary
+        id: candidate-binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
+      - name: Install candidate Homeboy binary
+        run: sudo cp "${{ steps.candidate-binary.outputs.binary-path }}" /usr/local/bin/homeboy
+      - id: action-revision
+        run: echo "value=$(git -C .homeboy-action rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: homeboy-differential-*-${{ matrix.artifact_key }}-*
+          path: differential-artifacts
+      - name: Reconcile provenance-bound phase evidence
+        id: reconcile
+        shell: bash
+        env:
+          PHASE_ARTIFACT_ROOT: differential-artifacts
+          REPOSITORY: ${{ github.repository }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+          COMMAND: ${{ matrix.command }}
+          ACTION_REVISION: ${{ steps.action-revision.outputs.value }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          REQUIRE_BASELINE: ${{ github.event_name == 'pull_request' && inputs.differential-gating == 'true' && matrix.baseline == 'true' }}
+        run: bash .homeboy-action/scripts/core/reconcile-differential-phases.sh
+
+      - name: Generate GitHub App token
+        id: app-token
+        if: always() && inputs.pr-comment != 'false'
+        uses: actions/create-github-app-token@v2
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+
+      - name: Post reconciled PR comment
+        if: always() && github.event_name == 'pull_request' && inputs.pr-comment != 'false'
+        shell: bash
+        env:
+          GITHUB_ACTION_PATH: ${{ github.workspace }}/.homeboy-action
+          HOMEBOY_OUTPUT_DIR: ${{ steps.reconcile.outputs.output-dir }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMANDS: ${{ matrix.command }}
+          COMPONENT_NAME: ${{ steps.reconcile.outputs.component }}
+          RESULTS: ${{ steps.reconcile.outputs.results }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMENT_KEY_INPUT: ${{ inputs.comment-key }}
+          COMMENT_SECTION_KEY_INPUT: ${{ inputs.comment-section-key || matrix.section_key }}
+          COMMENT_SECTION_TITLE_INPUT: ${{ inputs.comment-section-title || matrix.section_title }}
+          HOMEBOY_CI_RESULTS_ARTIFACT: homeboy-differential-candidate-${{ matrix.artifact_key }}-${{ github.run_attempt }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .homeboy-action/scripts/pr/post-pr-comment.sh
+
+  policy:
+    name: PR Policy
+    needs: reconcile
+    if: ${{ github.event_name == 'pull_request' && inputs.pr-policy != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy-action
+          ref: ${{ inputs.action-ref }}
+          path: .homeboy-action
+      - name: Download candidate Homeboy binary
+        id: candidate-binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
+      - name: Install candidate Homeboy binary
+        run: sudo cp "${{ steps.candidate-binary.outputs.binary-path }}" /usr/local/bin/homeboy
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
+      - name: Evaluate PR policy after reconciled quality gates
+        shell: bash
+        env:
+          GITHUB_ACTION_PATH: ${{ github.workspace }}/.homeboy-action
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          POLICY_PATH: ${{ inputs.pr-policy }}
+          POLICY_MERGE: ${{ inputs.pr-policy-merge }}
+          POLICY_MERGE_METHOD: ${{ inputs.pr-policy-merge-method }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+          COMPONENT_NAME: ${{ inputs.component }}
+        run: bash .homeboy-action/scripts/pr/policy-gate.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Prefer the reusable workflow so Homeboy Action owns the CI DAG and result
 aggregation. The workflow runs all requested quality commands before failing,
 so an audit failure does not hide lint or test feedback.
 
+For pull requests with `differential-gating: 'true'`, the reusable workflow
+materializes one candidate Homeboy binary, then runs candidate and base phases
+in separate jobs. A final reconciliation check is the only pass/fail decision:
+it accepts only artifacts bound to the repository, candidate SHA, base SHA,
+command, component, action revision, CLI revision, and phase identity. Missing
+or mismatched evidence fails closed. This DAG behavior is specific to the
+reusable workflow; direct composite-action callers keep the combined behavior.
+
 ```yaml
 name: CI
 on: [pull_request]

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Path to a pre-built homeboy binary. Skips source build and release download.'
     required: false
     default: ''
+  prepare-only:
+    description: 'Install and identify Homeboy without running commands. Intended for reusable workflow binary preparation.'
+    required: false
+    default: 'false'
   rust-toolchain:
     description: 'Rust toolchain for source builds (default: stable).'
     required: false
@@ -210,6 +214,9 @@ inputs:
     default: ''
 
 outputs:
+  component:
+    description: 'Resolved component ID from portable configuration.'
+    value: ${{ steps.read-config.outputs.portable-id }}
   results:
     description: 'JSON object with pass/fail results for each command'
     value: ${{ steps.select-results.outputs.results }}
@@ -291,6 +298,7 @@ runs:
       shell: bash
       env:
         COMMANDS_INPUT: ${{ inputs.commands }}
+        HOMEBOY_PREPARE_ONLY: ${{ inputs.prepare-only }}
       run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh run changed_scope_resolution -- bash ${{ github.action_path }}/scripts/core/resolve-commands.sh
 
     # ── Phase 3: Install Homeboy ──

--- a/scripts/core/download-candidate-binary.sh
+++ b/scripts/core/download-candidate-binary.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+run_id="${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+destination="${BINARY_DESTINATION:-.homeboy-bin}"
+selected=""
+selected_attempt=0
+
+while IFS= read -r name; do
+  if [[ "${name}" =~ ^homeboy-candidate-binary-([0-9]+)$ ]]; then
+    attempt="${BASH_REMATCH[1]}"
+    if [ "${attempt}" -gt "${selected_attempt}" ]; then
+      selected="${name}"
+      selected_attempt="${attempt}"
+    fi
+  fi
+done < <(gh api "repos/${repository}/actions/runs/${run_id}/artifacts" --paginate --jq '.artifacts[].name')
+
+if [ -z "${selected}" ]; then
+  echo "::error::No candidate Homeboy binary artifact exists for run ${run_id}."
+  exit 1
+fi
+
+rm -rf "${destination}"
+mkdir -p "${destination}"
+gh run download "${run_id}" --repo "${repository}" --name "${selected}" --dir "${destination}"
+
+binary="${destination}/homeboy"
+if [ ! -f "${binary}" ]; then
+  echo "::error::Artifact ${selected} did not contain homeboy."
+  exit 1
+fi
+
+chmod +x "${binary}"
+if command -v sha256sum >/dev/null 2>&1; then
+  digest="$(sha256sum "${binary}" | cut -d' ' -f1)"
+else
+  digest="$(shasum -a 256 "${binary}" | cut -d' ' -f1)"
+fi
+
+printf 'binary-path=%s\nbinary-sha256=%s\nartifact-name=%s\n' \
+  "${binary}" "${digest}" "${selected}" >> "${GITHUB_OUTPUT}"
+echo "Selected ${selected} (${digest})."

--- a/scripts/core/reconcile-differential-phases.sh
+++ b/scripts/core/reconcile-differential-phases.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# Reconcile independently produced candidate and baseline evidence. Artifacts
+# are untrusted transport: every identity field is checked before a verdict.
+set -euo pipefail
+
+artifact_root="${PHASE_ARTIFACT_ROOT:?PHASE_ARTIFACT_ROOT is required}"
+command="${COMMAND:?COMMAND is required}"
+action_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_closed() {
+  echo "::error::$1"
+  echo "results={\"${command}\":\"fail\"}" >> "${GITHUB_OUTPUT}"
+  exit 1
+}
+
+manifest_for() {
+  local phase="$1"
+  local path attempt selected="" selected_attempt=0 selected_count=0
+  while IFS= read -r path; do
+    attempt="$(jq -r '.run_attempt // 0' "${path}" 2>/dev/null || printf '0')"
+    [[ "${attempt}" =~ ^[0-9]+$ ]] || attempt=0
+    if [ "${attempt}" -gt "${selected_attempt}" ]; then
+      selected="${path}"
+      selected_attempt="${attempt}"
+      selected_count=1
+    elif [ "${attempt}" -eq "${selected_attempt}" ] && [ "${attempt}" -gt 0 ]; then
+      selected_count=$((selected_count + 1))
+    fi
+  done < <(find "${artifact_root}" -path "*/${phase}/manifest.json" -type f | sort)
+  [ -n "${selected}" ] && [ "${selected_count}" -eq 1 ] || fail_closed "Expected one newest ${phase} provenance artifact; found ${selected_count} at attempt ${selected_attempt}."
+  printf '%s\n' "${selected}"
+}
+
+candidate_manifest="$(manifest_for candidate)"
+candidate_dir="$(dirname "${candidate_manifest}")"
+
+validate_manifest() {
+  local phase="$1" manifest="$2" expected_sha="$3"
+  jq -e \
+    --arg phase "${phase}" --arg repository "${REPOSITORY:?REPOSITORY is required}" \
+    --arg candidate_sha "${CANDIDATE_SHA:?CANDIDATE_SHA is required}" --arg base_sha "${BASE_SHA:?BASE_SHA is required}" \
+    --arg command "${command}" --arg action_revision "${ACTION_REVISION:?ACTION_REVISION is required}" \
+    --arg expected_sha "${expected_sha}" '
+      type == "object"
+      and .phase == $phase
+      and .repository == $repository
+      and .candidate_sha == $candidate_sha
+      and .base_sha == $base_sha
+      and .checkout_sha == $expected_sha
+      and .command == $command
+      and .action_revision == $action_revision
+      and (.run_attempt | type == "number" and . > 0 and . <= (env.RUN_ATTEMPT | tonumber))
+      and (.component | type == "string" and length > 0)
+      and (.cli_revision | type == "string" and length > 0)
+      and (.binary_sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+      and (.results | type == "object" and (.[$command] == "pass" or .[$command] == "fail" or .[$command] == "timeout"))
+    ' "${manifest}" >/dev/null 2>&1 || fail_closed "${phase} phase provenance is missing, malformed, or does not match this workflow."
+}
+
+validate_manifest candidate "${candidate_manifest}" "${CANDIDATE_SHA}"
+candidate_results="$(jq -c '.results' "${candidate_manifest}")"
+candidate_output="${candidate_dir}/homeboy-ci-results"
+[ -d "${candidate_output}" ] || fail_closed "Candidate result payload is missing."
+
+if [ "${REQUIRE_BASELINE:-false}" = "true" ]; then
+  baseline_manifest="$(manifest_for baseline)"
+  baseline_dir="$(dirname "${baseline_manifest}")"
+  validate_manifest baseline "${baseline_manifest}" "${BASE_SHA}"
+  candidate_component="$(jq -r '.component' "${candidate_manifest}")"
+  baseline_component="$(jq -r '.component' "${baseline_manifest}")"
+  candidate_cli="$(jq -r '.cli_revision' "${candidate_manifest}")"
+  baseline_cli="$(jq -r '.cli_revision' "${baseline_manifest}")"
+  candidate_binary="$(jq -r '.binary_sha256' "${candidate_manifest}")"
+  baseline_binary="$(jq -r '.binary_sha256' "${baseline_manifest}")"
+  [ "${candidate_component}" = "${baseline_component}" ] || fail_closed "Candidate and baseline component provenance differs."
+  [ "${candidate_cli}" = "${baseline_cli}" ] || fail_closed "Candidate and baseline CLI provenance differs."
+  [ "${candidate_binary}" = "${baseline_binary}" ] || fail_closed "Candidate and baseline binary provenance differs."
+  baseline_results="$(jq -c '.results' "${baseline_manifest}")"
+  baseline_output="${baseline_dir}/homeboy-ci-results"
+  [ -d "${baseline_output}" ] || fail_closed "Baseline result payload is missing."
+
+  for baseline_file in "${baseline_output}"/*.json; do
+    [ -f "${baseline_file}" ] || continue
+    name="$(basename "${baseline_file}")"
+    if [ "${name}" = "baseline-status.json" ]; then
+      cp "${baseline_file}" "${candidate_output}/${name}"
+    else
+      cp "${baseline_file}" "${candidate_output}/baseline-${name}"
+    fi
+  done
+
+# apply-differential-gate expects baseline command metadata beside its payload.
+baseline_status="${baseline_output}/baseline-status.json"
+if [ ! -f "${baseline_status}" ]; then
+  baseline_status_value="$(jq -r --arg command "${command}" '.[$command]' <<< "${baseline_results}")"
+  structured=false
+  stem="$(printf '%s' "${command}" | tr -c 'A-Za-z0-9._-' '-')"
+  [ -f "${baseline_output}/${stem}.json" ] && structured=true
+  jq -cn --arg command "${command}" --arg status "${baseline_status_value}" --argjson structured "${structured}" \
+    '{($command): {status:$status, exit_code:(if $status == "pass" then 0 elif $status == "timeout" then 124 else 1 end), command:$command, structured_output:$structured}}' > "${baseline_status}"
+fi
+fi
+
+if [ "${REQUIRE_BASELINE:-false}" = "true" ]; then
+  results="$(python3 "${action_root}/scripts/core/apply-differential-gate.py" "${candidate_results}" "${candidate_output}" "${baseline_output}")"
+else
+  results="${candidate_results}"
+fi
+
+{
+  echo 'results<<__HOMEBOY_RESULTS__'
+  printf '%s\n' "${results}"
+  echo '__HOMEBOY_RESULTS__'
+} >> "${GITHUB_OUTPUT}"
+
+component="$(jq -r '.component' "${candidate_manifest}")"
+printf 'component=%s\noutput-dir=%s\n' "${component}" "${candidate_output}" >> "${GITHUB_OUTPUT}"
+
+RESULTS="${results}" COMMANDS="${command}" OPERATIONS_RESULTS='' PR_ACTIVE='' \
+  bash "${action_root}/scripts/core/enforce-final-status.sh"

--- a/scripts/core/resolve-commands.sh
+++ b/scripts/core/resolve-commands.sh
@@ -29,7 +29,10 @@ set -euo pipefail
 COMMANDS_INPUT="${COMMANDS_INPUT:-}"
 SCOPE_CONTEXT="${SCOPE_CONTEXT:-manual}"
 
-if [ -n "${COMMANDS_INPUT}" ]; then
+if [ "${HOMEBOY_PREPARE_ONLY:-false}" = "true" ]; then
+  ALL_COMMANDS=""
+  echo "Preparing Homeboy without running commands"
+elif [ -n "${COMMANDS_INPUT}" ]; then
   ALL_COMMANDS="${COMMANDS_INPUT}"
   echo "Commands from input: ${ALL_COMMANDS}"
 else

--- a/scripts/core/test-command-resolution.sh
+++ b/scripts/core/test-command-resolution.sh
@@ -83,6 +83,10 @@ cron_output="$(run_resolve "" "cron")"
 assert_equals "" "$(get_output "${cron_output}" "resolved-commands")" "cron default has no quality commands"
 assert_equals "release" "$(get_output "${cron_output}" "release-commands")" "cron default populates release bucket"
 
+prepare_output="$(HOMEBOY_PREPARE_ONLY=true run_resolve "review test")"
+assert_equals "" "$(get_output "${prepare_output}" "resolved-commands")" "prepare-only suppresses quality commands"
+assert_equals "" "$(get_output "${prepare_output}" "release-commands")" "prepare-only suppresses release commands"
+
 enforce_output="$(RESULTS='{}' COMMANDS='' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}")"
 assert_contains "No quality gate commands to enforce" "${enforce_output}" "release-only final status skips quality enforcement"
 

--- a/scripts/core/test-download-candidate-binary.sh
+++ b/scripts/core/test-download-candidate-binary.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin"
+
+cat > "${tmp}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = api ]; then
+  printf '%s\n' homeboy-candidate-binary-1 unrelated homeboy-candidate-binary-3 homeboy-candidate-binary-2
+  exit 0
+fi
+if [ "$1 $2" = 'run download' ]; then
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --name) name="$2"; shift 2 ;;
+      --dir) destination="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  printf '%s\n' "${name}" > "${destination}/homeboy"
+  exit 0
+fi
+exit 1
+SH
+chmod +x "${tmp}/bin/gh"
+
+PATH="${tmp}/bin:${PATH}" \
+GITHUB_REPOSITORY=example/repo \
+GITHUB_RUN_ID=42 \
+GITHUB_OUTPUT="${tmp}/output" \
+BINARY_DESTINATION="${tmp}/download" \
+bash "${ROOT}/scripts/core/download-candidate-binary.sh" >/dev/null
+
+grep -Fx 'artifact-name=homeboy-candidate-binary-3' "${tmp}/output" >/dev/null || { printf 'FAIL: newest binary attempt was not selected\n'; exit 1; }
+expected="$(shasum -a 256 "${tmp}/download/homeboy" | cut -d' ' -f1)"
+grep -Fx "binary-sha256=${expected}" "${tmp}/output" >/dev/null || { printf 'FAIL: selected binary digest was not published\n'; exit 1; }
+printf 'PASS: candidate binary selection is newest-attempt deterministic and digest-bound\n'

--- a/scripts/core/test-reconcile-differential-phases.sh
+++ b/scripts/core/test-reconcile-differential-phases.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RECONCILE="${ROOT}/scripts/core/reconcile-differential-phases.sh"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+write_phase() {
+  local phase="$1" checkout_sha="$2" component="$3" cli="$4" results="$5" payload="$6"
+  local dir="${tmp}/artifacts/${phase}"
+  mkdir -p "${dir}/homeboy-ci-results"
+  printf '%s\n' "${payload}" > "${dir}/homeboy-ci-results/review-test.json"
+  jq -cn --arg phase "${phase}" --arg repository example/repo --arg candidate_sha candidate --arg base_sha base --arg checkout_sha "${checkout_sha}" --arg command 'review test' --arg component "${component}" --arg action_revision action-sha --arg cli_revision "${cli}" --arg binary_sha256 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' --argjson run_attempt 2 --argjson results "${results}" '{phase:$phase,repository:$repository,candidate_sha:$candidate_sha,base_sha:$base_sha,checkout_sha:$checkout_sha,command:$command,component:$component,action_revision:$action_revision,cli_revision:$cli_revision,binary_sha256:$binary_sha256,run_attempt:$run_attempt,results:$results}' > "${dir}/manifest.json"
+}
+
+run_case() {
+  local expected="$1" label="$2"
+  shift 2
+  rm -f "${tmp}/output"
+  set +e
+  PHASE_ARTIFACT_ROOT="${tmp}/artifacts" REPOSITORY=example/repo CANDIDATE_SHA=candidate BASE_SHA=base COMMAND='review test' ACTION_REVISION=action-sha RUN_ATTEMPT=2 REQUIRE_BASELINE=true GITHUB_OUTPUT="${tmp}/output" bash "${RECONCILE}" >/dev/null 2>&1
+  local actual=$?
+  set -e
+  if [ "${actual}" -ne "${expected}" ]; then
+    printf 'FAIL: %s (expected exit %s, got %s)\n' "${label}" "${expected}" "${actual}"
+    exit 1
+  fi
+  printf 'PASS: %s\n' "${label}"
+}
+
+payload_pass='{"success":true,"data":{"test_counts":{"failed":0,"errors":0}}}'
+payload_one='{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}'
+
+rm -rf "${tmp}/artifacts"; write_phase candidate candidate component cli '{"review test":"pass"}' "${payload_pass}"; write_phase baseline base component cli '{"review test":"pass"}' "${payload_pass}"
+run_case 0 'matching passing phases reconcile green'
+
+rm -rf "${tmp}/artifacts"; write_phase candidate candidate component cli '{"review test":"fail"}' "${payload_one}"; write_phase baseline base component cli '{"review test":"pass"}' "${payload_pass}"
+run_case 1 'introduced candidate failure remains blocking'
+
+rm -rf "${tmp}/artifacts"; write_phase candidate candidate component cli '{"review test":"fail"}' "${payload_one}"; write_phase baseline base component cli '{"review test":"fail"}' "${payload_one}"
+run_case 0 'baseline red is preserved as a non-regression verdict'
+grep -F '"baseline_red"' "${tmp}/output" >/dev/null || { printf 'FAIL: baseline red verdict was not published\n'; exit 1; }
+
+rm -rf "${tmp}/artifacts"; write_phase candidate candidate component cli '{"review test":"timeout"}' "${payload_pass}"; write_phase baseline base component cli '{"review test":"pass"}' "${payload_pass}"
+run_case 1 'candidate timeout remains blocking'
+
+rm -rf "${tmp}/artifacts"; mkdir -p "${tmp}/artifacts"; write_phase baseline base component cli '{"review test":"pass"}' "${payload_pass}"
+run_case 1 'missing candidate artifact fails closed'
+
+rm -rf "${tmp}/artifacts"; write_phase candidate candidate component-a cli '{"review test":"pass"}' "${payload_pass}"; write_phase baseline base component-b cli '{"review test":"pass"}' "${payload_pass}"
+run_case 1 'component provenance mismatch fails closed'
+
+rm -rf "${tmp}/artifacts"; write_phase candidate candidate component cli '{"review test":"pass"}' "${payload_pass}"; write_phase baseline base component cli '{"review test":"pass"}' "${payload_pass}"
+jq '.binary_sha256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"' "${tmp}/artifacts/baseline/manifest.json" > "${tmp}/manifest.json"
+mv "${tmp}/manifest.json" "${tmp}/artifacts/baseline/manifest.json"
+run_case 1 'binary provenance mismatch fails closed'
+
+for field in repository candidate_sha base_sha command action_revision cli_revision phase; do
+  rm -rf "${tmp}/artifacts"
+  write_phase candidate candidate component cli '{"review test":"pass"}' "${payload_pass}"
+  write_phase baseline base component cli '{"review test":"pass"}' "${payload_pass}"
+  jq --arg field "${field}" '.[$field] = "mismatch"' "${tmp}/artifacts/candidate/manifest.json" > "${tmp}/manifest.json"
+  mv "${tmp}/manifest.json" "${tmp}/artifacts/candidate/manifest.json"
+  run_case 1 "${field} provenance mismatch fails closed"
+done
+
+# Candidate and baseline have identical dependencies, so rerunning either job
+# does not implicitly rerun the other phase or reuse its checkout.
+grep -F '  candidate:' "${WORKFLOW}" >/dev/null
+grep -F '  baseline:' "${WORKFLOW}" >/dev/null
+grep -F 'needs: [binary, plan]' "${WORKFLOW}" >/dev/null
+if grep -A3 '^  baseline:' "${WORKFLOW}" | grep -q 'candidate'; then
+  printf 'FAIL: baseline phase depends on candidate and cannot be retried independently\n'
+  exit 1
+fi
+printf 'PASS: workflow keeps candidate and baseline retries independent\n'
+
+rm -rf "${tmp}/artifacts"
+write_phase candidate candidate component cli '{"review test":"pass"}' "${payload_pass}"
+write_phase baseline base component cli '{"review test":"pass"}' "${payload_pass}"
+mkdir -p "${tmp}/artifacts/prior/candidate"
+cp -R "${tmp}/artifacts/candidate/." "${tmp}/artifacts/prior/candidate/"
+jq '.run_attempt = 1' "${tmp}/artifacts/prior/candidate/manifest.json" > "${tmp}/manifest.json"
+mv "${tmp}/manifest.json" "${tmp}/artifacts/prior/candidate/manifest.json"
+run_case 0 'reconciliation reuses the newest independently retried phase artifact'
+
+# These are literal GitHub expression contracts, not shell interpolation.
+# shellcheck disable=SC2016
+grep -F 'name: ${{ matrix.title }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: reconciliation did not preserve required check names\n'; exit 1; }
+# shellcheck disable=SC2016
+grep -F 'differential-gating: ${{ inputs.differential-gating }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate lost differential scope semantics\n'; exit 1; }
+# shellcheck disable=SC2016
+grep -F 'scope: ${{ inputs.scope }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: baseline lost caller scope semantics\n'; exit 1; }
+grep -F 'Evaluate PR policy after reconciled quality gates' "${WORKFLOW}" >/dev/null || { printf 'FAIL: reconciled workflow dropped PR policy evaluation\n'; exit 1; }
+# shellcheck disable=SC2016
+grep -F 'homeboy-differential-candidate-${{ matrix.artifact_key }}-${{ github.run_attempt }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate artifacts are not command- and attempt-scoped\n'; exit 1; }
+printf 'PASS: required checks, scope semantics, and post-reconciliation policy are preserved\n'

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
-if ! grep -q 'name: \${{ matrix.title }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
+if ! grep -q 'name: Candidate \${{ matrix.title }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q 'commands: \${{ matrix.command }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q '^      execution-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q '^          execution-timeout-seconds: \${{ inputs.execution-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml" \

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -59,10 +59,12 @@ assert_not_contains 'gh release create' "${WORKFLOW}" "release workflow does not
 assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not parse changelog notes"
 
 # GitHub-hosted workflow dependencies must use published action majors (#275).
-assert_count 'actions/checkout@v4' '3' "${CI_WORKFLOW}" "reusable CI workflow uses checkout v4 for every checkout"
-assert_count 'actions/create-github-app-token@v2' '1' "${CI_WORKFLOW}" "reusable CI workflow uses app-token v2"
+assert_count 'actions/checkout@v4' '9' "${CI_WORKFLOW}" "reusable CI workflow uses checkout v4 for every checkout"
+assert_count 'actions/create-github-app-token@v2' '3' "${CI_WORKFLOW}" "reusable CI workflow uses app-token v2"
 assert_not_contains 'actions/checkout@v6' "${CI_WORKFLOW}" "reusable CI workflow does not use unavailable checkout v6"
 assert_not_contains 'actions/create-github-app-token@v3' "${CI_WORKFLOW}" "reusable CI workflow does not use unavailable app-token v3"
+assert_not_contains 'merge-multiple: true' "${CI_WORKFLOW}" "reusable CI workflow never merges competing binary artifacts"
+assert_contains 'actions: read' "${CI_WORKFLOW}" "reusable CI workflow can download current-run artifacts"
 assert_count 'actions/checkout@v4' '3' "${WORKFLOW}" "release workflow uses checkout v4 for every checkout"
 assert_count 'actions/create-github-app-token@v2' '1' "${WORKFLOW}" "release workflow uses app-token v2"
 assert_not_contains 'actions/checkout@v6' "${WORKFLOW}" "release workflow does not use unavailable checkout v6"


### PR DESCRIPTION
Closes #312.

Unblocks Extra-Chill/homeboy#10992 and Extra-Chill/homeboy#10986.

## What changed

- materialize one candidate Homeboy binary for the reusable CI workflow
- run candidate and baseline quality phases as independent jobs
- publish attempt-scoped, full-command-keyed phase artifacts
- select the newest candidate binary deterministically and bind both phases to its SHA-256
- reconcile repository, candidate/base SHA, command, component, action, CLI, binary, phase, and attempt provenance before enforcing the established Audit/Lint/Test check
- preserve direct composite-action behavior, differential scope semantics, PR comments, and post-reconciliation PR policy

## Verification

- `actionlint .github/workflows/ci.yml`
- ShellCheck on changed shell scripts
- `scripts/core/test-download-candidate-binary.sh`
- `scripts/core/test-reconcile-differential-phases.sh`
- `scripts/release/test-release-workflow.sh`
- `scripts/core/test-command-resolution.sh`
- `scripts/core/test-test-action-workflow-liveness.sh`
- all remaining action shell/Python tests passed independently; `test-command-builders.sh` passed standalone
- `git diff --check`

The aggregate macOS runner cannot execute the Linux-only `timeout`/`/proc` paths; those unchanged contracts remain covered by repository CI.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol performed root-cause analysis, implementation repair, verification, and review. Homeboy Cook with OpenAI GPT-5.6 Terra drafted the initial candidate. Chris Huber reviewed the resulting code and remains responsible for every line.