### PR TITLE
fix(ci): fail a candidate Test shard that reports terminal failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,6 +751,25 @@ jobs:
           name: homeboy-test-shard-candidate-${{ matrix.shard_id }}-${{ github.run_attempt }}
           path: differential-phase
 
+      # Mirrors "Fail candidate phase when terminal evidence is not pass" in the
+      # unsharded candidate job. The action deliberately continues through
+      # publication so reconciliation receives the terminal evidence, and the
+      # upload above has already run, so aggregation is unaffected -- but the
+      # shard check itself must still report its own terminal failure.
+      #
+      # Without this, a shard that fails or exceeds test-timeout-seconds reports
+      # success while writing "timeout" into its manifest. Reconciliation then
+      # correctly refuses to pass an unmeasured suite, producing N green shard
+      # checks and one red aggregator: a reviewer scanning shard results sees
+      # only success, and the real cause is nowhere near the failing check.
+      #
+      # Deliberately not mirrored onto baseline-test-shards: like the unsharded
+      # baseline job, a red baseline is informational under differential gating
+      # and must not block a merge.
+      - name: Fail candidate Test shard when terminal evidence is not pass
+        if: always() && steps.phase.outcome == 'failure'
+        run: exit 1
+
   reconcile-test-shards:
     name: Test
     needs: [candidate-test-shards, baseline-test-shards, baseline-test-plan, plan]


### PR DESCRIPTION
## The bug

`candidate-test-shards` marks its phase step `continue-on-error: true` so the action can publish terminal evidence before the job ends. The **unsharded** `candidate` job compensates for that with a re-raise step:

```yaml
# The action deliberately continues through publication so reconciliation
# receives the terminal evidence, but the candidate check itself must
# still report that same terminal failure before a PR can be merged.
- name: Fail candidate phase when terminal evidence is not pass
  if: always() && steps.phase.outcome == 'failure'
  run: exit 1
```

**`candidate-test-shards` has no equivalent.** A shard that fails or exceeds `test-timeout-seconds` reports `success` while writing `"timeout"` into its own manifest.

## What that produces

Observed in `Extra-Chill/homeboy` run `31096136310` — every job green, aggregator red:

```
success | homeboy / Candidate Test shard shard-1     <- step log ends: exit code 1
success | homeboy / Candidate Test shard shard-2
... all 16 shards success ...
failure | homeboy / Test                             <- Enforce sharded Test result
```

Shard-1's own evidence:
```json
{ "code": "command.failed",
  "message": "test phase timed out after 1500s before reporting test counts, suite incomplete",
  "exit_code": 124 }
```

Reconciliation is behaving correctly — `enforce-final-status.sh` refuses to pass an unmeasured suite. But a reviewer scanning shard checks sees 16 successes, and the actual cause is nowhere near the check that went red.

## The change

Mirror the existing candidate re-raise onto `candidate-test-shards`.

Placed **after** the evidence upload, which is `if: always()`, so aggregation still receives every shard manifest and reconciliation is unaffected. The only behaviour change is that the shard check now reports its own terminal state.

## Deliberately not applied to `baseline-test-shards`

The unsharded `baseline` job has no re-raise either, and that asymmetry is intentional: under differential gating a red baseline is informational and must not block a merge. Adding the step there would invert that design.

Resulting symmetry:

| job | re-raise |
|---|---|
| `candidate` | yes |
| `candidate-test-shards` | yes (this PR) |
| `baseline` | no |
| `baseline-test-shards` | no |

## Verification

- `scripts/run-tests.sh`: **36 passed, 0 failed**
- Workflow parses; step ordering confirmed to place the re-raise last, after the upload

## Context

Companion to `Extra-Chill/homeboy#11743`, which fixes the underlying cause of the shard timeouts (a build script declaring `rerun-if-changed` on a path that does not exist, rebuilding all 29 workspace crates on every cargo invocation). That PR stops shards from timing out; this one ensures a shard that *does* fail says so.