### PR TITLE
fix(ci): isolate Test shard transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,11 +626,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Reserve action checkout path
+        run: |
+          if git ls-files --error-unmatch -- .homeboy-action >/dev/null 2>&1 || [ -e .homeboy-action ] || [ -L .homeboy-action ]; then
+            echo '::error::Refusing to overwrite consumer path reserved for the Homeboy Action checkout: .homeboy-action'
+            exit 1
+          fi
       - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
+      - name: Reserve action-owned candidate Test shard paths
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
       - id: candidate-binary
         env:
           GH_TOKEN: ${{ github.token }}
@@ -727,11 +735,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Reserve action checkout path
+        run: |
+          if git ls-files --error-unmatch -- .homeboy-action >/dev/null 2>&1 || [ -e .homeboy-action ] || [ -L .homeboy-action ]; then
+            echo '::error::Refusing to overwrite consumer path reserved for the Homeboy Action checkout: .homeboy-action'
+            exit 1
+          fi
       - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
+      - name: Reserve action-owned candidate Test shard paths
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
       - id: candidate-binary
         env:
           GH_TOKEN: ${{ github.token }}
@@ -911,11 +927,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+      - name: Reserve action checkout path
+        run: |
+          if git ls-files --error-unmatch -- .homeboy-action >/dev/null 2>&1 || [ -e .homeboy-action ] || [ -L .homeboy-action ]; then
+            echo '::error::Refusing to overwrite consumer path reserved for the Homeboy Action checkout: .homeboy-action'
+            exit 1
+          fi
       - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
+      - name: Reserve action-owned baseline Test shard paths
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
       - id: candidate-binary
         env:
           GH_TOKEN: ${{ github.token }}
@@ -989,11 +1013,19 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+      - name: Reserve action checkout path
+        run: |
+          if git ls-files --error-unmatch -- .homeboy-action >/dev/null 2>&1 || [ -e .homeboy-action ] || [ -L .homeboy-action ]; then
+            echo '::error::Refusing to overwrite consumer path reserved for the Homeboy Action checkout: .homeboy-action'
+            exit 1
+          fi
       - uses: actions/checkout@v6
         with:
           repository: Extra-Chill/homeboy-action
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
+      - name: Reserve action-owned baseline Test shard paths
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
       - id: candidate-binary
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,6 +638,7 @@ jobs:
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
       - name: Reserve action-owned candidate Test shard paths
+        id: prepare-workspace
         run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
       - id: candidate-binary
         env:
@@ -722,6 +723,9 @@ jobs:
         run: |
           echo '::error::Candidate Test inventory generation failed; shard execution was not started. Inspect the inventory provenance artifact and this job for the underlying command failure.'
           exit 1
+      - name: Restore consumer Git exclusions
+        if: always() && steps.prepare-workspace.outcome == 'success'
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh cleanup
 
   candidate-test-shards:
     name: Candidate Test shard ${{ matrix.shard_id }}
@@ -747,6 +751,7 @@ jobs:
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
       - name: Reserve action-owned candidate Test shard paths
+        id: prepare-workspace
         run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
       - id: candidate-binary
         env:
@@ -823,6 +828,9 @@ jobs:
       - name: Fail candidate Test shard when terminal evidence is not pass
         if: always() && steps.phase.outcome == 'failure'
         run: exit 1
+      - name: Restore consumer Git exclusions
+        if: always() && steps.prepare-workspace.outcome == 'success'
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh cleanup
 
   reconcile-test-shards:
     name: Test
@@ -939,6 +947,7 @@ jobs:
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
       - name: Reserve action-owned baseline Test shard paths
+        id: prepare-workspace
         run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
       - id: candidate-binary
         env:
@@ -1000,6 +1009,9 @@ jobs:
             homeboy-test-inventory.json
             homeboy-test-shard-plan.json
           if-no-files-found: error
+      - name: Restore consumer Git exclusions
+        if: always() && steps.prepare-workspace.outcome == 'success'
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh cleanup
 
   baseline-test-shards:
     name: Baseline Test shard ${{ matrix.shard_id }}
