### PR TITLE
Move action dependencies to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
     outputs:
       cargo-cache-key: ${{ steps.cargo-cache-key.outputs.key }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -198,7 +198,7 @@ jobs:
 
       - name: Cache cargo
         if: steps.cargo-cache-key.outputs.key != ''
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -212,7 +212,7 @@ jobs:
         run: ${{ inputs.build-command }}
 
       - name: Check out Homeboy Action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ inputs.action-ref }}
@@ -230,7 +230,7 @@ jobs:
           auto-setup: 'false'
 
       - name: Upload candidate Homeboy binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: homeboy-candidate-binary-${{ github.run_attempt }}
           path: /usr/local/bin/homeboy
@@ -350,14 +350,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Restore candidate cargo cache
         if: needs.binary.outputs.cargo-cache-key != ''
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -366,7 +366,7 @@ jobs:
           key: ${{ needs.binary.outputs.cargo-cache-key }}
 
       - name: Check out Homeboy Action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ inputs.action-ref }}
@@ -380,7 +380,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
@@ -451,7 +451,7 @@ jobs:
 
       - name: Upload candidate phase evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: homeboy-differential-candidate-${{ matrix.artifact_key }}-${{ github.run_attempt }}
           path: differential-phase
@@ -466,14 +466,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       - name: Restore candidate cargo cache
         if: needs.binary.outputs.cargo-cache-key != ''
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -481,7 +481,7 @@ jobs:
             target
           key: ${{ needs.binary.outputs.cargo-cache-key }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ inputs.action-ref }}
@@ -538,7 +538,7 @@ jobs:
           cp -R homeboy-ci-results differential-phase/baseline/homeboy-ci-results 2>/dev/null || mkdir -p differential-phase/baseline/homeboy-ci-results
       - name: Upload baseline phase evidence
         if: always() && matrix.baseline == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: homeboy-differential-baseline-${{ matrix.artifact_key }}-${{ github.run_attempt }}
           path: differential-phase
@@ -554,7 +554,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ inputs.action-ref }}
@@ -568,7 +568,7 @@ jobs:
         run: sudo cp "${{ steps.candidate-binary.outputs.binary-path }}" /usr/local/bin/homeboy
       - id: action-revision
         run: echo "value=$(git -C .homeboy-action rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           pattern: homeboy-differential-*-${{ matrix.artifact_key }}-*
@@ -590,7 +590,7 @@ jobs:
       - name: Generate GitHub App token
         id: app-token
         if: always() && inputs.pr-comment != 'false'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
