### PR TITLE
Preserve phase result JSON in provenance manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,8 @@ jobs:
         run: |
           mkdir -p differential-phase/candidate
           action_revision="$(git -C .homeboy-action rev-parse HEAD)"
-          results="${RESULTS:-{}}"
+          results="${RESULTS:-}"
+          [ -n "${results}" ] || results='{}'
           jq -cn --arg phase candidate --arg repository "${REPOSITORY}" --arg candidate_sha "${CANDIDATE_SHA}" --arg base_sha "${BASE_SHA}" --arg checkout_sha "${CANDIDATE_SHA}" --arg command "${COMMAND}" --arg component "${COMPONENT}" --arg action_revision "${action_revision}" --arg cli_revision "${CLI_REVISION}" --arg binary_sha256 "${BINARY_SHA256}" --argjson run_attempt "${RUN_ATTEMPT}" --argjson results "${results}" '{phase:$phase,repository:$repository,candidate_sha:$candidate_sha,base_sha:$base_sha,checkout_sha:$checkout_sha,command:$command,component:$component,action_revision:$action_revision,cli_revision:$cli_revision,binary_sha256:$binary_sha256,run_attempt:$run_attempt,results:$results}' > differential-phase/candidate/manifest.json
           cp -R homeboy-ci-results differential-phase/candidate/homeboy-ci-results 2>/dev/null || mkdir -p differential-phase/candidate/homeboy-ci-results
 
@@ -531,7 +532,8 @@ jobs:
         run: |
           mkdir -p differential-phase/baseline
           action_revision="$(git -C .homeboy-action rev-parse HEAD)"
-          results="${RESULTS:-{}}"
+          results="${RESULTS:-}"
+          [ -n "${results}" ] || results='{}'
           jq -cn --arg phase baseline --arg repository "${REPOSITORY}" --arg candidate_sha "${CANDIDATE_SHA}" --arg base_sha "${BASE_SHA}" --arg checkout_sha "${BASE_SHA}" --arg command "${COMMAND}" --arg component "${COMPONENT}" --arg action_revision "${action_revision}" --arg cli_revision "${CLI_REVISION}" --arg binary_sha256 "${BINARY_SHA256}" --argjson run_attempt "${RUN_ATTEMPT}" --argjson results "${results}" '{phase:$phase,repository:$repository,candidate_sha:$candidate_sha,base_sha:$base_sha,checkout_sha:$checkout_sha,command:$command,component:$component,action_revision:$action_revision,cli_revision:$cli_revision,binary_sha256:$binary_sha256,run_attempt:$run_attempt,results:$results}' > differential-phase/baseline/manifest.json
           cp -R homeboy-ci-results differential-phase/baseline/homeboy-ci-results 2>/dev/null || mkdir -p differential-phase/baseline/homeboy-ci-results
       - name: Upload baseline phase evidence

--- a/scripts/core/test-reconcile-differential-phases.sh
+++ b/scripts/core/test-reconcile-differential-phases.sh
@@ -78,6 +78,22 @@ if grep -A3 '^  baseline:' "${WORKFLOW}" | grep -q 'candidate'; then
 fi
 printf 'PASS: workflow keeps candidate and baseline retries independent\n'
 
+if grep -F 'results="${RESULTS:-{}}"' "${WORKFLOW}" >/dev/null \
+  || [ "$(grep -Fc 'results="${RESULTS:-}"' "${WORKFLOW}")" -ne 2 ] \
+  || [ "$(grep -Fc "[ -n \"\${results}\" ] || results='{}'" "${WORKFLOW}")" -ne 2 ]; then
+  printf 'FAIL: candidate and baseline provenance do not preserve populated result JSON\n'
+  exit 1
+fi
+RESULTS='{"review test":"pass"}'
+results="${RESULTS:-}"
+[ -n "${results}" ] || results='{}'
+jq -e '."review test" == "pass"' <<< "${results}" >/dev/null
+RESULTS=''
+results="${RESULTS:-}"
+[ -n "${results}" ] || results='{}'
+jq -e 'type == "object" and length == 0' <<< "${results}" >/dev/null
+printf 'PASS: populated and missing phase results remain valid provenance JSON\n'
+
 rm -rf "${tmp}/artifacts"
 write_phase candidate candidate component cli '{"review test":"pass"}' "${payload_pass}"
 write_phase baseline base component cli '{"review test":"pass"}' "${payload_pass}"


### PR DESCRIPTION
## Summary

- replace ambiguous Bash default expansion in candidate and baseline provenance writers
- preserve populated action result JSON byte-for-byte for `jq --argjson`
- default genuinely missing results to an empty object
- execute regression coverage for populated and missing values

Closes #318.
Supports Extra-Chill/homeboy#10992 and Extra-Chill/homeboy#11044.

## Root cause

`results="${RESULTS:-{}}"` appends an extra closing brace when `RESULTS` is populated. In https://github.com/Extra-Chill/homeboy/actions/runs/30669332973 the changed-scope Test passed 2/2 tests and emitted `{"review test":"pass"}`, but provenance failed with `jq: invalid JSON text passed to --argjson`; reconciliation then correctly failed closed.

## Verification

- `bash scripts/core/test-reconcile-differential-phases.sh`
- all macOS-compatible action shell/Python tests
- `actionlint .github/workflows/ci.yml`
- `bash -n scripts/core/test-reconcile-differential-phases.sh`
- `git diff --check`

The existing Linux `/proc` supervisor test remains covered by Ubuntu CI.

## AI assistance

OpenCode with OpenAI GPT-5.6 Sol traced a passing Test result into the failing provenance writer, identified the Bash expansion ambiguity, implemented the candidate/baseline fix and regression coverage, and ran verification. Chris Huber remains responsible for every line.