@@ -1025,6 +1037,7 @@ jobs:
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
       - name: Reserve action-owned baseline Test shard paths
+        id: prepare-workspace
         run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
       - id: candidate-binary
         env:
@@ -1081,6 +1094,9 @@ jobs:
         with:
           name: homeboy-test-shard-baseline-${{ matrix.shard_id }}-${{ github.run_attempt }}
           path: differential-phase
+      - name: Restore consumer Git exclusions
+        if: always() && steps.prepare-workspace.outcome == 'success'
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh cleanup
 
   reconcile:
     # This is the sole verdict and retains the established required-check name.

--- a/scripts/core/prepare-test-shard-workspace.sh
+++ b/scripts/core/prepare-test-shard-workspace.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Reserves the action-owned paths used to transport Test shard state. The action
+# checkout has already materialized; transport must not make consumer checks
+# mistake it for a consumer workspace change.
+set -euo pipefail
+
+workspace="${GITHUB_WORKSPACE:-$PWD}"
+git -C "${workspace}" rev-parse --is-inside-work-tree >/dev/null || {
+  echo "::error::Test shard workspace is not a Git worktree: ${workspace}" >&2
+  exit 1
+}
+
+for path in homeboy-test-inventory.json homeboy-test-shard-plan.json homeboy-test-shard.json; do
+  if git -C "${workspace}" ls-files --error-unmatch -- "${path}" >/dev/null 2>&1 || [ -e "${workspace}/${path}" ] || [ -L "${workspace}/${path}" ]; then
+    echo "::error::Refusing to overwrite consumer path reserved for Test shard transport: ${path}" >&2
+    exit 1
+  fi
+done
+
+if [ -L "${workspace}/.homeboy-action" ] || ! git -C "${workspace}/.homeboy-action" rev-parse --is-inside-work-tree >/dev/null; then
+  echo "::error::Homeboy Action checkout is missing or unsafe." >&2
+  exit 1
+fi
+
+exclude_file="$(git -C "${workspace}" rev-parse --path-format=absolute --git-path info/exclude)"
+mkdir -p "$(dirname "${exclude_file}")"
+printf '%s\n' '/.homeboy-action/' '/homeboy-test-inventory.json' '/homeboy-test-shard-plan.json' '/homeboy-test-shard.json' >> "${exclude_file}"

--- a/scripts/core/prepare-test-shard-workspace.sh
+++ b/scripts/core/prepare-test-shard-workspace.sh
@@ -6,10 +6,46 @@
 set -euo pipefail
 
 workspace="${GITHUB_WORKSPACE:-$PWD}"
+mode="${1:-prepare}"
 git -C "${workspace}" rev-parse --is-inside-work-tree >/dev/null || {
   echo "::error::Test shard workspace is not a Git worktree: ${workspace}" >&2
   exit 1
 }
+
+git_dir="$(git -C "${workspace}" rev-parse --absolute-git-dir)"
+exclude_file="$(git -C "${workspace}" rev-parse --path-format=absolute --git-path info/exclude)"
+state_dir="${git_dir}/homeboy-test-shard-workspace-exclude"
+
+case "${mode}" in
+  cleanup)
+    [ -d "${state_dir}" ] && [ ! -L "${state_dir}" ] || exit 0
+    [ -f "${state_dir}/original-exclude" ] && [ ! -L "${state_dir}/original-exclude" ] || {
+      echo "::error::Test shard workspace exclusion state is unsafe." >&2
+      exit 1
+    }
+    [ -f "${state_dir}/exclude-existed" ] || [ -f "${state_dir}/exclude-absent" ] || {
+      echo "::error::Test shard workspace exclusion state is incomplete." >&2
+      exit 1
+    }
+    [ ! -L "${exclude_file}" ] || {
+      echo "::error::Refusing to restore Test shard exclusions through a symlink." >&2
+      exit 1
+    }
+    if [ -f "${state_dir}/exclude-existed" ]; then
+      cp "${state_dir}/original-exclude" "${exclude_file}"
+    else
+      rm -f "${exclude_file}"
+    fi
+    rm -f "${state_dir}/original-exclude" "${state_dir}/exclude-existed" "${state_dir}/exclude-absent"
+    rmdir "${state_dir}"
+    exit 0
+    ;;
+  prepare) ;;
+  *)
+    echo "::error::Usage: $0 [prepare|cleanup]" >&2
+    exit 1
+    ;;
+esac
 
 for path in homeboy-test-inventory.json homeboy-test-shard-plan.json homeboy-test-shard.json; do
   if git -C "${workspace}" ls-files --error-unmatch -- "${path}" >/dev/null 2>&1 || [ -e "${workspace}/${path}" ] || [ -L "${workspace}/${path}" ]; then
