### PR TITLE
Resolve the action ref once so a mid-run release cannot break reconcile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,8 @@ permissions:
 jobs:
   binary:
     name: Prepare candidate Homeboy binary
+    # needs plan solely for needs.plan.outputs.action-sha; plan is pure bash.
+    needs: plan
     runs-on: ubuntu-latest
     outputs:
       cargo-cache-key: ${{ steps.cargo-cache-key.outputs.key }}
@@ -224,7 +226,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
-          ref: ${{ inputs.action-ref }}
+          ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
 
       - name: Materialize candidate Homeboy binary
@@ -250,7 +252,50 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
+      action-sha: ${{ steps.action-sha.outputs.sha }}
     steps:
+      # Resolve the action ref to an immutable SHA ONCE for the whole run.
+      #
+      # Every job used to check out `inputs.action-ref` independently. That ref
+      # is a floating tag by default (v2), and jobs in one run are minutes
+      # apart, so a release landing mid-run gave different jobs different action
+      # code. Provenance reconciliation compares an action_revision derived from
+      # each job's own checkout, so it failed closed and correctly — for a
+      # reason no operator would guess. See #332.
+      #
+      # Pinning the recorded revision alone would NOT be enough: the manifests
+      # would agree while the phases still ran different code, trading a loud
+      # failure for a silent inconsistency. The checkout itself has to be pinned.
+      - name: Resolve action revision
+        id: action-sha
+        shell: bash
+        env:
+          ACTION_REF: ${{ inputs.action-ref }}
+          ACTION_REPO: Extra-Chill/homeboy-action
+        run: |
+          set -euo pipefail
+          if [[ "${ACTION_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            sha="${ACTION_REF}"
+          else
+            refs="$(git ls-remote "https://github.com/${ACTION_REPO}" \
+              "refs/tags/${ACTION_REF}^{}" "refs/tags/${ACTION_REF}" "refs/heads/${ACTION_REF}")"
+            # An annotated tag resolves to a TAG OBJECT, not a commit, and
+            # ls-remote sorts its output rather than honouring argument order —
+            # so taking the first line yields the tag object and `rev-parse
+            # HEAD` in the consuming job would then report the commit instead.
+            # That is the very mismatch this pinning exists to remove. Prefer
+            # the ^{} dereferenced entry; branches and lightweight tags have
+            # none and fall through to the plain ref.
+            sha="$(printf '%s\n' "${refs}" | awk '$2 ~ /\^\{\}$/ {print $1; exit}')"
+            [ -n "${sha:-}" ] || sha="$(printf '%s\n' "${refs}" | awk 'NR==1{print $1}')"
+          fi
+          if [ -z "${sha:-}" ]; then
+            echo "::error::Could not resolve action-ref '${ACTION_REF}' in ${ACTION_REPO} to a commit."
+            exit 1
+          fi
+          echo "Resolved ${ACTION_REF} -> ${sha}"
+          echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
+
       - name: Plan quality checks
         id: plan
         shell: bash
@@ -378,7 +423,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
-          ref: ${{ inputs.action-ref }}
+          ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
 
       - name: Download candidate Homeboy binary
@@ -500,7 +545,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
-          ref: ${{ inputs.action-ref }}
+          ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
       - name: Download candidate Homeboy binary
         id: candidate-binary
@@ -573,7 +618,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
-          ref: ${{ inputs.action-ref }}
+          ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
       - name: Download candidate Homeboy binary
         id: candidate-binary
@@ -632,7 +677,7 @@ jobs:
 
   policy:
     name: PR Policy
-    needs: reconcile
+    needs: [reconcile, plan]
     if: ${{ github.event_name == 'pull_request' && inputs.pr-policy != '' }}
     runs-on: ubuntu-latest
     steps:
@@ -642,7 +687,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
-          ref: ${{ inputs.action-ref }}
+          ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
       - name: Download candidate Homeboy binary
         id: candidate-binary

--- a/scripts/core/test-action-ref-pinning.sh
+++ b/scripts/core/test-action-ref-pinning.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Every job must check out the action at ONE resolved SHA.
+#
+# Jobs used to check out `inputs.action-ref` independently. That default is a
+# floating tag (v2) and jobs in a run are minutes apart, so a release landing
+# mid-run gave different jobs different action code — and provenance
+# reconciliation, which compares an action_revision derived from each job's own
+# checkout, failed closed for a reason no operator would guess. See #332.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT}/.github/workflows/ci.yml"
+failed=0
+
+check() {
+  if [ "$1" -eq 0 ]; then printf 'PASS: %s\n' "$2"; else printf 'FAIL: %s\n' "$2"; failed=1; fi
+}
+
+python3 - "${WORKFLOW}" <<'PY'
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+jobs = d["jobs"]
+problems = []
+
+pinned = "${{ needs.plan.outputs.action-sha }}"
+for name, job in jobs.items():
+    refs = [
+        (s.get("with") or {}).get("ref")
+        for s in job.get("steps", [])
+        if (s.get("with") or {}).get("path") == ".homeboy-action"
+    ]
+    if not refs:
+        continue
+    for r in refs:
+        if r != pinned:
+            problems.append(f"{name}: checks out .homeboy-action at {r!r}, not the resolved SHA")
+    needs = job.get("needs")
+    needs = [needs] if isinstance(needs, str) else (needs or [])
+    # needs only exposes DIRECT dependencies, so a transitive path to plan is
+    # not enough to read needs.plan.outputs.
+    if "plan" not in needs:
+        problems.append(f"{name}: consumes needs.plan.outputs but does not list plan in needs")
+
+if jobs.get("plan", {}).get("outputs", {}).get("action-sha") is None:
+    problems.append("plan does not publish an action-sha output")
+
+if problems:
+    print("\n".join(problems))
+    sys.exit(1)
+PY
+check $? "every action checkout is pinned to the plan-resolved SHA and needs plan"
+
+# The resolver must prefer the ^{} dereferenced commit. An annotated tag
+# resolves to a TAG OBJECT, and `git ls-remote` sorts its output rather than
+# honouring argument order — so taking the first line silently yields the tag
+# object while `rev-parse HEAD` in the consuming job reports the commit. That
+# is the same mismatch this pinning removes.
+grep -q 'awk .\$2 ~ /\\\^\\{\\}\$/' "${WORKFLOW}"
+check $? "resolver prefers the dereferenced commit over the annotated tag object"
+
+grep -q 'ACTION_REF.*=~ \^\[0-9a-f\]{40}\$' "${WORKFLOW}"
+check $? "a full SHA passes through without a network lookup"
+
+grep -q 'Could not resolve action-ref' "${WORKFLOW}"
+check $? "an unresolvable ref fails loudly instead of checking out nothing"
+
+[ "${failed}" -eq 0 ] || exit 1
+printf 'Action ref pinning checks passed.\n'


### PR DESCRIPTION
Closes #332.

## The race

Every job checked out `inputs.action-ref` independently:

```yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ inputs.action-ref }}     # default: v2, a floating tag
    path: .homeboy-action
```

and then derived its own `action_revision` from that checkout. Jobs in one run are minutes apart, so a release landing mid-run gives different jobs different action code — and provenance reconciliation fails closed, correctly, for a reason nobody would guess.

**Proven** on `Extra-Chill/data-machine#3048`, run 30869272476:

```
Candidate Test  started 2026-08-04T01:38:36Z   -> v2 = v2.10.8
v2.10.9 released        2026-08-04T01:38:58Z   <- 22 seconds later
homeboy / Test  started 2026-08-04T01:53:27Z   -> v2 = v2.10.9
```

All four reconcile jobs failed. A probe PR on the same repo with no release in flight passes all four.

Systemic, not a one-off: ten `v2.10.x` tags in four days, and the window is the entire duration of a run. It is also self-amplifying during incident response — fixing a broken `v2` requires releasing, and each release breaks whatever is in flight. That is exactly what happened here.

## The fix

`plan` runs first and already publishes outputs, so it resolves the ref to an immutable SHA once:

```yaml
outputs:
  matrix:     ${{ steps.plan.outputs.matrix }}
  action-sha: ${{ steps.action-sha.outputs.sha }}
```

Every job then checks out `ref: ${{ needs.plan.outputs.action-sha }}`. `binary` and `policy` gain `plan` in `needs` — the `needs` context exposes only **direct** dependencies, so `policy`'s transitive path through `reconcile` is not enough to read `needs.plan.outputs`.

**The checkout is what is pinned, not just the recorded value.** Pinning `action_revision` alone would make the manifests agree while the phases still ran different code — trading a loud failure for a silent inconsistency.

## A trap worth knowing

The resolver prefers the `^{}` dereferenced entry. On the live repo right now:

```
refs/tags/v2       -> 9486dd4    (annotated TAG OBJECT)
refs/tags/v2^{}    -> 96cdaef    (the commit)
```

`git ls-remote` **sorts its output** rather than honouring argument order, so taking the first line yields the tag object — while `rev-parse HEAD` in the consuming job reports the commit. That reintroduces the exact mismatch this PR removes. My first implementation had this bug; it surfaced while verifying against real refs.

Verified: `v2`, `v2.10.10`, `v2.9.2`, `main`, and a full SHA all resolve to commits; an unknown ref fails loudly rather than checking out nothing.

## Tests

New `scripts/core/test-action-ref-pinning.sh` (auto-discovered by `run-tests.sh`) asserts:

- every `.homeboy-action` checkout uses the plan-resolved SHA
- every consuming job lists `plan` **directly** in `needs`
- the resolver prefers the dereferenced commit over the tag object
- a full SHA passes through without a network lookup
- an unresolvable ref fails loudly

Verified non-vacuous against all three regressions: unpinning one checkout, dropping `plan` from `policy`'s needs, and removing the `^{}` preference each fail the suite.

Full action shell suite: **34 passed, 0 failed**. `actionlint` clean.