### PR TITLE
fix(ci): terminalize Test inventory failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,7 @@ jobs:
         if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
         uses: taiki-e/install-action@nextest
       - name: Materialize canonical candidate Test inventory
+        id: inventory
         continue-on-error: true
         env:
           HOMEBOY_TEST_INVENTORY_ONLY: '1'
@@ -661,7 +662,10 @@ jobs:
           cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           pr-comment: 'false'
           auto-issue: 'false'
-      - id: plan
+      - name: Plan candidate Test shards
+        id: plan
+        if: always() && steps.inventory.outcome == 'success'
+        continue-on-error: true
         env:
           TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
           TEST_SHARD_PLAN_FILE: ${{ github.workspace }}/homeboy-test-shard-plan.json
@@ -670,18 +674,49 @@ jobs:
         run: |
           bash .homeboy-action/scripts/core/shard-tests.sh plan
           echo "matrix=$(jq -cn --arg command "${TEST_COMMAND}" --slurpfile plan homeboy-test-shard-plan.json '{include:[$plan[0].shards[] | {command:$command,shard_id:.id}]}')" >> "${GITHUB_OUTPUT}"
-      - uses: actions/upload-artifact@v7
+      - name: Write candidate Test inventory failure provenance
+        if: always() && (steps.inventory.outcome != 'success' || steps.plan.outcome != 'success')
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          COMMAND: ${{ needs.plan.outputs.test-command }}
+          INVENTORY_OUTCOME: ${{ steps.inventory.outcome }}
+          PLANNER_OUTCOME: ${{ steps.plan.outcome }}
+          RESULTS: ${{ steps.inventory.outputs.results }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          mkdir -p homeboy-test-inventory-failure
+          inventory_payload="${RESULTS-}"
+          [ -n "${inventory_payload}" ] || inventory_payload='{}'
+          jq -cn --arg schema 'homeboy/test-inventory-provenance/v1' --arg phase candidate --arg repository "${REPOSITORY}" --arg candidate_sha "${CANDIDATE_SHA}" --arg command "${COMMAND}" --arg inventory_outcome "${INVENTORY_OUTCOME}" --arg planner_outcome "${PLANNER_OUTCOME}" --argjson run_attempt "${RUN_ATTEMPT}" --argjson results "${inventory_payload}" \
+            '{schema:$schema,phase:$phase,repository:$repository,candidate_sha:$candidate_sha,command:$command,inventory_outcome:$inventory_outcome,planner_outcome:$planner_outcome,run_attempt:$run_attempt,results:$results}' > homeboy-test-inventory-failure/provenance.json
+          cp -R homeboy-ci-results homeboy-test-inventory-failure/homeboy-ci-results 2>/dev/null || true
+      - name: Upload candidate Test inventory failure provenance
+        if: always() && (steps.inventory.outcome != 'success' || steps.plan.outcome != 'success')
+        uses: actions/upload-artifact@v7
+        with:
+          name: homeboy-test-inventory-failure-${{ github.run_attempt }}
+          path: homeboy-test-inventory-failure
+          if-no-files-found: error
+      - name: Upload candidate Test shard plan
+        if: always() && steps.plan.outcome == 'success'
+        uses: actions/upload-artifact@v7
         with:
           name: homeboy-test-shard-plan-${{ github.run_attempt }}
           path: |
             homeboy-test-inventory.json
             homeboy-test-shard-plan.json
           if-no-files-found: error
+      - name: Fail candidate Test inventory generation
+        if: always() && (steps.inventory.outcome != 'success' || steps.plan.outcome != 'success')
+        run: |
+          echo '::error::Candidate Test inventory generation failed; shard execution was not started. Inspect the inventory provenance artifact and this job for the underlying command failure.'
+          exit 1
 
   candidate-test-shards:
     name: Candidate Test shard ${{ matrix.shard_id }}
     needs: [binary, plan, candidate-test-plan]
-    if: ${{ always() && needs.binary.result == 'success' && needs.plan.outputs.test-shards-enabled == 'true' }}
+    if: ${{ always() && needs.binary.result == 'success' && needs.plan.outputs.test-shards-enabled == 'true' && needs.candidate-test-plan.result == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -772,7 +807,7 @@ jobs:
 
   reconcile-test-shards:
     name: Test
-    needs: [candidate-test-shards, baseline-test-shards, baseline-test-plan, plan]
+    needs: [candidate-test-shards, candidate-test-plan, baseline-test-shards, baseline-test-plan, plan]
     if: ${{ always() && needs.plan.outputs.test-shards-enabled == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -781,19 +816,42 @@ jobs:
           repository: Extra-Chill/homeboy-action
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
+      - name: Download candidate Test inventory failure provenance
+        if: needs.candidate-test-plan.result != 'success'
+        uses: actions/download-artifact@v7
+        with:
+          name: homeboy-test-inventory-failure-${{ github.run_attempt }}
+          path: test-inventory-failure
+      - name: Report candidate Test inventory generation failure
+        if: needs.candidate-test-plan.result != 'success'
+        run: |
+          provenance=test-inventory-failure/provenance.json
+          command="$(jq -r .command "${provenance}")"
+          results="$(jq -c .results "${provenance}")"
+          echo "::error::Test inventory generation failed for '${command}' (inventory=${{ needs.candidate-test-plan.result }}; results=${results}). Inspect Plan candidate Test shards for the underlying command failure."
+          find test-inventory-failure/homeboy-ci-results -type f -maxdepth 1 -print -exec cat {} \; 2>/dev/null || true
+          exit 1
+      - name: Report baseline Test inventory generation failure
+        if: needs.candidate-test-plan.result == 'success' && github.event_name == 'pull_request' && inputs.differential-gating == 'true' && needs.baseline-test-plan.result != 'success'
+        run: |
+          echo '::error::Baseline Test inventory generation failed; baseline shard artifacts were not downloaded. Inspect Plan baseline Test shards for the underlying command failure.'
+          exit 1
       - uses: actions/download-artifact@v7
+        if: needs.candidate-test-plan.result == 'success'
         with:
           pattern: homeboy-test-shard-*
           path: test-shard-artifacts
       - uses: actions/download-artifact@v7
+        if: needs.candidate-test-plan.result == 'success'
         with:
           name: homeboy-test-shard-plan-${{ github.run_attempt }}
       - uses: actions/download-artifact@v7
-        if: github.event_name == 'pull_request' && inputs.differential-gating == 'true'
+        if: needs.candidate-test-plan.result == 'success' && github.event_name == 'pull_request' && inputs.differential-gating == 'true' && needs.baseline-test-plan.result == 'success'
         with:
           name: homeboy-baseline-test-shard-plan-${{ github.run_attempt }}
           path: baseline-test-plan
       - name: Aggregate complete candidate Test shard evidence
+        if: needs.candidate-test-plan.result == 'success'
         env:
           TEST_SHARD_ARTIFACT_ROOT: test-shard-artifacts
           TEST_SHARD_PLAN_FILE: homeboy-test-shard-plan.json
@@ -804,7 +862,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: bash .homeboy-action/scripts/core/shard-tests.sh aggregate
       - name: Aggregate complete baseline Test shard evidence
-        if: github.event_name == 'pull_request' && inputs.differential-gating == 'true'
+        if: needs.candidate-test-plan.result == 'success' && github.event_name == 'pull_request' && inputs.differential-gating == 'true' && needs.baseline-test-plan.result == 'success'
         env:
           TEST_SHARD_ARTIFACT_ROOT: test-shard-artifacts
           TEST_SHARD_PLAN_FILE: baseline-test-plan/homeboy-test-shard-plan.json
@@ -815,7 +873,7 @@ jobs:
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: bash .homeboy-action/scripts/core/shard-tests.sh aggregate
       - name: Apply differential Test result
-        if: github.event_name == 'pull_request' && inputs.differential-gating == 'true'
+        if: needs.candidate-test-plan.result == 'success' && github.event_name == 'pull_request' && inputs.differential-gating == 'true' && needs.baseline-test-plan.result == 'success'
         env:
           COMMAND: ${{ needs.plan.outputs.test-command }}
         run: |
@@ -834,7 +892,7 @@ jobs:
           python3 .homeboy-action/scripts/core/apply-differential-gate.py "$(cat homeboy-ci-results/results.json)" homeboy-ci-results homeboy-baseline-results > reconciled-results.json
           RESULTS="$(cat reconciled-results.json)" COMMANDS="${COMMAND}" OPERATIONS_RESULTS='' PR_ACTIVE='' bash .homeboy-action/scripts/core/enforce-final-status.sh
       - name: Enforce sharded Test result
-        if: github.event_name != 'pull_request' || inputs.differential-gating != 'true'
+        if: needs.candidate-test-plan.result == 'success' && (github.event_name != 'pull_request' || inputs.differential-gating != 'true')
         env:
           COMMAND: ${{ needs.plan.outputs.test-command }}
         run: RESULTS="$(cat homeboy-ci-results/results.json)" COMMANDS="${COMMAND}" OPERATIONS_RESULTS='' PR_ACTIVE='' bash .homeboy-action/scripts/core/enforce-final-status.sh
@@ -863,6 +921,7 @@ jobs:
         if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
         uses: taiki-e/install-action@nextest
       - name: Materialize canonical baseline Test inventory
+        id: inventory
         continue-on-error: true
         env:
           HOMEBOY_TEST_INVENTORY_ONLY: '1'
@@ -887,7 +946,10 @@ jobs:
           cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
           pr-comment: 'false'
           auto-issue: 'false'
-      - id: plan
+      - name: Plan baseline Test shards
+        id: plan
+        if: always() && steps.inventory.outcome == 'success'
+        continue-on-error: true
         env:
           TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
           TEST_SHARD_PLAN_FILE: ${{ github.workspace }}/homeboy-test-shard-plan.json
@@ -897,7 +959,14 @@ jobs:
           bash .homeboy-action/scripts/core/shard-tests.sh plan
           jq -cn --arg command "${TEST_COMMAND}" --slurpfile plan homeboy-test-shard-plan.json '{include:[$plan[0].shards[] | {command:$command,shard_id:.id}]}' >> /dev/null
           echo "matrix=$(jq -cn --arg command "${TEST_COMMAND}" --slurpfile plan homeboy-test-shard-plan.json '{include:[$plan[0].shards[] | {command:$command,shard_id:.id}]}')" >> "${GITHUB_OUTPUT}"
-      - uses: actions/upload-artifact@v7
+      - name: Fail baseline Test inventory generation
+        if: always() && (steps.inventory.outcome != 'success' || steps.plan.outcome != 'success')
+        run: |
+          echo '::error::Baseline Test inventory generation failed; baseline shard execution was not started.'
+          exit 1
+      - name: Upload baseline Test shard plan
+        if: always() && steps.plan.outcome == 'success'
+        uses: actions/upload-artifact@v7
         with:
           name: homeboy-baseline-test-shard-plan-${{ github.run_attempt }}
           path: |
@@ -908,7 +977,7 @@ jobs:
   baseline-test-shards:
     name: Baseline Test shard ${{ matrix.shard_id }}
     needs: [binary, plan, baseline-test-plan]
-    if: ${{ always() && needs.binary.result == 'success' && needs.plan.outputs.test-shards-enabled == 'true' && github.event_name == 'pull_request' && inputs.differential-gating == 'true' }}
+    if: ${{ always() && needs.binary.result == 'success' && needs.plan.outputs.test-shards-enabled == 'true' && github.event_name == 'pull_request' && inputs.differential-gating == 'true' && needs.baseline-test-plan.result == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -212,7 +212,7 @@ grep -F "inputs.test-shards == '1' || needs.reconcile-test-shards.result == 'suc
 if [ "$(grep -c 'uses: taiki-e/install-action@nextest' "${WORKFLOW}")" -ne 4 ]; then
   printf 'FAIL: Rust candidate and baseline plan/replay jobs do not all install cargo-nextest\n'; exit 1
 fi
-if [ "$(grep -c "continue-on-error: true" "${WORKFLOW}")" -lt 4 ]; then
+if [ "$(grep -c "continue-on-error: true" "${WORKFLOW}")" -lt 6 ]; then
   printf 'FAIL: inventory planning transport is not isolated from normal Test verdict enforcement\n'; exit 1
 fi
 if [ "$(grep -c "HOMEBOY_RUST_NEXTEST_FALLBACK: '0'" "${WORKFLOW}")" -ne 4 ] || [ "$(grep -c 'NEXTEST_PROFILE: ci' "${WORKFLOW}")" -ne 4 ]; then
@@ -225,4 +225,15 @@ fi
 # shellcheck disable=SC2016
 grep -F 'baseline_result="$(jq -r --arg command "${COMMAND}"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline metadata is not derived from its aggregate result\n'; exit 1; }
 grep -F 'result_filename="$(command_result_filename "${COMMAND}")"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline lookup does not use the canonical result filename\n'; exit 1; }
+grep -F 'name: Write candidate Test inventory failure provenance' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate inventory failures do not preserve provenance\n'; exit 1; }
+# shellcheck disable=SC2016
+grep -F 'name: homeboy-test-inventory-failure-${{ github.run_attempt }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate inventory failure provenance is not artifact-scoped\n'; exit 1; }
+grep -F "needs.candidate-test-plan.result == 'success'" "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate shard work can start without a successful inventory plan\n'; exit 1; }
+grep -F 'name: Report candidate Test inventory generation failure' "${WORKFLOW}" >/dev/null || { printf 'FAIL: Test does not report candidate inventory generation failures\n'; exit 1; }
+grep -F "if: needs.candidate-test-plan.result == 'success'" "${WORKFLOW}" >/dev/null || { printf 'FAIL: Test artifact downloads are not gated on a successful candidate plan\n'; exit 1; }
+grep -F "Candidate Test inventory generation failed; shard execution was not started" "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate inventory producer is not terminal\n'; exit 1; }
+grep -F "::error::Test inventory generation failed for" "${WORKFLOW}" >/dev/null || { printf 'FAIL: Test does not emit the inventory generation diagnostic\n'; exit 1; }
+if grep -A4 'name: Report candidate Test inventory generation failure' "${WORKFLOW}" | grep -F 'homeboy-test-shard-plan-' >/dev/null; then
+  printf 'FAIL: inventory failure reporting attempts to read a missing shard plan artifact\n'; exit 1
+fi
 printf 'PASS: policy waits for sharded Test reconciliation while preserving unsharded behavior\n'


### PR DESCRIPTION
## Summary
- terminate candidate Test inventory failures in the planning producer after preserving command-result provenance
- skip shard matrices, plan artifacts, and aggregate artifact reads when no candidate plan exists
- make the `Test` check report inventory generation failure and print preserved command evidence

Fixes #361

## Validation
- `bash scripts/core/test-test-shards.sh`
- `bash scripts/core/test-reconcile-differential-phases.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/self-test.yml .github/workflows/release.yml`
- `shellcheck -S warning scripts/core/test-test-shards.sh`
- all shell tests were invoked directly; macOS cannot run the repository's Linux-only `/proc` supervisor test

## AI Assistance
OpenAI gpt-5.6-terra via OpenCode implemented the workflow change, contract coverage, and validation. Chris Huber remains responsible for every line.