### PR TITLE
fix(ci): stream shard inventories into jq

### DIFF
--- a/scripts/core/shard-tests.sh
+++ b/scripts/core/shard-tests.sh
@@ -27,14 +27,14 @@ plan() {
   local canonical inventory_digest plan_digest
   canonical="$(jq -cS '{schema,runner,runner_fingerprint,workspace_fingerprint,inventory_fingerprint,tests:(.tests | sort_by(.id))}' "${inventory}")"
   inventory_digest="$(digest "${canonical}")"
-  jq -cn --argjson inventory "${canonical}" --arg inventory_digest "${inventory_digest}" --argjson count "${count}" --argjson unknown "${unknown}" '
+  printf '%s' "${canonical}" | jq -cn --slurpfile inventory /dev/stdin --arg inventory_digest "${inventory_digest}" --argjson count "${count}" --argjson unknown "${unknown}" '
     [range(0; $count) | {index:., duration_ms:0, tests:[]}] as $empty
-    | reduce ($inventory.tests | map(. + {weight:(.duration_ms // $unknown)}) | sort_by(-.weight, .id))[] as $test
+    | reduce ($inventory[0].tests | map(. + {weight:(.duration_ms // $unknown)}) | sort_by(-.weight, .id))[] as $test
         ($empty; (min_by(.duration_ms, .index).index) as $index | .[$index].duration_ms += $test.weight | .[$index].tests += [$test.id])
-    | {schema:"homeboy/test-shard-plan/v1", inventory_digest:$inventory_digest, inventory_fingerprint:$inventory.inventory_fingerprint,
-       shards:(map({schema:"homeboy/test-shard-manifest/v1", id:("shard-" + ((.index + 1)|tostring)), runner:$inventory.runner,
-         runner_fingerprint:$inventory.runner_fingerprint, workspace_fingerprint:$inventory.workspace_fingerprint,
-         inventory_fingerprint:$inventory.inventory_fingerprint, tests:.tests, estimated_duration_ms:.duration_ms}))}
+    | {schema:"homeboy/test-shard-plan/v1", inventory_digest:$inventory_digest, inventory_fingerprint:$inventory[0].inventory_fingerprint,
+       shards:(map({schema:"homeboy/test-shard-manifest/v1", id:("shard-" + ((.index + 1)|tostring)), runner:$inventory[0].runner,
+         runner_fingerprint:$inventory[0].runner_fingerprint, workspace_fingerprint:$inventory[0].workspace_fingerprint,
+         inventory_fingerprint:$inventory[0].inventory_fingerprint, tests:.tests, estimated_duration_ms:.duration_ms}))}
   ' > "${output}.tmp"
   plan_digest="$(digest "$(jq -cS . "${output}.tmp")")"
   jq --arg digest "${plan_digest}" '. + {plan_digest:$digest}' "${output}.tmp" > "${output}"

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -32,6 +32,14 @@ if TEST_INVENTORY_FILE="${tmp}/captured-inventory.json" TEST_SHARD_PLAN_FILE="${
   printf 'FAIL: empty shard plans must be rejected\n'; exit 1
 fi
 jq -e 'all(.shards[]; .schema == "homeboy/test-shard-manifest/v1" and (.runner == "fixture") and (.tests | all(type == "string")))' "${tmp}/one.json" >/dev/null || { printf 'FAIL: emitted shard manifests do not match the extension contract\n'; exit 1; }
+jq -n '{schema:"homeboy/test-inventory/v1",runner:"fixture",runner_fingerprint:"runner-a",workspace_fingerprint:"workspace-a",inventory_fingerprint:"large-inventory-a",tests:[range(0; 12000) | {id:("test-" + tostring + ("x" * 160)),duration_ms:1}]}' > "${tmp}/large-inventory.json"
+[ "$(wc -c < "${tmp}/large-inventory.json")" -gt 1048576 ] || { printf 'FAIL: large inventory must exceed a conservative argv-sized payload\n'; exit 1; }
+for output in large-one large-two; do
+  TEST_INVENTORY_FILE="${tmp}/large-inventory.json" TEST_SHARD_PLAN_FILE="${tmp}/${output}.json" TEST_SHARD_COUNT=2 \
+    bash "${ROOT}/scripts/core/shard-tests.sh" plan
+done
+cmp "${tmp}/large-one.json" "${tmp}/large-two.json" || { printf 'FAIL: large inventories must produce byte-identical plans\n'; exit 1; }
+jq -e '[.shards[].tests[]] | length == 12000' "${tmp}/large-one.json" >/dev/null || { printf 'FAIL: large plan membership is not exact\n'; exit 1; }
 jq '.workspace_fingerprint = "workspace-base"' "${tmp}/captured-inventory.json" > "${tmp}/base-inventory.json"
 TEST_INVENTORY_FILE="${tmp}/base-inventory.json" TEST_SHARD_PLAN_FILE="${tmp}/base-plan.json" TEST_SHARD_COUNT=2 bash "${ROOT}/scripts/core/shard-tests.sh" plan
 [ "$(jq -r .plan_digest "${tmp}/one.json")" != "$(jq -r .plan_digest "${tmp}/base-plan.json")" ] || { printf 'FAIL: candidate and baseline inventories must produce distinct plans\n'; exit 1; }


### PR DESCRIPTION
Closes #341.

Streams the canonical shard-test inventory to jq through stdin, eliminating the argv payload limit while preserving the canonical inventory and deterministic plan output.

Tests: `bash scripts/core/test-test-shards.sh`; full `scripts/**/test-*.sh` shell suite.

AI assistance: GPT-5.6 Sol via OpenCode; used to inspect the argv-size failure, implement stdin transport, and add regression coverage. Chris Huber remains responsible for every line.