### PR TITLE
fix(ci): expose named reusable workflow phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
 
-      - name: Materialize candidate Homeboy binary
+      - name: Binary setup
         uses: ./.homeboy-action
         with:
           commands: __prepare__
@@ -448,7 +448,8 @@ jobs:
           client-id: ${{ secrets.HOMEBOY_APP_ID }}
           private-key: ${{ secrets.HOMEBOY_APP_PRIVATE_KEY }}
 
-      - id: phase
+      - name: Run candidate ${{ matrix.title }}
+        id: phase
         continue-on-error: true
         uses: ./.homeboy-action
         with:
@@ -560,7 +561,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
-      - id: phase
+      - name: Run baseline ${{ matrix.title }}
+        id: phase
         if: matrix.baseline == 'true'
         continue-on-error: true
         uses: ./.homeboy-action
@@ -636,7 +638,7 @@ jobs:
       - name: Install cargo-nextest for Rust shard planning
         if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
         uses: taiki-e/install-action@nextest
-      - name: Materialize canonical candidate Test inventory
+      - name: Configure candidate Test shards
         continue-on-error: true
         env:
           HOMEBOY_TEST_INVENTORY_ONLY: '1'
@@ -707,7 +709,8 @@ jobs:
           name: homeboy-test-shard-plan-${{ github.run_attempt }}
       - name: Materialize assigned Test shard
         run: jq --arg id '${{ matrix.shard_id }}' '.shards[] | select(.id == $id)' homeboy-test-shard-plan.json > homeboy-test-shard.json
-      - id: phase
+      - name: Run candidate Test shard ${{ matrix.shard_id }}
+        id: phase
         continue-on-error: true
         env:
           HOMEBOY_TEST_SHARD_MANIFEST: ${{ github.workspace }}/homeboy-test-shard.json
@@ -862,7 +865,7 @@ jobs:
       - name: Install cargo-nextest for Rust baseline shard planning
         if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
         uses: taiki-e/install-action@nextest
-      - name: Materialize canonical baseline Test inventory
+      - name: Configure baseline Test shards
         continue-on-error: true
         env:
           HOMEBOY_TEST_INVENTORY_ONLY: '1'
@@ -933,7 +936,8 @@ jobs:
         with:
           name: homeboy-baseline-test-shard-plan-${{ github.run_attempt }}
       - run: jq --arg id '${{ matrix.shard_id }}' '.shards[] | select(.id == $id)' homeboy-test-shard-plan.json > homeboy-test-shard.json
-      - id: phase
+      - name: Run baseline Test shard ${{ matrix.shard_id }}
+        id: phase
         continue-on-error: true
         env:
           HOMEBOY_TEST_SHARD_MANIFEST: ${{ github.workspace }}/homeboy-test-shard.json

--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@ The generic source-mutation interface has been removed: `autofix`, `autofix-mode
 ### PR Quality Checks
 
 Prefer the reusable workflow so Homeboy Action owns the CI DAG and result
-aggregation. The workflow runs all requested quality commands before failing,
-so an audit failure does not hide lint or test feedback.
+aggregation. It projects binary setup, command execution, artifact
+publication, result reconciliation, and enforcement into named GitHub jobs and
+steps. A failed command appears as `Run candidate Audit`, `Run candidate Lint`,
+or `Run candidate Test` in the GitHub UI and `gh run view --log`, rather than
+as an anonymous composite-action step. The workflow runs all requested quality
+commands before failing, so an audit failure does not hide lint or test
+feedback.
 
 For pull requests with `differential-gating: 'true'`, the reusable workflow
 materializes one candidate Homeboy binary, then runs candidate and base phases
@@ -57,6 +62,37 @@ jobs:
       php-version: '8.3'
     secrets: inherit
 ```
+
+### Named-Phase Migration
+
+Existing direct action calls remain supported and preserve the combined
+composite lifecycle:
+
+```yaml
+- uses: Extra-Chill/homeboy-action@v2
+  with:
+    extension: wordpress
+    commands: review lint,review test
+```
+
+Move CI quality gates to the reusable workflow when GitHub-native failure
+attribution is required. Replace the action step with a job-level `uses` call,
+move its `with` values under the job, and add `secrets: inherit` when the
+action needs repository credentials. Keep direct action calls for release,
+operations, and other cases that require the composite action in an existing
+job. The reusable workflow retains structured result artifacts, failure
+digests, phase timings, and final status enforcement.
+
+```yaml
+jobs:
+  quality:
+    uses: Extra-Chill/homeboy-action/.github/workflows/ci.yml@v2
+    with:
+      extension: wordpress
+      commands: review lint,review test
+    secrets: inherit
+```
+
 
 When validating Homeboy itself or another project that needs to build a binary
 before running quality checks, keep the build as the hard gate and let the

--- a/scripts/core/test-reusable-workflow-named-phases.sh
+++ b/scripts/core/test-reusable-workflow-named-phases.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# A composite action cannot expose its internal steps through the GitHub Jobs
+# API. The reusable workflow must therefore name every action invocation that
+# owns a user-visible phase, including failing command and shard executions.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
+
+python3 - "${WORKFLOW}" <<'PY'
+import sys
+import yaml
+
+workflow = yaml.safe_load(open(sys.argv[1]))
+problems = []
+
+expected = {
+    "binary": ["Binary setup"],
+    "candidate": ["Run candidate ${{ matrix.title }}"],
+    "baseline": ["Run baseline ${{ matrix.title }}"],
+    "candidate-test-plan": ["Configure candidate Test shards"],
+    "candidate-test-shards": ["Run candidate Test shard ${{ matrix.shard_id }}"],
+    "baseline-test-plan": ["Configure baseline Test shards"],
+    "baseline-test-shards": ["Run baseline Test shard ${{ matrix.shard_id }}"],
+}
+
+for job_name, names in expected.items():
+    actual = [step.get("name") for step in workflow["jobs"][job_name].get("steps", [])]
+    for name in names:
+        if name not in actual:
+            problems.append(f"{job_name} does not expose named phase {name!r}")
+
+for job_name, job in workflow["jobs"].items():
+    for step in job.get("steps", []):
+        if step.get("uses") == "./.homeboy-action" and not step.get("name"):
+            problems.append(f"{job_name} has an anonymous Homeboy Action invocation")
+
+if problems:
+    print("\n".join(problems))
+    sys.exit(1)
+PY
+
+printf 'PASS: reusable workflow exposes named GitHub-native Homeboy phases\n'


### PR DESCRIPTION
## Summary
- name every reusable-workflow Homeboy Action invocation that owns binary setup, candidate/baseline commands, and Test shard planning/replay
- retain the composite action path while documenting migration to GitHub-native named CI steps
- add a workflow contract test that rejects anonymous Homeboy Action invocations

Fixes #359

## Verification
- `bash scripts/core/test-reusable-workflow-named-phases.sh`
- `bash scripts/core/test-action-ref-pinning.sh`
- `bash scripts/core/test-reusable-workflow-cargo-cache.sh`
- `actionlint -shellcheck= -pyflakes= .github/workflows/ci.yml .github/workflows/self-test.yml`
- `git diff --check`

The full `bash scripts/run-tests.sh` runner requires GNU `timeout`, which is unavailable on this macOS host; it exits before executing its first test.

## AI assistance
OpenAI gpt-5.6-terra via OpenCode inspected the composite-action observability boundary, implemented the reusable-workflow projection, and ran the listed deterministic checks. Chris Huber remains responsible for every line.