### PR TITLE
fix(ci): surface observation terminal diagnostics

### DIFF
--- a/scripts/core/enforce-final-status.sh
+++ b/scripts/core/enforce-final-status.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib.sh"
+
 OPERATIONS_RESULTS="${OPERATIONS_RESULTS:-}"
 HAS_QUALITY_COMMANDS=true
 HAS_OPERATIONS_COMMANDS=true
@@ -28,6 +32,18 @@ fi
 validate_results_json "Quality command" "${RESULTS:-}"
 validate_results_json "Operations command" "${OPERATIONS_RESULTS}"
 
+emit_terminal_diagnostics() {
+  local command diagnostic
+
+  while IFS= read -r command; do
+    [ -n "${command}" ] || continue
+    while IFS= read -r diagnostic; do
+      [ -n "${diagnostic}" ] || continue
+      printf '::error::homeboy %s terminal diagnostic: %s\n' "${command}" "${diagnostic}"
+    done < <(observation_terminal_diagnostics "${HOMEBOY_OBSERVATIONS_DIR:-}" "${command}")
+  done < <(jq -r 'to_entries[] | select(.value == "fail") | .key' <<< "${RESULTS:-{}}" 2>/dev/null || true)
+}
+
 if [ -z "${RESULTS:-}" ] || [ "${RESULTS}" = "{}" ]; then
   HAS_QUALITY_COMMANDS=false
 
@@ -52,6 +68,7 @@ FAILED=false
 # Check quality command results
 if [ "${HAS_QUALITY_COMMANDS}" = true ]; then
   if printf '%s\n' "${RESULTS}" | jq -e 'to_entries | any(.value == "fail")' > /dev/null; then
+    emit_terminal_diagnostics
     echo "::error::One or more quality commands failed"
     FAILED=true
   fi

--- a/scripts/core/lib.sh
+++ b/scripts/core/lib.sh
@@ -261,6 +261,36 @@ valid_command_result_output() {
     ' "${output_file}" >/dev/null 2>&1
 }
 
+# Observations retain terminal errors when a command fails before it can write
+# its command-result envelope. Keep diagnostics single-line and redact common
+# credential forms before sending them to GitHub logs or summaries.
+observation_terminal_diagnostics() {
+  local observation_dir="$1"
+  local command="$2"
+  local command_kind
+  command_kind="$(quality_base_command "${command}")"
+
+  [ -d "${observation_dir}" ] || return 0
+
+  find "${observation_dir}" -type f -name runs.json -print0 2>/dev/null \
+    | while IFS= read -r -d '' runs_file; do
+        jq -r --arg kind "${command_kind}" '
+          if type == "array" then . else [] end
+          | .[]
+          | select(.status == "error" and .kind == $kind)
+          | .metadata_json.error?
+          | select(type == "string" and length > 0)
+          | .[:1000]
+          | gsub("(?i)(bearer[[:space:]]+)[^[:space:]]+"; "\\1[REDACTED]")
+          | gsub("(?i)((token|password|secret|api[_-]?key)[=:][[:space:]]*)[^[:space:]]+"; "\\1[REDACTED]")
+          | gsub("(?i)gh[opsu]_[A-Za-z0-9_]+"; "[REDACTED]")
+          | gsub("(?i)github_pat_[A-Za-z0-9_]+"; "[REDACTED]")
+          | gsub("[\\r\\n]+"; " ")
+        ' "${runs_file}" 2>/dev/null || true
+      done \
+    | sort -u
+}
+
 review_subcommand_run_command() {
   local cmd="$1"
   local component_id="$2"

--- a/scripts/core/test-enforce-final-status.sh
+++ b/scripts/core/test-enforce-final-status.sh
@@ -4,6 +4,21 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENFORCE_STATUS="${SCRIPT_DIR}/enforce-final-status.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+mkdir -p "${TMPDIR}/observations"
+cat > "${TMPDIR}/observations/runs.json" <<'JSON'
+[
+  {
+    "kind": "test",
+    "status": "error",
+    "metadata_json": {
+      "error": "Invalid argument 'structured_sidecar': structured sidecar `test.failures` must be a JSON array for schema v1"
+    }
+  }
+]
+JSON
 
 assert_exit() {
   local expected="$1"
@@ -28,7 +43,13 @@ assert_exit 1 "malformed quality results fail closed" \
   env RESULTS='{"review test":"fail"}}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
 
 assert_exit 1 "failing quality results fail" \
-  env RESULTS='{"review test":"fail"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"
+  env RESULTS='{"review test":"fail"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' HOMEBOY_OBSERVATIONS_DIR="${TMPDIR}/observations" bash "${ENFORCE_STATUS}"
+
+output="$(env RESULTS='{"review test":"fail"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' HOMEBOY_OBSERVATIONS_DIR="${TMPDIR}/observations" bash "${ENFORCE_STATUS}" 2>&1 || true)"
+case "${output}" in
+  *"structured sidecar \`test.failures\` must be a JSON array for schema v1"*) printf 'PASS: final status renders observation terminal diagnostics\n' ;;
+  *) printf 'FAIL: final status omitted observation terminal diagnostics; got: %s\n' "${output}"; exit 1 ;;
+esac
 
 assert_exit 1 "timed out quality results fail with their classification" \
   env RESULTS='{"review test":"timeout"}' COMMANDS='review test' OPERATIONS_RESULTS='' PR_ACTIVE='' bash "${ENFORCE_STATUS}"

