### PR TITLE
Handle structured shard timeout evidence

### DIFF
--- a/scripts/core/shard-tests.sh
+++ b/scripts/core/shard-tests.sh
@@ -84,13 +84,18 @@ aggregate() (
     expected_total="$(jq '.tests | length' <<< "${shard}")"
     jq -ce --arg root "${command%% *}" --arg phase_status "${status}" '
       if .schema == "homeboy/command-result/v3" and .command == $root and (.success | type == "boolean") and (.status | type == "string") and (.exit_code | type == "number" and floor == .)
-        and (if .success then .status == "succeeded" and .exit_code == 0 else .status == "failed" and .exit_code != 0 end)
-        and (.data.test_counts | type == "object") and all(.data.test_counts.passed, .data.test_counts.failed, .data.test_counts.skipped, .data.test_counts.total; type == "number" and . >= 0 and floor == .)
-        and (.data.test_counts.passed + .data.test_counts.failed + .data.test_counts.skipped == .data.test_counts.total)
-        and (if $phase_status == "pass" then .success == true and .exit_code == 0 and .data.test_counts.failed == 0
-              elif $phase_status == "fail" then .success == false and .exit_code != 0
-              else true end)
-      then {data:{test_counts:{passed:.data.test_counts.passed,failed:.data.test_counts.failed,skipped:.data.test_counts.skipped,total:.data.test_counts.total}}}
+        and (if $phase_status == "timeout"
+          then .success == false and .status == "failed" and .exit_code == 124
+          else (if .success then .status == "succeeded" and .exit_code == 0 else .status == "failed" and .exit_code != 0 end)
+            and (.data.test_counts | type == "object") and all(.data.test_counts.passed, .data.test_counts.failed, .data.test_counts.skipped, .data.test_counts.total; type == "number" and . >= 0 and floor == .)
+            and (.data.test_counts.passed + .data.test_counts.failed + .data.test_counts.skipped == .data.test_counts.total)
+            and (if $phase_status == "pass" then .success == true and .exit_code == 0 and .data.test_counts.failed == 0
+                  else .success == false and .exit_code != 0 end)
+          end)
+      then if $phase_status == "timeout"
+        then {data:{test_counts:{passed:0,failed:0,skipped:0,total:0}}}
+        else {data:{test_counts:{passed:.data.test_counts.passed,failed:.data.test_counts.failed,skipped:.data.test_counts.skipped,total:.data.test_counts.total}}}
+        end
       else empty
       end
     ' "${payload}" >> "${payload_stream}" || fail "${phase} shard ${id} has invalid structured $(command_result_filename "${command}") counts."

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -195,6 +195,10 @@ mv "${tmp}/bad.json" "${tmp}/artifacts/candidate-shard-2/candidate/manifest.json
 rm "${tmp}/artifacts/candidate-shard-2/candidate/homeboy-ci-results/review-test.json"
 TEST_SHARD_ARTIFACT_ROOT="${tmp}/artifacts" TEST_SHARD_PLAN_FILE="${tmp}/one.json" TEST_INVENTORY_FILE="${tmp}/captured-inventory.json" TEST_SHARD_PHASE=candidate TEST_SHARD_COMMAND='review test' TEST_SHARD_OUTPUT_DIR="${tmp}/timeout-output" RUN_ATTEMPT=2 bash "${ROOT}/scripts/core/shard-tests.sh" aggregate
 jq -e '."review test" == "timeout"' "${tmp}/timeout-output/results.json" >/dev/null || { printf 'FAIL: timeout without payload must not pass\n'; exit 1; }
+jq -n '{schema:"homeboy/command-result/v3",command:"review",success:false,status:"failed",exit_code:124,summary:"test phase timed out before reporting test counts",data:{failure:{category:"infrastructure",phase:"test"}}}' > "${tmp}/artifacts/candidate-shard-2/candidate/homeboy-ci-results/review-test.json"
+TEST_SHARD_ARTIFACT_ROOT="${tmp}/artifacts" TEST_SHARD_PLAN_FILE="${tmp}/one.json" TEST_INVENTORY_FILE="${tmp}/captured-inventory.json" TEST_SHARD_PHASE=candidate TEST_SHARD_COMMAND='review test' TEST_SHARD_OUTPUT_DIR="${tmp}/structured-timeout-output" RUN_ATTEMPT=2 bash "${ROOT}/scripts/core/shard-tests.sh" aggregate
+jq -e '.schema == "homeboy/command-result/v3" and .success == false and .status == "failed" and .exit_code == 124 and .data.test_counts == {passed:0,failed:0,skipped:0,total:0}' "${tmp}/structured-timeout-output/review-test.json" >/dev/null || { printf 'FAIL: structured timeout without completed counts did not aggregate deterministically\n'; exit 1; }
+jq -e '."review test" == "timeout"' "${tmp}/structured-timeout-output/results.json" >/dev/null || { printf 'FAIL: structured timeout did not retain its timeout result\n'; exit 1; }
 
 jq '.data.test_counts.total = 999' "${tmp}/artifacts/baseline-shard-2/baseline/homeboy-ci-results/review-test.json" > "${tmp}/bad.json"
 mv "${tmp}/bad.json" "${tmp}/artifacts/baseline-shard-2/baseline/homeboy-ci-results/review-test.json"


### PR DESCRIPTION
## Summary

- validate timeout shards against the coherent Homeboy v3 timeout tuple without requiring completed test counts
- normalize timed-out shard count contribution to zero while preserving aggregate timeout/exit 124
- retain strict count validation for passing and ordinary failing shards
- cover the exact structured timeout shape observed in Homeboy CI

Closes #352.

## Evidence

- Production failure: https://github.com/Extra-Chill/homeboy/actions/runs/31044057517/job/92448807764
- `bash scripts/core/test-test-shards.sh`
- `shellcheck -e SC2016 scripts/core/shard-tests.sh scripts/core/test-test-shards.sh`
- `git diff --check`

## AI assistance

OpenAI gpt-5.6-sol via OpenCode traced the production artifact contract and implemented the focused aggregation test and repair. Chris Huber reviewed and remains responsible for every line.