### PR TITLE
Select nextest explicitly for Rust shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,7 @@ jobs:
         env:
           HOMEBOY_TEST_INVENTORY_ONLY: '1'
           HOMEBOY_TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
+          HOMEBOY_RUST_TEST_RUNNER: nextest
           HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
           NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
@@ -707,6 +708,7 @@ jobs:
         continue-on-error: true
         env:
           HOMEBOY_TEST_SHARD_MANIFEST: ${{ github.workspace }}/homeboy-test-shard.json
+          HOMEBOY_RUST_TEST_RUNNER: nextest
           HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
           NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
@@ -838,6 +840,7 @@ jobs:
         env:
           HOMEBOY_TEST_INVENTORY_ONLY: '1'
           HOMEBOY_TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
+          HOMEBOY_RUST_TEST_RUNNER: nextest
           HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
           NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
@@ -904,6 +907,7 @@ jobs:
         continue-on-error: true
         env:
           HOMEBOY_TEST_SHARD_MANIFEST: ${{ github.workspace }}/homeboy-test-shard.json
+          HOMEBOY_RUST_TEST_RUNNER: nextest
           HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
           NEXTEST_PROFILE: ci
         uses: ./.homeboy-action

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -92,6 +92,9 @@ fi
 if [ "$(grep -c "HOMEBOY_RUST_NEXTEST_FALLBACK: '0'" "${WORKFLOW}")" -ne 4 ] || [ "$(grep -c 'NEXTEST_PROFILE: ci' "${WORKFLOW}")" -ne 4 ]; then
   printf 'FAIL: Rust shard jobs do not require nextest with the CI profile\n'; exit 1
 fi
+if [ "$(grep -c 'HOMEBOY_RUST_TEST_RUNNER: nextest' "${WORKFLOW}")" -ne 4 ]; then
+  printf 'FAIL: Rust shard jobs do not explicitly select nextest\n'; exit 1
+fi
 # The literal workflow expression is the contract.
 # shellcheck disable=SC2016
 grep -F 'baseline_result="$(jq -r --arg command "${COMMAND}"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline metadata is not derived from its aggregate result\n'; exit 1; }


### PR DESCRIPTION
## Summary
- explicitly select nextest in all candidate and baseline Rust shard planning/replay paths
- keep unsharded component defaults on measured Cargo execution
- require runner selection in the shard workflow contract test

Closes #339.
Supports https://github.com/Extra-Chill/homeboy/issues/11399.

## Verification
- `bash scripts/core/test-test-shards.sh`
- `actionlint .github/workflows/ci.yml`
- `shellcheck scripts/core/test-test-shards.sh`
- `git diff --check`

## AI assistance
OpenAI gpt-5.6-sol via OpenCode ran a real Homeboy nextest invocation, isolated measured nextest to shard replay, implemented explicit runner selection, and verified the workflow contract. Chris Huber reviewed and remains responsible for every line.