### PR TITLE
fix(ci): fail candidate after terminal evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,13 @@ jobs:
           path: differential-phase
           if-no-files-found: warn
 
+      # The action deliberately continues through publication so reconciliation
+      # receives the terminal evidence, but the candidate check itself must
+      # still report that same terminal failure before a PR can be merged.
+      - name: Fail candidate phase when terminal evidence is not pass
+        if: always() && steps.phase.outcome == 'failure'
+        run: exit 1
+
   baseline:
     name: Baseline ${{ matrix.title }}
     needs: [binary, plan]

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -15,7 +15,8 @@ if ! grep -q 'name: Candidate \${{ matrix.title }}' "${ROOT_DIR}/.github/workflo
   || [ "$(grep -c "HOMEBOY_TEST_TIMEOUT_SECONDS: \${{ inputs.test-timeout-seconds || env.HOMEBOY_TEST_TIMEOUT_SECONDS || '1500' }}" "${ROOT_DIR}/action.yml")" -ne 3 ] \
   || ! grep -q "if: steps.resolve-commands.outputs.has-test == 'true'" "${ROOT_DIR}/action.yml" \
   || ! grep -q '^      cleanup-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
-  || ! grep -q '^          cleanup-timeout-seconds: \${{ inputs.cleanup-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml"; then
+  || ! grep -q '^          cleanup-timeout-seconds: \${{ inputs.cleanup-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || ! grep -A2 'name: Fail candidate phase when terminal evidence is not pass' "${ROOT_DIR}/.github/workflows/ci.yml" | grep -q "if: always() && steps.phase.outcome == 'failure'"; then
   printf 'FAIL: reusable CI Test job does not pass its exact matrix command to the action\n'
   exit 1
 fi


### PR DESCRIPTION
## Summary

Fails the Candidate phase after it uploads provenance-bound terminal evidence when its Homeboy action result is unsuccessful.

Fixes #320
Refs Extra-Chill/homeboy#11155 and #11000

## Root Cause

Homeboy run [30713173774](https://github.com/Extra-Chill/homeboy/actions/runs/30713173774) retained a truthful `review test: timeout` result (`exit_code: 124`) at the configured 1500-second budget. The reusable workflow marked the action phase `continue-on-error` so it could publish evidence, but never converted the phase failure into a Candidate job failure. Final reconciliation correctly rejected the artifact 14 seconds later.

## Behavior

Candidate evidence is still uploaded unconditionally. Immediately after upload, the Candidate job fails when the action phase has a terminal failure, so Candidate Test and final reconciliation report the same terminal outcome. Timeout budgets, differential processing, and artifact retention are unchanged.

## Verification

- Replayed the exact retained candidate artifact through `reconcile-differential-phases.sh`; it fails with the retained 1500-second timeout as expected.
- `bash scripts/core/test-test-action-workflow-liveness.sh`
- `bash scripts/core/test-enforce-final-status.sh`
- `bash scripts/core/test-reconcile-differential-phases.sh`
- `cargo fmt --all --check` in the Homeboy consumer worktree
- `cargo check --workspace` in the Homeboy consumer worktree
- `cargo test -p homeboy-core controller_runtime::tests::pin_current_uses_the_explicit_test_controller_fixture`
- `cargo test --test cook_lab_handoff_test -- --exact contradictory_cook_arguments_survive_controller_transport_context`

## Known Local Gate Constraints

`bash scripts/run-tests.sh` cannot run on this macOS host because its GNU `timeout` dependency is absent. `cargo clippy --workspace --all-targets -- -D warnings` fails on current Homeboy `main` warnings unrelated to this action-only diff. The reverse broker integration test hit a local controller HTTP timeout under host load.

## AI Assistance

OpenAI GPT-5.6 Sol via OpenCode investigated retained CI evidence, implemented the workflow fix, and ran substantive verification. Chris Huber remains responsible for every line.