### PR TITLE
fix: propagate reusable test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,10 @@ on:
         description: 'Maximum wall-clock time for each Homeboy command phase.'
         type: string
         default: '1800'
+      test-timeout-seconds:
+        description: 'Maximum wall-clock time for the Homeboy test child. Must leave cleanup margin below the command phase timeout.'
+        type: string
+        default: '1500'
       cleanup-timeout-seconds:
         description: 'Maximum wall-clock time to terminate command descendants.'
         type: string
@@ -394,6 +398,7 @@ jobs:
           baseline-commands: none
           observation-window: ${{ inputs.observation-window }}
           execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
+          test-timeout-seconds: ${{ inputs.test-timeout-seconds }}
           cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           app-token: ${{ steps.app-token.outputs.token || github.token }}
           comment-key: ${{ inputs.comment-key }}
@@ -478,6 +483,7 @@ jobs:
           differential-gating: 'true'
           baseline-commands: none
           execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
+          test-timeout-seconds: ${{ inputs.test-timeout-seconds }}
           cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           pr-comment: 'false'
           auto-issue: 'false'

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Use these outputs to gate downstream jobs:
 | `baseline-commands` | No | `auto` | Commands to rerun at the PR base when `differential-gating` is true. `auto` reruns requested `review audit`/`review lint`/`review test` commands; use a comma-separated subset such as `review audit` or `none` to skip baseline reruns. |
 | `observation-window` | No | `24h` | Duration window passed to best-effort `homeboy runs export --since` for the separate matrix-safe observations artifact. |
 | `execution-timeout-seconds` | No | `1800` | Per-command wall-clock budget. The action writes liveness notices and returns timeout evidence when the budget expires. |
+| `test-timeout-seconds` | No | inherited / `1500` | Homeboy test-child budget. Direct action calls preserve `HOMEBOY_TEST_TIMEOUT_SECONDS` when omitted; the reusable workflow defaults to `1500`. Must leave cleanup margin below `execution-timeout-seconds`. |
 | `cleanup-timeout-seconds` | No | `15` | Process-group teardown budget after a command finishes or times out. The action retains command logs and fails with diagnostics if cleanup cannot finish. |
 | `import-observations` | No | `false` | Download and best-effort import earlier `homeboy-observations-*` artifacts from the same workflow run before command execution. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |

--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,10 @@ inputs:
     description: 'Maximum wall-clock time for a Homeboy command phase. Emits liveness notices and exits with actionable timeout evidence.'
     required: false
     default: '1800'
+  test-timeout-seconds:
+    description: 'Maximum wall-clock time for the Homeboy test child. Empty preserves HOMEBOY_TEST_TIMEOUT_SECONDS or Homeboy default. Must leave cleanup-timeout-seconds of margin below execution-timeout-seconds.'
+    required: false
+    default: ''
   cleanup-timeout-seconds:
     description: 'Maximum wall-clock time to terminate and verify a Homeboy command process group after command completion or timeout. Emits retained-log diagnostics and fails when cleanup cannot finish.'
     required: false
@@ -300,6 +304,15 @@ runs:
         COMMANDS_INPUT: ${{ inputs.commands }}
         HOMEBOY_PREPARE_ONLY: ${{ inputs.prepare-only }}
       run: bash ${{ github.action_path }}/scripts/core/phase-progress.sh run changed_scope_resolution -- bash ${{ github.action_path }}/scripts/core/resolve-commands.sh
+
+    - name: Validate timeout budgets
+      if: steps.resolve-commands.outputs.has-test == 'true'
+      shell: bash
+      env:
+        HOMEBOY_TEST_TIMEOUT_SECONDS: ${{ inputs.test-timeout-seconds || env.HOMEBOY_TEST_TIMEOUT_SECONDS || '1500' }}
+        HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
+        HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
+      run: bash ${{ github.action_path }}/scripts/core/validate-timeout-budgets.sh
 
     # ── Phase 3: Install Homeboy ──
     # Homeboy installs before PHP/Node so we can use `homeboy component env`
@@ -513,6 +526,7 @@ runs:
         RUN_GROUP_PREFIX: homeboy
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
         HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
