### PR TITLE
Provision nextest for sharded Rust tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,10 +633,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
+      - name: Install cargo-nextest for Rust shard planning
+        if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
+        uses: taiki-e/install-action@nextest
       - name: Materialize canonical candidate Test inventory
+        continue-on-error: true
         env:
           HOMEBOY_TEST_INVENTORY_ONLY: '1'
           HOMEBOY_TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
+          HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
+          NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
         with:
           binary-path: ${{ steps.candidate-binary.outputs.binary-path }}
@@ -689,6 +695,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
+      - name: Install cargo-nextest for Rust shard replay
+        if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
+        uses: taiki-e/install-action@nextest
       - uses: actions/download-artifact@v7
         with:
           name: homeboy-test-shard-plan-${{ github.run_attempt }}
@@ -698,6 +707,8 @@ jobs:
         continue-on-error: true
         env:
           HOMEBOY_TEST_SHARD_MANIFEST: ${{ github.workspace }}/homeboy-test-shard.json
+          HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
+          NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
         with:
           binary-path: ${{ steps.candidate-binary.outputs.binary-path }}
@@ -819,10 +830,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
+      - name: Install cargo-nextest for Rust baseline shard planning
+        if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
+        uses: taiki-e/install-action@nextest
       - name: Materialize canonical baseline Test inventory
+        continue-on-error: true
         env:
           HOMEBOY_TEST_INVENTORY_ONLY: '1'
           HOMEBOY_TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
+          HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
+          NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
         with:
           binary-path: ${{ steps.candidate-binary.outputs.binary-path }}
@@ -876,6 +893,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
+      - name: Install cargo-nextest for Rust baseline shard replay
+        if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
+        uses: taiki-e/install-action@nextest
       - uses: actions/download-artifact@v7
         with:
           name: homeboy-baseline-test-shard-plan-${{ github.run_attempt }}
@@ -884,6 +904,8 @@ jobs:
         continue-on-error: true
         env:
           HOMEBOY_TEST_SHARD_MANIFEST: ${{ github.workspace }}/homeboy-test-shard.json
+          HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
+          NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
         with:
           binary-path: ${{ steps.candidate-binary.outputs.binary-path }}

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -83,6 +83,15 @@ printf 'PASS: missing, mismatched, failed, and timed-out shards fail closed\n'
 
 grep -F 'needs: [reconcile, reconcile-test-shards, plan]' "${WORKFLOW}" >/dev/null || { printf 'FAIL: policy does not wait for the sharded Test verdict and pinned plan\n'; exit 1; }
 grep -F "inputs.test-shards == '1' || needs.reconcile-test-shards.result == 'success'" "${WORKFLOW}" >/dev/null || { printf 'FAIL: policy can bypass a failed sharded Test verdict\n'; exit 1; }
+if [ "$(grep -c 'uses: taiki-e/install-action@nextest' "${WORKFLOW}")" -ne 4 ]; then
+  printf 'FAIL: Rust candidate and baseline plan/replay jobs do not all install cargo-nextest\n'; exit 1
+fi
+if [ "$(grep -c "continue-on-error: true" "${WORKFLOW}")" -lt 4 ]; then
+  printf 'FAIL: inventory planning transport is not isolated from normal Test verdict enforcement\n'; exit 1
+fi
+if [ "$(grep -c "HOMEBOY_RUST_NEXTEST_FALLBACK: '0'" "${WORKFLOW}")" -ne 4 ] || [ "$(grep -c 'NEXTEST_PROFILE: ci' "${WORKFLOW}")" -ne 4 ]; then
+  printf 'FAIL: Rust shard jobs do not require nextest with the CI profile\n'; exit 1
+fi
 # The literal workflow expression is the contract.
 # shellcheck disable=SC2016
 grep -F 'baseline_result="$(jq -r --arg command "${COMMAND}"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline metadata is not derived from its aggregate result\n'; exit 1; }


### PR DESCRIPTION
## Summary
- install prebuilt cargo-nextest in candidate and baseline shard plan/replay jobs for auto-setup Cargo workspaces
- require nextest rather than silently falling back to per-test Cargo replay
- select the CI nextest profile and validate inventory files independently from normal Test verdicts

Closes #337.
Supports https://github.com/Extra-Chill/homeboy/issues/11399.

## Verification
- `bash scripts/core/test-test-shards.sh`
- `bash scripts/release/test-release-workflow.sh`
- `actionlint .github/workflows/ci.yml`
- `shellcheck scripts/core/test-test-shards.sh`
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode traced the released sharding workflow through the Rust extension, implemented setup and inventory-planning semantics, and ran workflow contract tests. Chris Huber reviewed and remains responsible for every line.