### PR TITLE
fix(ci): replay shard manifests with canonical result paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -794,6 +794,8 @@ jobs:
         env:
           COMMAND: ${{ needs.plan.outputs.test-command }}
         run: |
+          source .homeboy-action/scripts/core/lib.sh
+          result_filename="$(command_result_filename "${COMMAND}")"
           baseline_result="$(jq -r --arg command "${COMMAND}" '.[$command]' homeboy-baseline-results/results.json)"
           case "${baseline_result}" in
             pass) baseline_exit=0 ;;
@@ -801,7 +803,7 @@ jobs:
             *) baseline_exit=1 ;;
           esac
           structured_output=false
-          [ ! -f homeboy-baseline-results/review-test.json ] || structured_output=true
+          [ ! -f "homeboy-baseline-results/${result_filename}" ] || structured_output=true
           jq -cn --arg command "${COMMAND}" --arg status "${baseline_result}" --argjson exit_code "${baseline_exit}" --argjson structured_output "${structured_output}" \
             '{($command):{status:$status,exit_code:$exit_code,command:$command,structured_output:$structured_output}}' > homeboy-baseline-results/baseline-status.json
           python3 .homeboy-action/scripts/core/apply-differential-gate.py "$(cat homeboy-ci-results/results.json)" homeboy-ci-results homeboy-baseline-results > reconciled-results.json

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -501,3 +501,7 @@ command_output_stem() {
   fi
   printf '%s\n' "${stem}"
 }
+
+command_result_filename() {
+  printf '%s.json\n' "$(command_output_stem "$1")"
+}

--- a/scripts/core/run-homeboy-commands.sh
+++ b/scripts/core/run-homeboy-commands.sh
@@ -53,7 +53,7 @@ for CMD in "${CMD_ARRAY[@]}"; do
   if [ "$(printf '%s' "${CMD}" | awk '{print $1}')" = "bench" ]; then
     CI_RESULT_JSON="${HOMEBOY_CI_RESULTS_DIR}/bench.json"
   else
-    CI_RESULT_JSON="${HOMEBOY_CI_RESULTS_DIR}/${OUTPUT_STEM}.json"
+    CI_RESULT_JSON="${HOMEBOY_CI_RESULTS_DIR}/$(command_result_filename "${CMD}")"
   fi
   # This is the one durable result path consumed by artifacts and reporting.
   OUTPUT_JSON="${CI_RESULT_JSON}"

--- a/scripts/core/shard-tests.sh
+++ b/scripts/core/shard-tests.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+
 fail() { echo "::error::$1" >&2; exit 1; }
 digest() { printf '%s' "$1" | shasum -a 256 | awk '{print $1}'; }
 
@@ -67,13 +71,13 @@ aggregate() {
       ' "${manifest}" >/dev/null 2>&1; then matches+=("${manifest}"); fi
     done < <(find "${root}" -path "*/${phase}/manifest.json" -type f -print | sort)
     [ "${#matches[@]}" -eq 1 ] || fail "Expected exactly one valid ${phase} shard evidence manifest for ${id}."
-    manifest="${matches[0]}"; status="$(jq -r --arg command "${command}" '.results[$command]' "${manifest}")"; payload="$(dirname "${manifest}")/homeboy-ci-results/review-test.json"
+    manifest="${matches[0]}"; status="$(jq -r --arg command "${command}" '.results[$command]' "${manifest}")"; payload="$(dirname "${manifest}")/homeboy-ci-results/$(command_result_filename "${command}")"
     case "${status}" in
       timeout) aggregate_status="timeout" ;;
       fail) [ "${aggregate_status}" = timeout ] || aggregate_status="fail" ;;
     esac
     if [ ! -f "${payload}" ]; then
-      [ "${status}" = timeout ] || fail "${phase} shard ${id} is ${status} but has no structured review-test.json result."
+      [ "${status}" = timeout ] || fail "${phase} shard ${id} is ${status} but has no structured $(command_result_filename "${command}") result."
       continue
     fi
     expected_total="$(jq '.tests | length' <<< "${shard}")"