+        HOMEBOY_TEST_TIMEOUT_SECONDS: ${{ inputs.test-timeout-seconds || env.HOMEBOY_TEST_TIMEOUT_SECONDS || '1500' }}
         HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF: true
         HOMEBOY_ACTION_PHASE_HEARTBEAT_SECONDS: ${{ inputs.phase-heartbeat-seconds }}
         HOMEBOY_ACTION_PHASE_BUDGET_SECONDS: ${{ inputs.phase-budget-seconds }}
@@ -600,6 +614,7 @@ runs:
         RUN_GROUP_PREFIX: homeboy baseline
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}
         HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS: ${{ inputs.cleanup-timeout-seconds }}
+        HOMEBOY_TEST_TIMEOUT_SECONDS: ${{ inputs.test-timeout-seconds || env.HOMEBOY_TEST_TIMEOUT_SECONDS || '1500' }}
         HOMEBOY_ACTION_REQUIRE_CONTAINMENT_PROOF: true
         HOMEBOY_ACTION_PHASE_HEARTBEAT_SECONDS: ${{ inputs.phase-heartbeat-seconds }}
         HOMEBOY_ACTION_PHASE_BUDGET_SECONDS: ${{ inputs.phase-budget-seconds }}

--- a/scripts/core/resolve-commands.sh
+++ b/scripts/core/resolve-commands.sh
@@ -23,6 +23,7 @@
 #   RESOLVED_COMMANDS     — comma-separated quality command list
 #   RELEASE_COMMANDS      — comma-separated release command list
 #   OPERATIONS_COMMANDS   — comma-separated operations command list (fleet/deploy)
+#   has-test              — true when an exact test or review test command is present
 
 set -euo pipefail
 
@@ -63,6 +64,7 @@ fi
 QUALITY_COMMANDS=()
 RELEASE_COMMANDS=()
 OPS_COMMANDS=()
+HAS_TEST=false
 
 IFS=',' read -ra _ALL_ARRAY <<< "${ALL_COMMANDS}"
 for _cmd in "${_ALL_ARRAY[@]}"; do
@@ -78,6 +80,10 @@ for _cmd in "${_ALL_ARRAY[@]}"; do
       ;;
     *)
       QUALITY_COMMANDS+=("${_cmd}")
+      _subcommand="$(printf '%s' "${_cmd}" | awk '{print $2}')"
+      if [ "${_base}" = "test" ] || { [ "${_base}" = "review" ] && [ "${_subcommand}" = "test" ]; }; then
+        HAS_TEST=true
+      fi
       ;;
   esac
 done
@@ -110,6 +116,7 @@ fi
 
 echo "RESOLVED_COMMANDS=${RESOLVED_COMMANDS}" >> "${GITHUB_ENV}"
 echo "resolved-commands=${RESOLVED_COMMANDS}" >> "${GITHUB_OUTPUT}"
+echo "has-test=${HAS_TEST}" >> "${GITHUB_OUTPUT}"
 
 echo "RELEASE_COMMANDS=${RELEASE_COMMANDS_OUTPUT}" >> "${GITHUB_ENV}"
 echo "release-commands=${RELEASE_COMMANDS_OUTPUT}" >> "${GITHUB_OUTPUT}"

--- a/scripts/core/test-command-resolution.sh
+++ b/scripts/core/test-command-resolution.sh
@@ -87,6 +87,13 @@ prepare_output="$(HOMEBOY_PREPARE_ONLY=true run_resolve "review test")"
 assert_equals "" "$(get_output "${prepare_output}" "resolved-commands")" "prepare-only suppresses quality commands"
 assert_equals "" "$(get_output "${prepare_output}" "release-commands")" "prepare-only suppresses release commands"
 
