### PR TITLE
Restore build cache in differential phase jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,8 @@ jobs:
   binary:
     name: Prepare candidate Homeboy binary
     runs-on: ubuntu-latest
+    outputs:
+      cargo-cache-key: ${{ steps.cargo-cache-key.outputs.key }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -189,15 +191,20 @@ jobs:
         with:
           toolchain: ${{ inputs.rust-toolchain }}
 
-      - name: Cache cargo
+      - name: Resolve candidate cargo cache key
+        id: cargo-cache-key
         if: hashFiles('Cargo.lock') != ''
+        run: echo "key=${RUNNER_OS}-cargo-ci-${{ hashFiles('Cargo.lock') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache cargo
+        if: steps.cargo-cache-key.outputs.key != ''
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('Cargo.lock') }}
+          key: ${{ steps.cargo-cache-key.outputs.key }}
           restore-keys: ${{ runner.os }}-cargo-ci-
 
       - name: Build candidate Homeboy binary
@@ -348,6 +355,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
+      - name: Restore candidate cargo cache
+        if: needs.binary.outputs.cargo-cache-key != ''
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ needs.binary.outputs.cargo-cache-key }}
+
       - name: Check out Homeboy Action
         uses: actions/checkout@v4
         with:
@@ -452,6 +469,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+
+      - name: Restore candidate cargo cache
+        if: needs.binary.outputs.cargo-cache-key != ''
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ needs.binary.outputs.cargo-cache-key }}
+
       - uses: actions/checkout@v4
         with:
           repository: Extra-Chill/homeboy-action

--- a/scripts/core/test-reusable-workflow-cargo-cache.sh
+++ b/scripts/core/test-reusable-workflow-cargo-cache.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
+
+if [ "$(grep -c '^      cargo-cache-key: \${{ steps.cargo-cache-key.outputs.key }}$' "${WORKFLOW}")" -ne 1 ] \
+  || [ "$(grep -c '^        id: cargo-cache-key$' "${WORKFLOW}")" -ne 1 ] \
+  || [ "$(grep -c '^          key: \${{ steps.cargo-cache-key.outputs.key }}$' "${WORKFLOW}")" -ne 1 ]; then
+  printf 'FAIL: binary job does not publish and consume one candidate cargo cache identity\n'
+  exit 1
+fi
+
+if [ "$(grep -c '^      - name: Restore candidate cargo cache$' "${WORKFLOW}")" -ne 2 ] \
+  || [ "$(grep -Fc "        if: needs.binary.outputs.cargo-cache-key != ''" "${WORKFLOW}")" -ne 2 ] \
+  || [ "$(grep -c '^          key: \${{ needs.binary.outputs.cargo-cache-key }}$' "${WORKFLOW}")" -ne 2 ]; then
+  printf 'FAIL: candidate and baseline jobs do not restore the binary job cargo cache identity\n'
+  exit 1
+fi
+
+if [ "$(grep -c "if: hashFiles('Cargo.lock') != ''" "${WORKFLOW}")" -ne 1 ]; then
+  printf 'FAIL: Cargo cache discovery must remain conditional and owned by the candidate checkout\n'
+  exit 1
+fi
+
+printf 'PASS: reusable differential phases restore the candidate build cargo cache identity\n'


### PR DESCRIPTION
## Summary

- publish the candidate checkout Cargo cache identity from the binary preparation job
- restore that exact cache in independent candidate and baseline phase jobs
- keep cache discovery conditional so non-Rust consumers remain unchanged
- prove candidate-lockfile cache parity with a focused workflow contract test

Closes #315.
Supports Extra-Chill/homeboy#10992 and Extra-Chill/homeboy#10998.

## Evidence

The failed integration run https://github.com/Extra-Chill/homeboy/actions/runs/30639492935 resolved the requested 3000/2700 second budgets, but candidate and baseline started from cold `target` directories and were externally terminated with exit 143 after 1,853 and 2,018 seconds. The binary job already populates and saves the candidate Cargo cache; this change carries its exact key across the job boundary, including when a PR changes `Cargo.lock`.

Verified locally:

- `actionlint .github/workflows/ci.yml`
- `bash scripts/core/test-reusable-workflow-cargo-cache.sh`
- all macOS-compatible action shell/Python tests
- `git diff --check`

The existing Linux-specific supervisor test requires `/proc` and remains covered by Ubuntu CI.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol correlated the live runner shutdown evidence with the reusable workflow cache boundary, implemented the workflow and contract test, and ran verification. Chris Huber remains responsible for every line.