@@ -620,10 +620,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && inputs.pr-policy != '' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ inputs.action-ref }}
@@ -637,7 +637,7 @@ jobs:
         run: sudo cp "${{ steps.candidate-binary.outputs.binary-path }}" /usr/local/bin/homeboy
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       should-release: ${{ steps.check.outputs.should-release }}
       tooling-identity: ${{ steps.release-check.outputs.tooling-identity }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -114,13 +114,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
           app-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -143,7 +143,7 @@ jobs:
     if: ${{ always() && needs.check.outputs.should-release == 'true' && needs.release.result == 'failure' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Save failed SHA
         run: git rev-parse HEAD > "${RUNNER_TEMP}/homeboy-release-last-failed"

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Full history: the scope tests resolve real revisions (`HEAD~1`) against
       # this checkout, which a shallow clone cannot provide.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -283,7 +283,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: Extra-Chill/homeboy-action@v2
         with:
           extension: rust
@@ -293,7 +293,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: Extra-Chill/homeboy-action@v2
         with:
           extension: rust
@@ -303,7 +303,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: Extra-Chill/homeboy-action@v2
         with:
           extension: rust
@@ -318,7 +318,7 @@ All three jobs write to the **same PR comment** automatically.
 Use `pr-policy` to classify whether a PR is safe for deterministic auto-merge after Homeboy checks pass. Homeboy core reads changed files from GitHub, applies repo-local author, branch, path, and content rules, then exposes `pr-policy-safe` and optionally merges the PR.
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 
 - uses: Extra-Chill/homeboy-action@v2
   with:
@@ -380,7 +380,7 @@ jobs:
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check for releasable commits
@@ -395,7 +395,7 @@ jobs:
     if: needs.check.outputs.should-release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: cargo fmt --check && cargo clippy && cargo test
       - uses: Extra-Chill/homeboy-action@v2
         with:
@@ -411,7 +411,7 @@ jobs:
       released: ${{ steps.release.outputs.released }}
       release-tag: ${{ steps.release.outputs.release-tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -433,11 +433,11 @@ jobs:
     if: needs.prepare.outputs.released == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.release-tag }}
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: artifacts-*
           path: artifacts
@@ -481,7 +481,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -515,7 +515,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -553,7 +553,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/action.yml
+++ b/action.yml
@@ -497,7 +497,7 @@ runs:
     - name: Download Homeboy observations
       if: steps.check-pr-state.outputs.active != 'false' && steps.resolve-commands.outputs.resolved-commands != '' && inputs.import-observations == 'true'
       continue-on-error: true
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: homeboy-observations-*
         path: homeboy-observations-import
@@ -585,7 +585,7 @@ runs:
 
     - name: Upload Homeboy observations
       if: always() && steps.check-pr-state.outputs.active != 'false' && steps.resolve-commands.outputs.resolved-commands != ''
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.artifact-names.outputs.homeboy-observations }}
         path: homeboy-observations/**

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -58,17 +58,27 @@ assert_not_contains '^  create-release:' "${WORKFLOW}" "release workflow has no 
 assert_not_contains 'gh release create' "${WORKFLOW}" "release workflow does not shell out to gh release create"
 assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not parse changelog notes"
 
-# GitHub-hosted workflow dependencies must use published action majors (#275).
-assert_count 'actions/checkout@v4' '9' "${CI_WORKFLOW}" "reusable CI workflow uses checkout v4 for every checkout"
-assert_count 'actions/create-github-app-token@v2' '3' "${CI_WORKFLOW}" "reusable CI workflow uses app-token v2"
-assert_not_contains 'actions/checkout@v6' "${CI_WORKFLOW}" "reusable CI workflow does not use unavailable checkout v6"
-assert_not_contains 'actions/create-github-app-token@v3' "${CI_WORKFLOW}" "reusable CI workflow does not use unavailable app-token v3"
+# GitHub-hosted workflow dependencies must use Node 24-capable action majors (#321).
+assert_count 'actions/checkout@v6' '9' "${CI_WORKFLOW}" "reusable CI workflow uses checkout v6 for every checkout"
+assert_count 'actions/cache@v5' '3' "${CI_WORKFLOW}" "reusable CI workflow uses cache v5"
+assert_count 'actions/upload-artifact@v7' '3' "${CI_WORKFLOW}" "reusable CI workflow uses artifact upload v7"
+assert_count 'actions/download-artifact@v7' '1' "${CI_WORKFLOW}" "reusable CI workflow uses artifact download v7"
+assert_count 'actions/create-github-app-token@v3' '3' "${CI_WORKFLOW}" "reusable CI workflow uses app-token v3"
+assert_not_contains 'actions/checkout@v4' "${CI_WORKFLOW}" "reusable CI workflow has no checkout v4 references"
+assert_not_contains 'actions/cache@v4' "${CI_WORKFLOW}" "reusable CI workflow has no cache v4 references"
+assert_not_contains 'actions/\(upload\|download\)-artifact@v4' "${CI_WORKFLOW}" "reusable CI workflow has no artifact v4 references"
+assert_not_contains 'actions/create-github-app-token@v2' "${CI_WORKFLOW}" "reusable CI workflow has no app-token v2 references"
 assert_not_contains 'merge-multiple: true' "${CI_WORKFLOW}" "reusable CI workflow never merges competing binary artifacts"
 assert_contains 'actions: read' "${CI_WORKFLOW}" "reusable CI workflow can download current-run artifacts"
-assert_count 'actions/checkout@v4' '3' "${WORKFLOW}" "release workflow uses checkout v4 for every checkout"
-assert_count 'actions/create-github-app-token@v2' '1' "${WORKFLOW}" "release workflow uses app-token v2"
-assert_not_contains 'actions/checkout@v6' "${WORKFLOW}" "release workflow does not use unavailable checkout v6"
-assert_not_contains 'actions/create-github-app-token@v3' "${WORKFLOW}" "release workflow does not use unavailable app-token v3"
+assert_count 'actions/checkout@v6' '3' "${WORKFLOW}" "release workflow uses checkout v6 for every checkout"
+assert_count 'actions/create-github-app-token@v3' '1' "${WORKFLOW}" "release workflow uses app-token v3"
+assert_not_contains 'actions/checkout@v4' "${WORKFLOW}" "release workflow has no checkout v4 references"
+assert_not_contains 'actions/create-github-app-token@v2' "${WORKFLOW}" "release workflow has no app-token v2 references"
+assert_contains 'actions/checkout@v6' "${SELF_TEST_WORKFLOW}" "self-test workflow uses checkout v6"
+assert_not_contains 'actions/checkout@v4' "${SELF_TEST_WORKFLOW}" "self-test workflow has no checkout v4 references"
+assert_count 'actions/upload-artifact@v7' '3' "${ROOT_DIR}/action.yml" "composite action uses artifact upload v7"
+assert_count 'actions/download-artifact@v7' '1' "${ROOT_DIR}/action.yml" "composite action uses artifact download v7"
+assert_not_contains 'actions/\(upload\|download\)-artifact@v4' "${ROOT_DIR}/action.yml" "composite action has no artifact v4 references"
 
 # Releasing moves the floating v2 tag, so the action's own shell tests must
 # gate publication rather than running advisory-only (or not at all).


### PR DESCRIPTION
## Summary

- upgrade composite artifact actions to v7
- upgrade repository workflow checkout, cache, artifact, and app-token majors
- update documented examples and release contracts while preserving floating `v2` movement

Closes #321.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/self-test.yml`
- YAML parse validation for action and workflow files
- `bash -n` and `shellcheck -S warning` for the release contract
- `bash scripts/release/test-release-workflow.sh`
- 36 of 37 directly runnable shell/Python tests passed; the remaining Linux `/proc` assertion is unavailable on macOS
- `git diff --check`

## AI assistance

OpenCode using `openai/gpt-5.6-sol` implemented and verified the Node 24 action dependency migration. Chris Huber reviewed the resulting diff and remains responsible for every line.