@@ -18,11 +54,31 @@ for path in homeboy-test-inventory.json homeboy-test-shard-plan.json homeboy-tes
   fi
 done
 
-if [ -L "${workspace}/.homeboy-action" ] || ! git -C "${workspace}/.homeboy-action" rev-parse --is-inside-work-tree >/dev/null; then
+action_checkout="${workspace}/.homeboy-action"
+if [ -L "${action_checkout}" ] || ! action_toplevel="$(git -C "${action_checkout}" rev-parse --show-toplevel 2>/dev/null)" || [ "${action_toplevel}" != "$(cd "${action_checkout}" && pwd -P)" ]; then
   echo "::error::Homeboy Action checkout is missing or unsafe." >&2
   exit 1
 fi
 
-exclude_file="$(git -C "${workspace}" rev-parse --path-format=absolute --git-path info/exclude)"
 mkdir -p "$(dirname "${exclude_file}")"
-printf '%s\n' '/.homeboy-action/' '/homeboy-test-inventory.json' '/homeboy-test-shard-plan.json' '/homeboy-test-shard.json' >> "${exclude_file}"
+[ ! -e "${state_dir}" ] && [ ! -L "${state_dir}" ] || {
+  echo "::error::Test shard workspace exclusion state already exists." >&2
+  exit 1
+}
+if [ -L "${exclude_file}" ] || { [ -e "${exclude_file}" ] && [ ! -f "${exclude_file}" ]; }; then
+  echo "::error::Refusing to replace Test shard exclusions through an unsafe path." >&2
+  exit 1
+fi
+
+mkdir "${state_dir}"
+if [ -e "${exclude_file}" ]; then
+  cp "${exclude_file}" "${state_dir}/original-exclude"
+  : > "${state_dir}/exclude-existed"
+else
+  : > "${state_dir}/original-exclude"
+  : > "${state_dir}/exclude-absent"
+fi
+
+# Replace, rather than append to, consumer exclusions while replay runs. This
+# prevents a preexisting broad exclusion from hiding a real consumer change.
+printf '%s\n' '/.homeboy-action/' '/homeboy-test-inventory.json' '/homeboy-test-shard-plan.json' '/homeboy-test-shard.json' > "${exclude_file}"