@@ -85,11 +89,11 @@ aggregate() {
       and (if $phase_status == "pass" then .success == true and .exit_code == 0 and .data.test_counts.failed == 0
             elif $phase_status == "fail" then .success == false and .exit_code != 0
             else true end)
-    ' "${payload}" >/dev/null 2>&1 || fail "${phase} shard ${id} has invalid structured review-test.json counts."
+    ' "${payload}" >/dev/null 2>&1 || fail "${phase} shard ${id} has invalid structured $(command_result_filename "${command}") counts."
     if [ "${status}" = pass ]; then
       [ "$(jq '.data.test_counts.total' "${payload}")" = "${expected_total}" ] || fail "${phase} shard ${id} structured total does not match its planned membership."
     fi
-    cp "${payload}" "${output}/${id}-review-test.json"
+    cp "${payload}" "${output}/${id}-$(command_result_filename "${command}")"
     payloads+=("${payload}")
   done < <(jq -c '.shards[]' "${plan}")
   local payload_json='[]'
@@ -103,7 +107,7 @@ aggregate() {
   jq -n --arg root "${command%% *}" --arg plan_digest "${plan_digest}" --arg status "${aggregate_status}" --argjson payloads "${payload_json}" '
     {schema:"homeboy/command-result/v3",command:$root,success:($status == "pass"),status:(if $status == "pass" then "succeeded" else "failed" end),exit_code:(if $status == "pass" then 0 elif $status == "timeout" then 124 else 1 end),
      data:{test_counts:{passed:([$payloads[].data.test_counts.passed] | add // 0),failed:([$payloads[].data.test_counts.failed] | add // 0),skipped:([$payloads[].data.test_counts.skipped] | add // 0),total:([$payloads[].data.test_counts.total] | add // 0)},shard_plan_digest:$plan_digest,shard_count:($payloads|length)}}
-  ' > "${output}/review-test.json"
+  ' > "${output}/$(command_result_filename "${command}")"
   printf '{"%s":"%s"}\n' "${command}" "${aggregate_status}" > "${output}/results.json"
 }
 

--- a/scripts/core/test-apply-differential-gate.sh
+++ b/scripts/core/test-apply-differential-gate.sh
@@ -40,6 +40,14 @@ printf '{"review test":{"status":"fail","exit_code":1,"command":"homeboy review 
 result="$(python3 "${APPLY_GATE}" '{"review test":"fail"}' "${current_dir}" "${base_dir}")"
 assert_equals '{"review test":"baseline_red"}' "${result}" "a failure that reproduces unchanged on the baseline is baseline_red, not pass"
 
+# Sharded workflow commands retain their original spelling. A bare `test`
+# command therefore reads `test.json`, not the review-command filename.
+printf '{"success":false,"data":{"test_counts":{"failed":2,"errors":0}}}\n' > "${current_dir}/test.json"
+printf '{"success":false,"data":{"test_counts":{"failed":1,"errors":0}}}\n' > "${base_dir}/test.json"
+printf '{"test":{"status":"fail","exit_code":1,"command":"homeboy review test sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
+result="$(python3 "${APPLY_GATE}" '{"test":"fail"}' "${current_dir}" "${base_dir}")"
+assert_equals '{"test":"fail"}' "${result}" "bare test command reads its structured failing baseline and keeps regressions blocking"
+
 printf '{"success":false,"data":{"test_counts":{"failed":2,"errors":0}}}\n' > "${current_dir}/review-test.json"
 printf '{"review test":{"status":"fail","exit_code":1,"command":"homeboy review test sample --path .","structured_output":true}}\n' > "${base_dir}/baseline-status.json"
 result="$(python3 "${APPLY_GATE}" '{"review test":"fail"}' "${current_dir}" "${base_dir}")"

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -15,8 +15,23 @@ mkdir -p "${tmp}/bin"
 cat > "${tmp}/bin/homeboy" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-[ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = 1 ] || exit 99
-cp "${FIXTURE_INVENTORY}" "${HOMEBOY_TEST_INVENTORY_FILE}"
+if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = 1 ]; then
+  cp "${FIXTURE_INVENTORY}" "${HOMEBOY_TEST_INVENTORY_FILE}"
+  exit 0
+fi
+
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ] && [ -s "${HOMEBOY_TEST_SHARD_MANIFEST}" ] || exit 98
+total="$(jq '.tests | length' "${HOMEBOY_TEST_SHARD_MANIFEST}")"
+[ "${total}" -gt 0 ] || exit 97
+mkdir -p "$(dirname "${output}")"
+jq -n --argjson total "${total}" '{schema:"homeboy/command-result/v3",command:"review",success:true,status:"succeeded",exit_code:0,data:{test_counts:{passed:$total,failed:0,skipped:0,total:$total}}}' > "${output}"
 SH
 chmod +x "${tmp}/bin/homeboy"
 PATH="${tmp}/bin:${PATH}" FIXTURE_INVENTORY="${tmp}/inventory.json" HOMEBOY_TEST_INVENTORY_ONLY=1 HOMEBOY_TEST_INVENTORY_FILE="${tmp}/captured-inventory.json" homeboy review test fixture
@@ -47,6 +62,16 @@ printf 'PASS: deterministic duration-balanced plan has exact membership\n'
 
 plan_digest="$(jq -r .plan_digest "${tmp}/one.json")"
 inventory_digest="$(jq -r .inventory_digest "${tmp}/one.json")"
+shard_manifest="${tmp}/shard-1.json"
+jq --arg id shard-1 '.shards[] | select(.id == $id)' "${tmp}/one.json" > "${shard_manifest}"
+mkdir -p "${tmp}/replay-workspace"
+PATH="${tmp}/bin:${PATH}" GITHUB_ACTION_PATH="${ROOT}" GITHUB_WORKSPACE="${tmp}/replay-workspace" GITHUB_OUTPUT="${tmp}/replay-output" GITHUB_ENV="${tmp}/replay-env" RESOLVED_COMMANDS='review test' COMPONENT_NAME=fixture HOMEBOY_TEST_SHARD_MANIFEST="${shard_manifest}" \
+  bash "${ROOT}/scripts/core/run-homeboy-commands.sh"
+replay_result="${tmp}/replay-workspace/homeboy-ci-results/review-test.json"
+replay_total="$(jq '.data.test_counts.total' "${replay_result}")"
+[ "${replay_total}" -gt 0 ] || { printf 'FAIL: non-empty shard manifest replay did not execute tests\n'; exit 1; }
+[ "${replay_total}" = "$(jq '.tests | length' "${shard_manifest}")" ] || { printf 'FAIL: replay total does not match assigned shard membership\n'; exit 1; }
+printf 'PASS: non-empty shard manifest replays assigned tests through the action command wrapper\n'
 for phase in candidate baseline; do
   for shard in shard-1 shard-2; do
     mkdir -p "${tmp}/artifacts/${phase}-${shard}/${phase}/homeboy-ci-results"
@@ -58,6 +83,11 @@ for phase in candidate baseline; do
   TEST_SHARD_ARTIFACT_ROOT="${tmp}/artifacts" TEST_SHARD_PLAN_FILE="${tmp}/one.json" TEST_INVENTORY_FILE="${tmp}/captured-inventory.json" TEST_SHARD_PHASE="${phase}" TEST_SHARD_COMMAND='review test' TEST_SHARD_OUTPUT_DIR="${tmp}/${phase}-output" RUN_ATTEMPT=2 \
     bash "${ROOT}/scripts/core/shard-tests.sh" aggregate
 done
+cp "${replay_result}" "${tmp}/artifacts/candidate-shard-1/candidate/homeboy-ci-results/review-test.json"
+TEST_SHARD_ARTIFACT_ROOT="${tmp}/artifacts" TEST_SHARD_PLAN_FILE="${tmp}/one.json" TEST_INVENTORY_FILE="${tmp}/captured-inventory.json" TEST_SHARD_PHASE=candidate TEST_SHARD_COMMAND='review test' TEST_SHARD_OUTPUT_DIR="${tmp}/candidate-replay-output" RUN_ATTEMPT=2 \
+  bash "${ROOT}/scripts/core/shard-tests.sh" aggregate
+jq -e '.data.test_counts.total == 4' "${tmp}/candidate-replay-output/review-test.json" >/dev/null || { printf 'FAIL: aggregate did not include replayed shard evidence\n'; exit 1; }
+jq -e '.data.shard_plan_digest == $digest' --arg digest "${plan_digest}" "${tmp}/candidate-replay-output/review-test.json" >/dev/null || { printf 'FAIL: aggregation did not preserve immutable plan identity\n'; exit 1; }
 jq -e '."review test" == "pass"' "${tmp}/candidate-output/results.json" >/dev/null
 jq -e '.data.test_counts.total == 4' "${tmp}/candidate-output/review-test.json" >/dev/null || { printf 'FAIL: aggregation did not sum actual structured shard counts\n'; exit 1; }
 cp "${tmp}/artifacts/candidate-shard-1/candidate/homeboy-ci-results/review-test.json" "${tmp}/passing-shard.json"

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -21,6 +21,7 @@ if [ "${HOMEBOY_TEST_INVENTORY_ONLY:-}" = 1 ]; then
 fi
 
 output=""
+printf '%s\n' "$@" > "${FAKE_HOMEBOY_ARGS}"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --output) output="$2"; shift 2 ;;
@@ -28,6 +29,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 [ -n "${HOMEBOY_TEST_SHARD_MANIFEST:-}" ] && [ -s "${HOMEBOY_TEST_SHARD_MANIFEST}" ] || exit 98
+[ "${HOMEBOY_TEST_SHARD_MANIFEST}" = "${FAKE_EXPECTED_SHARD_MANIFEST}" ] || exit 96
 total="$(jq '.tests | length' "${HOMEBOY_TEST_SHARD_MANIFEST}")"
 [ "${total}" -gt 0 ] || exit 97
 mkdir -p "$(dirname "${output}")"
@@ -65,13 +67,16 @@ inventory_digest="$(jq -r .inventory_digest "${tmp}/one.json")"
 shard_manifest="${tmp}/shard-1.json"
 jq --arg id shard-1 '.shards[] | select(.id == $id)' "${tmp}/one.json" > "${shard_manifest}"
 mkdir -p "${tmp}/replay-workspace"
-PATH="${tmp}/bin:${PATH}" GITHUB_ACTION_PATH="${ROOT}" GITHUB_WORKSPACE="${tmp}/replay-workspace" GITHUB_OUTPUT="${tmp}/replay-output" GITHUB_ENV="${tmp}/replay-env" RESOLVED_COMMANDS='review test' COMPONENT_NAME=fixture HOMEBOY_TEST_SHARD_MANIFEST="${shard_manifest}" \
+PATH="${tmp}/bin:${PATH}" GITHUB_ACTION_PATH="${ROOT}" GITHUB_WORKSPACE="${tmp}/replay-workspace" GITHUB_OUTPUT="${tmp}/replay-output" GITHUB_ENV="${tmp}/replay-env" RESOLVED_COMMANDS='review test' COMPONENT_NAME=fixture HOMEBOY_TEST_SHARD_MANIFEST="${shard_manifest}" FAKE_EXPECTED_SHARD_MANIFEST="${shard_manifest}" FAKE_HOMEBOY_ARGS="${tmp}/replay-args" \
   bash "${ROOT}/scripts/core/run-homeboy-commands.sh"
 replay_result="${tmp}/replay-workspace/homeboy-ci-results/review-test.json"
 replay_total="$(jq '.data.test_counts.total' "${replay_result}")"
 [ "${replay_total}" -gt 0 ] || { printf 'FAIL: non-empty shard manifest replay did not execute tests\n'; exit 1; }
 [ "${replay_total}" = "$(jq '.tests | length' "${shard_manifest}")" ] || { printf 'FAIL: replay total does not match assigned shard membership\n'; exit 1; }
-printf 'PASS: non-empty shard manifest replays assigned tests through the action command wrapper\n'
+if grep -Fx -- "$(jq -r '.tests[0]' "${shard_manifest}")" "${tmp}/replay-args" >/dev/null; then
+  printf 'FAIL: action expanded an assigned test ID into the Homeboy command argv\n'; exit 1
+fi
+printf 'PASS: non-empty shard manifest is passed by path and replays assigned tests through the action command wrapper\n'
 for phase in candidate baseline; do
   for shard in shard-1 shard-2; do
     mkdir -p "${tmp}/artifacts/${phase}-${shard}/${phase}/homeboy-ci-results"
@@ -167,4 +172,5 @@ fi
 # The literal workflow expression is the contract.
 # shellcheck disable=SC2016
 grep -F 'baseline_result="$(jq -r --arg command "${COMMAND}"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline metadata is not derived from its aggregate result\n'; exit 1; }
+grep -F 'result_filename="$(command_result_filename "${COMMAND}")"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline lookup does not use the canonical result filename\n'; exit 1; }
 printf 'PASS: policy waits for sharded Test reconciliation while preserving unsharded behavior\n'

