### PR TITLE
Propagate timeout budgets to reusable test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,9 @@ jobs:
           auto-setup: ${{ inputs.auto-setup }}
           php-version: ${{ inputs.php-version }}
           node-version: ${{ inputs.node-version }}
+          execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
+          test-timeout-seconds: ${{ inputs.test-timeout-seconds }}
+          cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           pr-comment: 'false'
           auto-issue: 'false'
       - id: plan
@@ -725,6 +728,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
           differential-gating: ${{ inputs.differential-gating }}
           baseline-commands: none
+          execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
+          test-timeout-seconds: ${{ inputs.test-timeout-seconds }}
+          cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           pr-comment: 'false'
           auto-issue: 'false'
       - name: Write candidate Test shard provenance
@@ -857,6 +863,9 @@ jobs:
           auto-setup: ${{ inputs.auto-setup }}
           php-version: ${{ inputs.php-version }}
           node-version: ${{ inputs.node-version }}
+          execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
+          test-timeout-seconds: ${{ inputs.test-timeout-seconds }}
+          cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           pr-comment: 'false'
           auto-issue: 'false'
       - id: plan
@@ -926,6 +935,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
           differential-gating: 'true'
           baseline-commands: none
+          execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
+          test-timeout-seconds: ${{ inputs.test-timeout-seconds }}
+          cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           pr-comment: 'false'
           auto-issue: 'false'
       - name: Write baseline Test shard provenance

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -9,13 +9,13 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 if ! grep -q 'name: Candidate \${{ matrix.title }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q 'commands: \${{ matrix.command }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q '^      execution-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
-  || ! grep -q '^          execution-timeout-seconds: \${{ inputs.execution-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || [ "$(grep -c '^          execution-timeout-seconds: \${{ inputs.execution-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 6 ] \
   || ! grep -q '^      test-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
-  || [ "$(grep -c '^          test-timeout-seconds: \${{ inputs.test-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 2 ] \
+  || [ "$(grep -c '^          test-timeout-seconds: \${{ inputs.test-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 6 ] \
   || [ "$(grep -c "HOMEBOY_TEST_TIMEOUT_SECONDS: \${{ inputs.test-timeout-seconds || env.HOMEBOY_TEST_TIMEOUT_SECONDS || '1500' }}" "${ROOT_DIR}/action.yml")" -ne 3 ] \
   || ! grep -q "if: steps.resolve-commands.outputs.has-test == 'true'" "${ROOT_DIR}/action.yml" \
   || ! grep -q '^      cleanup-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
-  || ! grep -q '^          cleanup-timeout-seconds: \${{ inputs.cleanup-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
+  || [ "$(grep -c '^          cleanup-timeout-seconds: \${{ inputs.cleanup-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 6 ] \
   || ! grep -A2 'name: Fail candidate phase when terminal evidence is not pass' "${ROOT_DIR}/.github/workflows/ci.yml" | grep -q "if: always() && steps.phase.outcome == 'failure'"; then
   printf 'FAIL: reusable CI Test job does not pass its exact matrix command to the action\n'
   exit 1


### PR DESCRIPTION
## Summary

- forward execution, test, and cleanup timeout inputs to candidate and baseline shard planning
- forward the same budgets to candidate and baseline shard execution
- strengthen the reusable-workflow liveness contract to cover all six action invocation sites

Closes #350.

## Verification

- `bash scripts/core/test-test-action-workflow-liveness.sh`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Full aggregate shell runner requires GNU `timeout` and is covered by Linux CI.

## AI assistance disclosure

OpenAI gpt-5.6-sol via OpenCode traced the missing timeout propagation, implemented the workflow repair, and updated its deterministic contract test. Chris Huber reviewed and remains responsible for every line.