--- a/scripts/core/test-test-shard-workspace.sh
+++ b/scripts/core/test-test-shard-workspace.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PREPARE="${ROOT}/scripts/core/prepare-test-shard-workspace.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+for phase in candidate baseline; do
+  workspace="${tmp}/${phase}"
+  mkdir -p "${workspace}"
+  git -C "${workspace}" init -q
+  git -C "${workspace}" config user.name fixture
+  git -C "${workspace}" config user.email fixture@example.invalid
+  printf 'consumer\n' > "${workspace}/consumer.txt"
+  git -C "${workspace}" add consumer.txt
+  git -C "${workspace}" commit -qm fixture
+  git -C "${workspace}" init -q .homeboy-action
+
+  GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}"
+  mkdir -p "${workspace}/.homeboy-action"
+  : > "${workspace}/homeboy-test-inventory.json"
+  : > "${workspace}/homeboy-test-shard-plan.json"
+  : > "${workspace}/homeboy-test-shard.json"
+
+  status="$(git -C "${workspace}" status --porcelain)"
+  [ -z "${status}" ] || { printf 'FAIL: %s replay sees action-owned transport as consumer changes: %s\n' "${phase}" "${status}"; exit 1; }
+
+  printf 'dirty\n' >> "${workspace}/consumer.txt"
+  : > "${workspace}/consumer-change.txt"
+  status="$(git -C "${workspace}" status --porcelain)"
+  printf '%s\n' "${status}" | grep -Fx ' M consumer.txt' >/dev/null || { printf 'FAIL: %s replay hid a real tracked consumer change\n' "${phase}"; exit 1; }
+  printf '%s\n' "${status}" | grep -Fx '?? consumer-change.txt' >/dev/null || { printf 'FAIL: %s replay hid a real untracked consumer change\n' "${phase}"; exit 1; }
+done
+
+for collision in homeboy-test-inventory.json homeboy-test-shard-plan.json homeboy-test-shard.json; do
+  workspace="${tmp}/collision-${collision}"
+  mkdir -p "${workspace}"
+  git -C "${workspace}" init -q
+  git -C "${workspace}" init -q .homeboy-action
+  : > "${workspace}/${collision}"
+  if GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" >/dev/null 2>&1; then
+    printf 'FAIL: action accepted preexisting consumer transport collision: %s\n' "${collision}"
+    exit 1
+  fi
+done
+
+workspace="${tmp}/action-checkout-collision"
+mkdir -p "${workspace}/.homeboy-action"
+git -C "${workspace}" init -q
+printf 'consumer-owned\n' > "${workspace}/.homeboy-action/marker"
+git -C "${workspace}" add .homeboy-action
+git -C "${workspace}" config user.name fixture
+git -C "${workspace}" config user.email fixture@example.invalid
+git -C "${workspace}" commit -qm fixture
+if ! git -C "${workspace}" ls-files --error-unmatch -- .homeboy-action >/dev/null 2>&1; then
+  printf 'FAIL: fixture did not retain a consumer-owned action checkout collision\n'
+  exit 1
+fi
+
+printf 'PASS: candidate and baseline Test shard transport stays out of consumer status without hiding real changes\n'

--- a/scripts/core/test-test-shard-workspace.sh
+++ b/scripts/core/test-test-shard-workspace.sh
@@ -8,7 +8,7 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 
 for phase in candidate baseline; do
-  workspace="${tmp}/${phase}"
+  workspace="${tmp}/${phase} workspace"
   mkdir -p "${workspace}"
   git -C "${workspace}" init -q
   git -C "${workspace}" config user.name fixture
@@ -17,6 +17,7 @@ for phase in candidate baseline; do
   git -C "${workspace}" add consumer.txt
   git -C "${workspace}" commit -qm fixture
   git -C "${workspace}" init -q .homeboy-action
+  printf 'consumer-change.txt\n' > "$(git -C "${workspace}" rev-parse --git-path info/exclude)"
 
   GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}"
   mkdir -p "${workspace}/.homeboy-action"
@@ -24,15 +25,35 @@ for phase in candidate baseline; do
   : > "${workspace}/homeboy-test-shard-plan.json"
   : > "${workspace}/homeboy-test-shard.json"
 
-  status="$(git -C "${workspace}" status --porcelain)"
+  status="$(git -C "${workspace}" status --porcelain --untracked-files=all)"
   [ -z "${status}" ] || { printf 'FAIL: %s replay sees action-owned transport as consumer changes: %s\n' "${phase}" "${status}"; exit 1; }
 
   printf 'dirty\n' >> "${workspace}/consumer.txt"
   : > "${workspace}/consumer-change.txt"
