### PR TITLE
fix: stop reporting an unmeasured command as a pre-existing failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -641,6 +641,7 @@ runs:
           || contains(steps.select-results.outputs.results, '"timeout"')
           || contains(steps.select-results.outputs.results, '"baseline_red"')
           || contains(steps.select-results.outputs.results, '"inconclusive"')
+          || contains(steps.select-results.outputs.results, '"no_measurement"')
         )
       shell: bash
       env:

--- a/scripts/core/apply-differential-gate.py
+++ b/scripts/core/apply-differential-gate.py
@@ -212,6 +212,33 @@ def main() -> int:
         base_structured = base_metadata.get("structured_output") is True
 
         if base_failed and (base is None or not base_structured):
+            # `baseline_red` asserts something specific: this failure is
+            # pre-existing. That claim needs an observation on the candidate
+            # side to rest on -- "the same thing is wrong on main" presumes we
+            # know what is wrong here.
+            #
+            # When the candidate also produced no measurement, there is no such
+            # observation. A double timeout is the concrete case: both sides ran
+            # out of clock, neither wrote counts, and nothing at all is known
+            # about the command. Reporting that as `baseline_red` overstates it,
+            # and it is indistinguishable in the results JSON from a genuine
+            # measured-and-unchanged failure.
+            #
+            # `no_measurement` is deliberately non-blocking, exactly like
+            # `baseline_red`: a candidate is still not answerable for an
+            # infrastructure condition it did not cause, which is the decision
+            # the "timeout that also times out on the baseline" case encodes.
+            # This only stops the two states from being reported as one, so the
+            # absence of evidence is visible and countable rather than dressed
+            # up as a diagnosis. See Extra-Chill/homeboy#10999.
+            if timed_out or current is None:
+                adjusted[command] = "no_measurement"
+                print(
+                    f"::warning::Differential gate marked {command} no_measurement: neither the candidate nor the baseline produced comparable counts (baseline command `{command_label(command, base_metadata)}` exited {base_metadata.get('exit_code', 'unknown')}). Nothing is known about this command -- this is not evidence that the failure is pre-existing.",
+                    file=sys.stderr,
+                )
+                continue
+
             adjusted[command] = "baseline_red"
             print(
                 f"::warning::Differential gate marked {command} baseline_red: baseline command `{command_label(command, base_metadata)}` exited {base_metadata.get('exit_code', 'unknown')} before comparable counts were available",

--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -65,6 +65,13 @@ if [ "${HAS_QUALITY_COMMANDS}" = true ]; then
   if printf '%s\n' "${RESULTS}" | jq -e 'to_entries | any(.value == "inconclusive")' > /dev/null; then
     echo "::warning::One or more quality commands were inconclusive; preserving evidence without failing the PR"
   fi
+  # Non-blocking, like `baseline_red`: the candidate is not answerable for an
+  # infrastructure condition it did not cause. Distinct from `baseline_red`
+  # because nothing was measured on either side, so nothing is known -- this is
+  # not a finding that the failure is pre-existing. See Extra-Chill/homeboy#10999.
+  if printf '%s\n' "${RESULTS}" | jq -e 'to_entries | any(.value == "no_measurement")' > /dev/null; then
+    echo "::warning::One or more quality commands produced no measurement on either the candidate or the baseline; nothing is known about them. Not failing the PR, but this is not a pass."
+  fi
 fi
 
 # Check operations command results

--- a/scripts/core/test-apply-differential-gate.sh
+++ b/scripts/core/test-apply-differential-gate.sh
@@ -63,14 +63,30 @@ assert_equals '{"review lint":"baseline_red"}' "${result}" "lint baseline count 
 
 timed_out_payload='{"success":false,"data":{"exit_code":124,"failure":{"category":"infrastructure","phase":"test"},"raw_output":{"stderr_tail":"Homeboy command timed out after 1500000ms; terminated child process group before returning failure evidence."},"test_counts":{"failed":0,"errors":0}}}'
 
-# A timeout that also happens on the baseline is pre-existing, exactly like a
-# baseline-red test failure. Before this change `timeout` skipped the gate
-# entirely and stayed a hard red no matter what the baseline did.
+# A timeout that also happens on the baseline must not fail the candidate.
+# Before this was admitted to the gate, `timeout` skipped it entirely and stayed
+# a hard red no matter what the baseline did.
+#
+# It is reported as `no_measurement` rather than `baseline_red`. Both are
+# non-blocking, so the decision above is unchanged -- but `baseline_red` claims
+# the failure is *pre-existing*, and that claim needs an observation on the
+# candidate side to rest on. Here neither side wrote counts, so nothing is known
+# and there is nothing to call pre-existing. See Extra-Chill/homeboy#10999.
 printf '%s\n' "${timed_out_payload}" > "${current_dir}/review-test.json"
 rm -f "${base_dir}/review-test.json"
 printf '{"review test":{"status":"timeout","exit_code":124,"command":"homeboy review test sample --path .","structured_output":false}}\n' > "${base_dir}/baseline-status.json"
 result="$(python3 "${APPLY_GATE}" '{"review test":"timeout"}' "${current_dir}" "${base_dir}")"
-assert_equals '{"review test":"baseline_red"}' "${result}" "a timeout that also times out on the baseline is pre-existing, not a candidate failure"
+assert_equals '{"review test":"no_measurement"}' "${result}" "a double timeout reports no_measurement, not a pre-existing-failure diagnosis"
+
+# The discriminator. Same unmeasurable baseline, but here the candidate DID
+# measure -- so "this failure reproduces on main" is a claim the evidence can
+# support, and the verdict must stay `baseline_red`. If the new branch were
+# keyed on the baseline alone it would swallow this case too.
+printf '{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}\n' > "${current_dir}/review-test.json"
+rm -f "${base_dir}/review-test.json"
+printf '{"review test":{"status":"fail","exit_code":1,"command":"homeboy review test sample --path .","structured_output":false}}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"review test":"fail"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"review test":"baseline_red"}' "${result}" "a measured candidate against an unmeasurable baseline is still baseline_red"
 
 # The important negative. A killed run reports FEWER failures than a healthy
 # baseline (0 here, versus 1), so a naive count comparison reads the timeout as

--- a/scripts/core/test-enforce-final-status.sh
+++ b/scripts/core/test-enforce-final-status.sh
@@ -51,4 +51,18 @@ assert_exit 0 "baseline red quality results do not fail PR" \
 assert_exit 0 "inconclusive quality results do not fail PR" \
   env RESULTS='{"review lint":"inconclusive"}' COMMANDS='review lint' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
 
+# `no_measurement` is non-blocking by design: a candidate is not answerable for
+# an infrastructure condition it did not cause. This pins that, so the split
+# introduced for Extra-Chill/homeboy#10999 cannot quietly start failing PRs.
+assert_exit 0 "no_measurement quality results do not fail PR" \
+  env RESULTS='{"review test":"no_measurement"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+
+# ...and it must still say so out loud. A silent non-blocking verdict is how an
+# unmeasured command reads as a clean run.
+output="$(env RESULTS='{"review test":"no_measurement"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}" 2>&1)"
+case "${output}" in
+  *"::warning::"*"no measurement"*) printf 'PASS: no_measurement emits a warning annotation\n' ;;
+  *) printf 'FAIL: no_measurement did not annotate; got: %s\n' "${output}"; exit 1 ;;
+esac
+
 printf 'All final status enforcement checks passed.\n'