+review_test_output="$(run_resolve "review test")"
+assert_equals "true" "$(get_output "${review_test_output}" "has-test")" "review test enables the test budget"
+bare_test_output="$(run_resolve "test")"
+assert_equals "true" "$(get_output "${bare_test_output}" "has-test")" "bare test enables the test budget"
+contest_output="$(run_resolve "contest,review latest")"
+assert_equals "false" "$(get_output "${contest_output}" "has-test")" "unrelated commands containing test do not enable the test budget"
+
 enforce_output="$(RESULTS='{}' COMMANDS='' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}")"
 assert_contains "No quality gate commands to enforce" "${enforce_output}" "release-only final status skips quality enforcement"
 

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -10,6 +10,10 @@ if ! grep -q 'name: Candidate \${{ matrix.title }}' "${ROOT_DIR}/.github/workflo
   || ! grep -q 'commands: \${{ matrix.command }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q '^      execution-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q '^          execution-timeout-seconds: \${{ inputs.execution-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || ! grep -q '^      test-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || [ "$(grep -c '^          test-timeout-seconds: \${{ inputs.test-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 2 ] \
+  || [ "$(grep -c "HOMEBOY_TEST_TIMEOUT_SECONDS: \${{ inputs.test-timeout-seconds || env.HOMEBOY_TEST_TIMEOUT_SECONDS || '1500' }}" "${ROOT_DIR}/action.yml")" -ne 3 ] \
+  || ! grep -q "if: steps.resolve-commands.outputs.has-test == 'true'" "${ROOT_DIR}/action.yml" \
   || ! grep -q '^      cleanup-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q '^          cleanup-timeout-seconds: \${{ inputs.cleanup-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml"; then
   printf 'FAIL: reusable CI Test job does not pass its exact matrix command to the action\n'

--- a/scripts/core/test-validate-timeout-budgets.sh
+++ b/scripts/core/test-validate-timeout-budgets.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATE="${ROOT}/scripts/core/validate-timeout-budgets.sh"
+
+HOMEBOY_TEST_TIMEOUT_SECONDS=1500 HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS=1800 HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=15 bash "${VALIDATE}"
+printf 'PASS: default timeout ordering is valid\n'
+
+for values in '1800 1800 15' '1790 1800 15' 'invalid 1800 15'; do
+  read -r test_timeout execution_timeout cleanup_timeout <<< "${values}"
+  if HOMEBOY_TEST_TIMEOUT_SECONDS="${test_timeout}" HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS="${execution_timeout}" HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS="${cleanup_timeout}" bash "${VALIDATE}" >/dev/null 2>&1; then
+    printf 'FAIL: invalid timeout ordering passed: %s\n' "${values}"
+    exit 1
+  fi
+done
+printf 'PASS: invalid timeout values and insufficient cleanup margin fail closed\n'

--- a/scripts/core/validate-timeout-budgets.sh
+++ b/scripts/core/validate-timeout-budgets.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_timeout="${HOMEBOY_TEST_TIMEOUT_SECONDS:?HOMEBOY_TEST_TIMEOUT_SECONDS is required}"
+execution_timeout="${HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS:?HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS is required}"
+cleanup_timeout="${HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS:?HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS is required}"
+
+for value in "${test_timeout}" "${execution_timeout}" "${cleanup_timeout}"; do
+  if ! [[ "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::Timeout budgets must be positive integer seconds."
+    exit 1
+  fi
+done
+
+if [ $((test_timeout + cleanup_timeout)) -ge "${execution_timeout}" ]; then
+  echo "::error::test-timeout-seconds (${test_timeout}) plus cleanup-timeout-seconds (${cleanup_timeout}) must remain below execution-timeout-seconds (${execution_timeout}) so Homeboy can publish structured timeout evidence before the outer process-group backstop."
+  exit 1
+fi


### PR DESCRIPTION
Closes #303.

Unblocks Extra-Chill/homeboy#10992 and Extra-Chill/homeboy#10986 after the restartable differential DAG released in v2.10.0.

## What changed

- expose `test-timeout-seconds` in the composite action and reusable workflow
- pass the configured budget to both candidate and baseline Homeboy commands
- preserve direct callers in this order: explicit input, inherited `HOMEBOY_TEST_TIMEOUT_SECONDS`, then `1500`
- detect exact `test` and `review test` commands instead of substrings
- fail closed unless test budget plus cleanup margin remains below the outer execution budget

## Verification

- `actionlint .github/workflows/ci.yml`
- ShellCheck on changed standalone scripts
- `scripts/core/test-validate-timeout-budgets.sh`
- `scripts/core/test-command-resolution.sh`
- `scripts/core/test-test-action-workflow-liveness.sh`
- `git diff --check`
- independent review found no remaining blocker/high/medium issues

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol implemented, tested, and reviewed the change. Chris Huber reviewed the resulting code and remains responsible for every line.