-  status="$(git -C "${workspace}" status --porcelain)"
+  mkdir -p "${workspace}/components/nested"
+  : > "${workspace}/components/nested/homeboy-test-shard.json"
+  status="$(git -C "${workspace}" status --porcelain --untracked-files=all)"
   printf '%s\n' "${status}" | grep -Fx ' M consumer.txt' >/dev/null || { printf 'FAIL: %s replay hid a real tracked consumer change\n' "${phase}"; exit 1; }
   printf '%s\n' "${status}" | grep -Fx '?? consumer-change.txt' >/dev/null || { printf 'FAIL: %s replay hid a real untracked consumer change\n' "${phase}"; exit 1; }
+  printf '%s\n' "${status}" | grep -Fx '?? components/nested/homeboy-test-shard.json' >/dev/null || { printf 'FAIL: %s replay hid a nested consumer path\n' "${phase}"; exit 1; }
+
+  GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" cleanup
+  cmp <(printf 'consumer-change.txt\n') "$(git -C "${workspace}" rev-parse --git-path info/exclude)" || { printf 'FAIL: %s replay did not restore consumer exclusions\n' "${phase}"; exit 1; }
 done
+
+workspace="${tmp}/tracked-collision"
+mkdir -p "${workspace}"
+git -C "${workspace}" init -q
+git -C "${workspace}" config user.name fixture
+git -C "${workspace}" config user.email fixture@example.invalid
+git -C "${workspace}" init -q .homeboy-action
+: > "${workspace}/homeboy-test-inventory.json"
+git -C "${workspace}" add homeboy-test-inventory.json
+git -C "${workspace}" commit -qm fixture
+if GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" >/dev/null 2>&1; then
+  printf 'FAIL: action accepted a tracked transport collision\n'
+  exit 1
+fi
 
 for collision in homeboy-test-inventory.json homeboy-test-shard-plan.json homeboy-test-shard.json; do
   workspace="${tmp}/collision-${collision}"
@@ -58,5 +79,43 @@ if ! git -C "${workspace}" ls-files --error-unmatch -- .homeboy-action >/dev/nul
   printf 'FAIL: fixture did not retain a consumer-owned action checkout collision\n'
   exit 1
 fi
+if GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" >/dev/null 2>&1; then
+  printf 'FAIL: action accepted a consumer-owned action checkout collision\n'
+  exit 1
+fi
+
+workspace="${tmp}/symlink-collision"
+mkdir -p "${workspace}"
+git -C "${workspace}" init -q
+git -C "${workspace}" init -q .homeboy-action
+ln -s /tmp "${workspace}/homeboy-test-shard.json"
+if GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" >/dev/null 2>&1; then
+  printf 'FAIL: action accepted a symlinked transport collision\n'
+  exit 1
+fi
+
+workspace="${tmp}/action-checkout-symlink"
+mkdir -p "${workspace}"
+git -C "${workspace}" init -q
+ln -s /tmp "${workspace}/.homeboy-action"
+if GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" >/dev/null 2>&1; then
+  printf 'FAIL: action accepted a symlinked action checkout collision\n'
+  exit 1
+fi
+
+primary="${tmp}/linked-primary"
+linked="${tmp}/linked workspace"
+git init -q "${primary}"
+git -C "${primary}" config user.name fixture
+git -C "${primary}" config user.email fixture@example.invalid
+printf 'consumer\n' > "${primary}/consumer.txt"
+git -C "${primary}" add consumer.txt
+git -C "${primary}" commit -qm fixture
+git -C "${primary}" worktree add -q "${linked}" -b linked-fixture
+git -C "${linked}" init -q .homeboy-action
+GITHUB_WORKSPACE="${linked}" bash "${PREPARE}"
+: > "${linked}/homeboy-test-shard.json"
+[ -z "$(git -C "${linked}" status --porcelain)" ] || { printf 'FAIL: linked consumer worktree did not honor ephemeral exclusions\n'; exit 1; }
+GITHUB_WORKSPACE="${linked}" bash "${PREPARE}" cleanup
 
 printf 'PASS: candidate and baseline Test shard transport stays out of consumer status without hiding real changes\n'

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -221,8 +221,8 @@ fi
 if [ "$(grep -c 'HOMEBOY_RUST_TEST_RUNNER: nextest' "${WORKFLOW}")" -ne 4 ]; then
   printf 'FAIL: Rust shard jobs do not explicitly select nextest\n'; exit 1
 fi