--- a/scripts/digest/generate-failure-digest.sh
+++ b/scripts/digest/generate-failure-digest.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../core/lib.sh"
+
 OUTPUT_DIR="${HOMEBOY_CI_RESULTS_DIR:-${HOMEBOY_OUTPUT_DIR:-}}"
 RESULTS_JSON="${RESULTS:-"{}"}"
 RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
@@ -53,10 +57,6 @@ append_local_reproduction_commands() {
   } >> "${digest_file}"
 }
 
-command_artifact_stem() {
-  printf '%s' "$1" | sed -E 's/[^[:alnum:]._-]+/-/g; s/^-+//; s/-+$//'
-}
-
 append_differential_evidence() {
   local digest_file="$1"
   local baseline_status_file="${OUTPUT_DIR}/baseline-status.json"
@@ -80,21 +80,21 @@ append_differential_evidence() {
 
   while IFS=$'\t' read -r command status; do
     [ -n "${command}" ] || continue
-    local baseline_command baseline_exit baseline_result candidate_result artifact_stem baseline_json baseline_log
+    local baseline_command baseline_exit baseline_result candidate_result result_filename baseline_json baseline_log
     baseline_command="$(jq -r --arg cmd "${command}" '.[$cmd].command // ("homeboy " + $cmd)' "${baseline_status_file}" 2>/dev/null || printf 'homeboy %s' "${command}")"
     baseline_exit="$(jq -r --arg cmd "${command}" '.[$cmd].exit_code // "unknown"' "${baseline_status_file}" 2>/dev/null || printf 'unknown')"
     baseline_result="$(jq -r --arg cmd "${command}" '.[$cmd].status // "unknown"' "${baseline_status_file}" 2>/dev/null || printf 'unknown')"
     candidate_result="$(jq -r --arg cmd "${command}" '.[$cmd] // "unknown"' <<< "${RESULTS_JSON}" 2>/dev/null || printf 'unknown')"
-    artifact_stem="$(command_artifact_stem "${command}")"
-    baseline_json="baseline-${artifact_stem}.json"
-    baseline_log="baseline-${artifact_stem}.log"
+    result_filename="$(command_result_filename "${command}")"
+    baseline_json="baseline-${result_filename}"
+    baseline_log="baseline-${result_filename%.json}.log"
 
     {
       printf -- '- `%s`: **%s**\n' "${command}" "${status}"
       printf '  - Baseline command: `%s`\n' "${baseline_command}"
       printf '  - Baseline result: `%s` (exit `%s`)\n' "${baseline_result}" "${baseline_exit}"
       printf '  - Candidate result: `%s`\n' "${candidate_result}"
-      printf '  - Artifact refs: `%s`, `%s`, `%s`\n' "${artifact_stem}.json" "${baseline_json}" "${baseline_log}"
+      printf '  - Artifact refs: `%s`, `%s`, `%s`\n' "${result_filename}" "${baseline_json}" "${baseline_log}"
     } >> "${digest_file}"
   done <<< "${rows}"
 }


### PR DESCRIPTION
## Summary
- use one command-derived result filename for command execution, shard aggregation, and differential failure-digest references
- resolve sharded differential baseline evidence through that same filename for both `review test` and bare `test` commands
- replay a non-empty assigned shard manifest through the action command wrapper, assert the manifest is passed by path rather than expanded into argv, and aggregate its actual structured result
- preserve immutable shard plan digest verification during aggregation

Partially addresses #345. Large Rust shard manifests remain blocked on the owning runner fix in Extra-Chill/homeboy-extensions#2545; this action intentionally does not duplicate extension-side nextest batching.

## Verification
- `bash scripts/core/test-test-shards.sh`
- `bash scripts/core/test-apply-differential-gate.sh`
- direct execution of every shell/Python test in `scripts/**/test-*`, excluding the Linux-only `/proc` assertion in `test-run-with-liveness-timeout.sh`
- `actionlint .github/workflows/ci.yml`
- `shellcheck -x -e SC1091,SC2155,SC2221,SC2222,SC2295,SC2016 scripts/core/test-test-shards.sh scripts/core/test-apply-differential-gate.sh`
- `git diff --check`

AI assistance: OpenAI GPT-5.6 Sol via OpenCode inspected consumer CI artifacts, the upstream runner contract, and review findings; it implemented the action contract repairs and executed verification. Chris Huber remains responsible for every line.