--- a/scripts/digest/generate-failure-digest.sh
+++ b/scripts/digest/generate-failure-digest.sh
@@ -64,7 +64,7 @@ append_differential_evidence() {
 
   rows="$(jq -r '
     to_entries[]
-    | select(.value == "baseline_red" or .value == "inconclusive")
+    | select(.value == "baseline_red" or .value == "inconclusive" or .value == "no_measurement")
     | [.key, .value] | @tsv
   ' <<< "${RESULTS_JSON}" 2>/dev/null || true)"
 

--- a/scripts/pr/comment/lib.sh
+++ b/scripts/pr/comment/lib.sh
@@ -83,7 +83,7 @@ summary_json_for_command() {
 
 command_status() {
   local command="$1"
-  echo "${RESULTS}" | jq -r --arg cmd "${command}" 'if .[$cmd] == "pass" or .[$cmd] == "fail" or .[$cmd] == "timeout" or .[$cmd] == "baseline_red" or .[$cmd] == "inconclusive" then .[$cmd] else "unknown" end' 2>/dev/null || echo "unknown"
+  echo "${RESULTS}" | jq -r --arg cmd "${command}" 'if .[$cmd] == "pass" or .[$cmd] == "fail" or .[$cmd] == "timeout" or .[$cmd] == "baseline_red" or .[$cmd] == "inconclusive" or .[$cmd] == "no_measurement" then .[$cmd] else "unknown" end' 2>/dev/null || echo "unknown"
 }
 
 is_refactor_owning_section() {

--- a/scripts/pr/comment/sections.sh
+++ b/scripts/pr/comment/sections.sh
@@ -71,7 +71,7 @@ status_icon() {
     # able to tell "this change broke tests" from "the suite never finished"
     # without opening the run.
     timeout) printf '%s\n' ':hourglass_flowing_sand:' ;;
-    baseline_red|inconclusive) printf '%s\n' ':warning:' ;;
+    baseline_red|inconclusive|no_measurement) printf '%s\n' ':warning:' ;;
     skipped) printf '%s\n' ':fast_forward:' ;;
     *) printf '%s\n' ':warning:' ;;
   esac