--- a/scripts/digest/generate-failure-digest.sh
+++ b/scripts/digest/generate-failure-digest.sh
@@ -99,6 +99,27 @@ append_differential_evidence() {
   done <<< "${rows}"
 }
 
+append_terminal_diagnostics() {
+  local digest_file="$1"
+  local diagnostics=""
+  local command diagnostic
+
+  while IFS= read -r command; do
+    [ -n "${command}" ] || continue
+    while IFS= read -r diagnostic; do
+      [ -n "${diagnostic}" ] || continue
+      printf '::error::homeboy %s terminal diagnostic: %s\n' "${command}" "${diagnostic}"
+      diagnostics+="- \`homeboy ${command}\`: ${diagnostic}"$'\n'
+    done < <(observation_terminal_diagnostics "${HOMEBOY_OBSERVATIONS_DIR:-}" "${command}")
+  done < <(jq -r 'to_entries[] | select(.value == "fail") | .key' <<< "${RESULTS_JSON}" 2>/dev/null || true)
+
+  [ -n "${diagnostics}" ] || return 0
+  {
+    printf '\n### Terminal diagnostics\n'
+    printf '%s' "${diagnostics}"
+  } >> "${digest_file}"
+}
+
 if [ -z "${OUTPUT_DIR}" ] || [ ! -d "${OUTPUT_DIR}" ]; then
   echo "No output directory available; skipping failure digest"
   exit 0
@@ -149,6 +170,7 @@ fi
 
 append_local_reproduction_commands "${DIGEST_FILE}"
 append_differential_evidence "${DIGEST_FILE}"
+append_terminal_diagnostics "${DIGEST_FILE}"
 
 if [ -n "${GITHUB_ENV:-}" ]; then
   echo "HOMEBOY_FAILURE_DIGEST_FILE=${DIGEST_FILE}" >> "${GITHUB_ENV}"

--- a/scripts/digest/test-generate-failure-digest.sh
+++ b/scripts/digest/test-generate-failure-digest.sh
@@ -12,6 +12,19 @@ SUMMARY_FILE="${TMPDIR}/summary.md"
 ENV_FILE="${TMPDIR}/github-env"
 ARGS_FILE="${TMPDIR}/homeboy-args"
 mkdir -p "${BIN_DIR}" "${OUTPUT_DIR}"
+mkdir -p "${TMPDIR}/observations"
+
+cat > "${TMPDIR}/observations/runs.json" <<'JSON'
+[
+  {
+    "kind": "test",
+    "status": "error",
+    "metadata_json": {
+      "error": "Invalid argument 'structured_sidecar': structured sidecar `test.failures` must be a JSON array for schema v1"
+    }
+  }
+]
+JSON
 
 cat > "${BIN_DIR}/homeboy" <<'STUB'
 #!/usr/bin/env bash
@@ -45,6 +58,7 @@ export SCOPE_MODE="changed"
 export SCOPE_BASE_REF="abc123base"
 export GITHUB_ENV="${ENV_FILE}"
 export GITHUB_STEP_SUMMARY="${SUMMARY_FILE}"
+export HOMEBOY_OBSERVATIONS_DIR="${TMPDIR}/observations"
 
 bash "${ROOT}/scripts/digest/generate-failure-digest.sh"
 
@@ -64,6 +78,8 @@ grep -F -- "- Scope mode: \`changed\`" "${DIGEST_FILE}" >/dev/null
 grep -F -- "- Scope base ref: \`abc123base\`" "${DIGEST_FILE}" >/dev/null
 grep -F "homeboy review lint wordpress --path . --changed-since abc123base" "${DIGEST_FILE}" >/dev/null
 grep -F "homeboy review test wordpress --path . --changed-since abc123base" "${DIGEST_FILE}" >/dev/null
+grep -F "### Terminal diagnostics" "${DIGEST_FILE}" >/dev/null
+grep -F "structured sidecar \`test.failures\` must be a JSON array for schema v1" "${DIGEST_FILE}" >/dev/null
 
 grep -Fx -- "report" "${ARGS_FILE}" >/dev/null
 grep -Fx -- "failure-digest" "${ARGS_FILE}" >/dev/null


### PR DESCRIPTION
## Summary

- Extract safe, redacted terminal diagnostics from exported Homeboy `runs.json` observations when failed commands have no usable structured result.
- Render those diagnostics as GitHub error annotations during final status enforcement and append them to the failure digest.
- Cover the SSI schema-validation failure: `structured sidecar test.failures must be a JSON array for schema v1`.

Fixes #357.

## Verification

- `bash scripts/digest/test-generate-failure-digest.sh`
- `bash scripts/core/test-enforce-final-status.sh`
- `bash scripts/core/test-run-homeboy-commands.sh`
- `bash -n scripts/core/lib.sh scripts/digest/generate-failure-digest.sh scripts/core/enforce-final-status.sh scripts/digest/test-generate-failure-digest.sh scripts/core/test-enforce-final-status.sh`
- `git diff --check`

`bash scripts/run-tests.sh` is blocked on this macOS host because the runner requires GNU `timeout`; neither `timeout` nor `gtimeout` is installed, so all tests exit before their test bodies run.

## AI assistance

OpenAI GPT-5.6 Sol via OpenCode investigated the failing SSI run, implemented the change, and ran the listed verification. Chris Huber remains responsible for every line and this pull request.