### PR TITLE
Use GitHub App client IDs in workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # actionlint v1.7.12 bundles the pre-v3.1.0 input schema.
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - id: phase
@@ -600,7 +600,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - name: Post reconciled PR comment
@@ -647,7 +647,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
       - name: Evaluate PR policy after reconciled quality gates
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         continue-on-error: true
         with:
-          app-id: ${{ secrets.HOMEBOY_APP_ID }}
+          client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- replace deprecated `app-id` inputs with canonical `client-id` in CI and release workflows
- preserve the existing secret values and workflow permissions
- narrowly suppress actionlint v1.7.12 stale-schema false positives documented in rhysd/actionlint#669

Closes #321.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/self-test.yml`
- `bash scripts/release/test-release-workflow.sh`
- `git diff --check`
- live `actions/create-github-app-token@v3/action.yml` confirms `client-id` is canonical and `app-id` is deprecated

## AI assistance

OpenCode using `openai/gpt-5.6-sol` traced the post-upgrade runtime warning, verified upstream action metadata, and implemented the migration. Chris Huber reviewed the resulting diff and remains responsible for every line.