-if [ "$(grep -c 'prepare-test-shard-workspace.sh' "${WORKFLOW}")" -ne 4 ]; then
-  printf 'FAIL: candidate and baseline Test shard jobs do not reserve action-owned transport paths symmetrically\n'; exit 1
+if [ "$(grep -c 'prepare-test-shard-workspace.sh' "${WORKFLOW}")" -ne 8 ]; then
+  printf 'FAIL: candidate and baseline Test shard jobs do not reserve and restore action-owned transport paths symmetrically\n'; exit 1
 fi
 if [ "$(grep -c 'Refusing to overwrite consumer path reserved for the Homeboy Action checkout' "${WORKFLOW}")" -ne 4 ]; then
   printf 'FAIL: candidate and baseline Test shard jobs do not reject action checkout collisions symmetrically\n'; exit 1

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -221,9 +221,16 @@ fi
 if [ "$(grep -c 'HOMEBOY_RUST_TEST_RUNNER: nextest' "${WORKFLOW}")" -ne 4 ]; then
   printf 'FAIL: Rust shard jobs do not explicitly select nextest\n'; exit 1
 fi
+if [ "$(grep -c 'prepare-test-shard-workspace.sh' "${WORKFLOW}")" -ne 4 ]; then
+  printf 'FAIL: candidate and baseline Test shard jobs do not reserve action-owned transport paths symmetrically\n'; exit 1
+fi
+if [ "$(grep -c 'Refusing to overwrite consumer path reserved for the Homeboy Action checkout' "${WORKFLOW}")" -ne 4 ]; then
+  printf 'FAIL: candidate and baseline Test shard jobs do not reject action checkout collisions symmetrically\n'; exit 1
+fi
 # The literal workflow expression is the contract.
 # shellcheck disable=SC2016
 grep -F 'baseline_result="$(jq -r --arg command "${COMMAND}"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline metadata is not derived from its aggregate result\n'; exit 1; }
+# shellcheck disable=SC2016
 grep -F 'result_filename="$(command_result_filename "${COMMAND}")"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline lookup does not use the canonical result filename\n'; exit 1; }
 grep -F 'name: Write candidate Test inventory failure provenance' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate inventory failures do not preserve provenance\n'; exit 1; }
 # shellcheck disable=SC2016


### PR DESCRIPTION
Fixes #363.

## Summary
- Reserve the action checkout and Test shard transport paths in candidate and baseline plan/replay jobs.
- Reject tracked, existing, and symlinked consumer path collisions before checkout or artifact materialization.
- Add only root-anchored action-owned entries to the ephemeral consumer Git exclude file, preserving all other consumer status changes.
- Add deterministic candidate/baseline Git-fixture coverage for clean replay transport, tracked and untracked consumer dirtiness, and transport collisions.

## Verification
- Hosted Self Test workflow: passed in 2m6s: https://github.com/Extra-Chill/homeboy-action/actions/runs/31279761488/job/93159076070
- `bash scripts/core/test-test-shard-workspace.sh`
- `bash scripts/core/test-test-shards.sh`
- `shellcheck scripts/core/prepare-test-shard-workspace.sh scripts/core/test-test-shard-workspace.sh scripts/core/test-test-shards.sh`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/self-test.yml`
- `git diff --check`
- Full `scripts/run-tests.sh` with a local macOS `timeout` compatibility executable: 37/38 passed. The existing `scripts/core/test-run-with-liveness-timeout.sh` fails on Darwin because its test directly scans Linux `/proc`; this change does not touch that liveness code.

## AI Assistance
OpenAI GPT-5.6 Sol via OpenCode implemented the workflow and shell-contract changes and ran the listed checks. Chris Huber reviewed and remains responsible for every line.