### PR TITLE
Drop actions: read from ci.yml — it disabled CI in every consumer repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,17 @@ on:
       HOMEBOY_APP_PRIVATE_KEY:
         required: false
 
+# A called workflow cannot request a permission the CALLER has not granted —
+# GitHub fails the whole run at startup, before any job, with no usable error
+# in the API. Adding a scope here is therefore a breaking change for every
+# consumer that does not already grant it, and it presents to them as
+# "no checks reported" rather than as a failure.
+#
+# `actions: read` was added in #313 and silently disabled CI in every consumer
+# repo from v2.10.0 onward. It was not needed: the only actions-scoped step is
+# `actions/download-artifact` reading artifacts from its OWN run, which the
+# default token can already do. See #327.
 permissions:
-  actions: read
   contents: write
   pull-requests: write
   issues: write


### PR DESCRIPTION
Closes #327.

## Root cause

`v2.10.0` (#313) added one line to `ci.yml`'s top-level permissions:

```yaml
permissions:
  actions: read      # <- this
  contents: write
  pull-requests: write
  issues: write
```

**A called workflow cannot request a permission the caller has not granted.** GitHub fails the entire run at startup — before any job — so every consumer whose caller does not declare `actions:` had its CI silently disabled from `v2.10.0` onward.

## Evidence

Bisected against a live consumer (`Extra-Chill/data-machine`) using `workflow_dispatch` on throwaway branches:

| pinned ref | result |
| --- | --- |
| `v2.9.2` | starts |
| `v2.9.3` | starts |
| **`v2.10.0`** | **`startup_failure`** ← first bad |
| `v2.10.1` … `v2.10.7` | `startup_failure` |

Reducing `v2.10.0` to a **single job** still failed, which ruled out the new `candidate`/`baseline`/`reconcile`/`policy` jobs and the `fromJson(needs.plan.outputs.matrix)` strategy. That pointed at the header, and the only header change between `v2.9.3` and `v2.10.0` is this line.

Removing it and re-running the same consumer:

```
prefix-policy                          -> success
homeboy / Prepare candidate binary     -> success
homeboy / Plan                         -> success
homeboy / Candidate Lint/Audit/Test    -> running
```

`startup_failure` → full DAG.

## Why the permission was not needed

The only actions-scoped step is:

```yaml
- uses: actions/download-artifact@v4
  with:
    pattern: homeboy-differential-*-${{ matrix.artifact_key }}-*
    path: differential-artifacts
```

No `run-id`, no `github-token` — it reads artifacts from its **own** run, which the default `GITHUB_TOKEN` can already do. `actions: read` is only required for cross-run artifact access.

## Impact while broken

| repo | no CI since |
| --- | --- |
| `Extra-Chill/data-machine` | 2026-08-02 (last green: `release: v0.171.2`, 2026-07-29) |
| `Extra-Chill/data-machine-code` | 2026-07-30 |

Both shipped releases in that window with zero verification — `data-machine` v0.171.3, `data-machine-code` v0.56.0 and v0.56.1.

The failure mode is worse than a red build: `gh pr checks` reports **"no checks reported"**, not a failure. A PR looks like the repo simply has no CI, so merging proceeds naturally.

## Guard

A comment now sits above `permissions:` explaining that adding a scope here is a breaking change for consumers rather than a local one, and that it presents as absent checks rather than as an error.

Worth considering separately: `homeboy-action` has no PR CI of its own, so a `ci.yml` change cannot be validated before it reaches the `v2` tag every consumer follows — which is how a one-line permission addition took down the fleet for four days.

## After merge

`v2` needs to move to the new release for consumers to recover.