@@ -84,6 +84,7 @@ status_label() {
     timeout) printf '%s\n' 'timed out' ;;
     baseline_red) printf '%s\n' 'baseline red' ;;
     inconclusive) printf '%s\n' 'inconclusive' ;;
+    no_measurement) printf '%s\n' 'no measurement' ;;
     skipped) printf '%s\n' 'skipped' ;;
     *) printf '%s\n' 'unknown' ;;
   esac


### PR DESCRIPTION
Fixes Extra-Chill/homeboy#10999.

## The claim that was not earned

`baseline_red` asserts something specific: **this failure is pre-existing**. That claim needs an observation on the candidate side to rest on — "the same thing is wrong on main" presumes we know what is wrong here.

When the baseline produced no comparable counts *and* the candidate also produced none, there is no such observation. The concrete case is a double timeout — both sides ran out of clock, neither wrote counts, nothing at all is known about the command:

```
FIRST_RESULTS: {"review test":"timeout"}
##[warning]Differential gate marked review test baseline_red: baseline command … exited … before comparable counts were available
RESULTS: {"review test":"baseline_red"}
```

That run ([homeboy 30604805517](https://github.com/Extra-Chill/homeboy/actions/runs/30604805517)) concluded **`success`**. In the results JSON it was indistinguishable from a genuine measured-and-unchanged failure.

## What this does — and deliberately does not — change

Splits that case out as `no_measurement`.

**This is not a change to blocking semantics.** `no_measurement` is non-blocking exactly like `baseline_red`. A candidate is still not answerable for an infrastructure condition it did not cause, which is precisely the decision encoded by the existing "a timeout that also times out on the baseline is pre-existing, not a candidate failure" test. That decision stands.

All this does is stop two different states from being reported as one, so an absence of evidence is visible and countable rather than dressed up as a diagnosis.

Blocking the double-timeout case was considered and rejected for now: homeboy#10997 measured 16 of 26 recent Test jobs terminated mid-run, so blocking would fail a large share of PRs for infrastructure they did not cause. That option stays open once the termination rate comes down.

## Threaded through every consumer

Grepped the verdict vocabulary and updated all of it:

| file | change |
|---|---|
| `scripts/core/apply-differential-gate.py` | emits `no_measurement` when neither side measured |
| `scripts/core/enforce-final-status.sh` | warns, does not fail |
| `scripts/pr/comment/sections.sh` | `:warning:` icon, `no measurement` label |
| `scripts/pr/comment/lib.sh` | added to the known-status allowlist (else it renders `unknown`) |
| `scripts/digest/generate-failure-digest.sh` | included in differential evidence rows |
| `action.yml` | added to the failure-digest trigger condition |

`scripts/core/reconcile-differential-phases.sh` needs no change — it validates raw *phase* results (`pass|fail|timeout`) before the gate runs, and `no_measurement` cannot appear there.

## Tests

- The existing double-timeout assertion now expects `no_measurement`, with its comment rewritten to explain why the decision it pins is unchanged.
- **A new discriminator:** a *measured* candidate against the same unmeasurable baseline must stay `baseline_red`. This fails if the new branch is keyed on the baseline alone, which was the easy way to get this wrong.
- `no_measurement` does not fail the PR, **and** emits an annotation — a silent non-blocking verdict is exactly how an unmeasured command comes to read as a clean run.

All 38 test suites in `scripts/**` pass locally, including `test-unknown-status-rendering.sh`, which would have caught an unhandled verdict falling through to `unknown`.

## Delivery

`homeboy`'s `ci.yml` consumes this action at `ref: v2`, so this does not reach that repository's CI until a release advances `v2`.