### PR TITLE
Make candidate binary and Test shards hermetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,12 @@ jobs:
           ref: ${{ needs.plan.outputs.action-sha }}
           path: .homeboy-action
 
+      - name: Reserve action checkout during candidate binary setup
+        id: prepare-binary-workspace
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh prepare .homeboy-action
+
       - name: Binary setup
+        id: binary-setup
         uses: ./.homeboy-action
         with:
           commands: __prepare__
@@ -243,6 +248,10 @@ jobs:
           binary-path: ${{ inputs.build-command != '' && inputs.build-artifact-path || inputs.binary-path }}
           rust-toolchain: ${{ inputs.rust-toolchain }}
           auto-setup: 'false'
+
+      - name: Restore consumer Git exclusions
+        if: always() && steps.prepare-binary-workspace.outcome == 'success'
+        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh cleanup
 
       - name: Upload candidate Homeboy binary
         uses: actions/upload-artifact@v7
@@ -781,7 +790,9 @@ jobs:
           commands: ${{ matrix.command }}
           component: ${{ inputs.component }}
           args: ${{ inputs.args }}
-          scope: ${{ inputs.scope }}
+          # The immutable manifest is the shard selector; changed-scope routing
+          # must not further filter its assigned test membership.
+          scope: full
           auto-setup: ${{ inputs.auto-setup }}
           php-version: ${{ inputs.php-version }}
           node-version: ${{ inputs.node-version }}
@@ -913,7 +924,7 @@ jobs:
             *) baseline_exit=1 ;;
           esac
           structured_output=false
-          [ ! -f "homeboy-baseline-results/${result_filename}" ] || structured_output=true
+          [ -f "homeboy-baseline-results/${result_filename}" ] && structured_output=true
           jq -cn --arg command "${COMMAND}" --arg status "${baseline_result}" --argjson exit_code "${baseline_exit}" --argjson structured_output "${structured_output}" \
             '{($command):{status:$status,exit_code:$exit_code,command:$command,structured_output:$structured_output}}' > homeboy-baseline-results/baseline-status.json
           python3 .homeboy-action/scripts/core/apply-differential-gate.py "$(cat homeboy-ci-results/results.json)" homeboy-ci-results homeboy-baseline-results > reconciled-results.json
@@ -1066,7 +1077,9 @@ jobs:
           commands: ${{ matrix.command }}
           component: ${{ inputs.component }}
           args: ${{ inputs.args }}
-          scope: ${{ inputs.scope }}
+          # The immutable manifest is the shard selector; baseline attribution
+          # must replay its complete assigned membership at the base revision.
+          scope: full
           auto-setup: ${{ inputs.auto-setup }}
           php-version: ${{ inputs.php-version }}
           node-version: ${{ inputs.node-version }}

--- a/scripts/core/prepare-test-shard-workspace.sh
+++ b/scripts/core/prepare-test-shard-workspace.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# Reserves the action-owned paths used to transport Test shard state. The action
-# checkout has already materialized; transport must not make consumer checks
-# mistake it for a consumer workspace change.
+# Temporarily hides action-owned paths from Git status without masking consumer
+# changes. The original exclusions are restored exactly by `cleanup`.
 set -euo pipefail
 
 workspace="${GITHUB_WORKSPACE:-$PWD}"
 mode="${1:-prepare}"
+shift || true
 git -C "${workspace}" rev-parse --is-inside-work-tree >/dev/null || {
   echo "::error::Test shard workspace is not a Git worktree: ${workspace}" >&2
   exit 1
@@ -47,15 +47,30 @@ case "${mode}" in
     ;;
 esac
 
-for path in homeboy-test-inventory.json homeboy-test-shard-plan.json homeboy-test-shard.json; do
+paths=("$@")
+if [ "${#paths[@]}" -eq 0 ]; then
+  paths=(.homeboy-action homeboy-test-inventory.json homeboy-test-shard-plan.json homeboy-test-shard.json)
+fi
+
+for path in "${paths[@]}"; do
+  case "${path}" in
+    .homeboy-action|homeboy-test-inventory.json|homeboy-test-shard-plan.json|homeboy-test-shard.json) ;;
+    *)
+      echo "::error::Unsupported action-owned exclusion path: ${path}" >&2
+      exit 1
+      ;;
+  esac
   if git -C "${workspace}" ls-files --error-unmatch -- "${path}" >/dev/null 2>&1 || [ -e "${workspace}/${path}" ] || [ -L "${workspace}/${path}" ]; then
+    if [ "${path}" = .homeboy-action ]; then
+      continue
+    fi
     echo "::error::Refusing to overwrite consumer path reserved for Test shard transport: ${path}" >&2
     exit 1
   fi
 done
 
 action_checkout="${workspace}/.homeboy-action"
-if [ -L "${action_checkout}" ] || ! action_toplevel="$(git -C "${action_checkout}" rev-parse --show-toplevel 2>/dev/null)" || [ "${action_toplevel}" != "$(cd "${action_checkout}" && pwd -P)" ]; then
+if [[ " ${paths[*]} " == *" .homeboy-action "* ]] && { [ -L "${action_checkout}" ] || ! action_toplevel="$(git -C "${action_checkout}" rev-parse --show-toplevel 2>/dev/null)" || [ "${action_toplevel}" != "$(cd "${action_checkout}" && pwd -P)" ]; }; then
   echo "::error::Homeboy Action checkout is missing or unsafe." >&2
   exit 1
 fi
@@ -79,6 +94,11 @@ else
   : > "${state_dir}/exclude-absent"
 fi
 
-# Replace, rather than append to, consumer exclusions while replay runs. This
-# prevents a preexisting broad exclusion from hiding a real consumer change.
-printf '%s\n' '/.homeboy-action/' '/homeboy-test-inventory.json' '/homeboy-test-shard-plan.json' '/homeboy-test-shard.json' > "${exclude_file}"
+# Replace, rather than append to, consumer exclusions while action work runs.
+# This prevents a preexisting broad exclusion from hiding a real consumer change.
+for path in "${paths[@]}"; do
+  case "${path}" in
+    .homeboy-action) printf '/%s/\n' "${path}" ;;
+    *) printf '/%s\n' "${path}" ;;
+  esac
+done > "${exclude_file}"

--- a/scripts/core/test-test-shard-workspace.sh
+++ b/scripts/core/test-test-shard-workspace.sh
@@ -17,7 +17,7 @@ for phase in candidate baseline; do
   git -C "${workspace}" add consumer.txt
   git -C "${workspace}" commit -qm fixture
   git -C "${workspace}" init -q .homeboy-action
-  printf 'consumer-change.txt\n' > "$(git -C "${workspace}" rev-parse --git-path info/exclude)"
+  printf 'consumer-change.txt\n' > "$(git -C "${workspace}" rev-parse --path-format=absolute --git-path info/exclude)"
 
   GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}"
   mkdir -p "${workspace}/.homeboy-action"
@@ -38,8 +38,30 @@ for phase in candidate baseline; do
   printf '%s\n' "${status}" | grep -Fx '?? components/nested/homeboy-test-shard.json' >/dev/null || { printf 'FAIL: %s replay hid a nested consumer path\n' "${phase}"; exit 1; }
 
   GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" cleanup
-  cmp <(printf 'consumer-change.txt\n') "$(git -C "${workspace}" rev-parse --git-path info/exclude)" || { printf 'FAIL: %s replay did not restore consumer exclusions\n' "${phase}"; exit 1; }
+  cmp <(printf 'consumer-change.txt\n') "$(git -C "${workspace}" rev-parse --path-format=absolute --git-path info/exclude)" || { printf 'FAIL: %s replay did not restore consumer exclusions\n' "${phase}"; exit 1; }
 done
+
+workspace="${tmp}/binary-identity"
+mkdir -p "${workspace}"
+git -C "${workspace}" init -q
+git -C "${workspace}" config user.name fixture
+git -C "${workspace}" config user.email fixture@example.invalid
+printf 'consumer\n' > "${workspace}/consumer.txt"
+git -C "${workspace}" add consumer.txt
+git -C "${workspace}" commit -qm fixture
+git -C "${workspace}" init -q .homeboy-action
+printf 'existing-exclusion.txt\n' > "$(git -C "${workspace}" rev-parse --path-format=absolute --git-path info/exclude)"
+GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" prepare .homeboy-action
+printf 'dirty\n' >> "${workspace}/consumer.txt"
+status="$(git -C "${workspace}" status --porcelain --untracked-files=all)"
+printf '%s\n' "${status}" | grep -Fx ' M consumer.txt' >/dev/null || { printf 'FAIL: candidate binary identity setup hid a real consumer change\n'; exit 1; }
+if printf '%s\n' "${status}" | grep -F .homeboy-action >/dev/null; then
+  printf 'FAIL: candidate binary identity setup exposed the action checkout\n'
+  exit 1
+fi
+GITHUB_WORKSPACE="${workspace}" bash "${PREPARE}" cleanup
+cmp <(printf 'existing-exclusion.txt\n') "$(git -C "${workspace}" rev-parse --path-format=absolute --git-path info/exclude)" || { printf 'FAIL: candidate binary identity setup did not restore consumer exclusions\n'; exit 1; }
+printf 'PASS: candidate binary identity setup excludes only the action checkout and restores consumer exclusions\n'
 
 workspace="${tmp}/tracked-collision"
 mkdir -p "${workspace}"

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -221,8 +221,8 @@ fi
 if [ "$(grep -c 'HOMEBOY_RUST_TEST_RUNNER: nextest' "${WORKFLOW}")" -ne 4 ]; then
   printf 'FAIL: Rust shard jobs do not explicitly select nextest\n'; exit 1
 fi
-if [ "$(grep -c 'prepare-test-shard-workspace.sh' "${WORKFLOW}")" -ne 8 ]; then
-  printf 'FAIL: candidate and baseline Test shard jobs do not reserve and restore action-owned transport paths symmetrically\n'; exit 1
+if [ "$(grep -c 'prepare-test-shard-workspace.sh' "${WORKFLOW}")" -ne 10 ]; then
+  printf 'FAIL: candidate binary and Test shard jobs do not reserve and restore action-owned paths symmetrically\n'; exit 1
 fi
 if [ "$(grep -c 'Refusing to overwrite consumer path reserved for the Homeboy Action checkout' "${WORKFLOW}")" -ne 4 ]; then
   printf 'FAIL: candidate and baseline Test shard jobs do not reject action checkout collisions symmetrically\n'; exit 1
@@ -232,6 +232,13 @@ fi
 grep -F 'baseline_result="$(jq -r --arg command "${COMMAND}"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline metadata is not derived from its aggregate result\n'; exit 1; }
 # shellcheck disable=SC2016
 grep -F 'result_filename="$(command_result_filename "${COMMAND}")"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline lookup does not use the canonical result filename\n'; exit 1; }
+# shellcheck disable=SC2016
+grep -F '[ -f "homeboy-baseline-results/${result_filename}" ] && structured_output=true' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline lookup does not fail closed when its declared result is absent\n'; exit 1; }
+if [ "$(grep -c 'scope: full' "${WORKFLOW}")" -lt 4 ]; then
+  printf 'FAIL: candidate and baseline shard planning and replay do not use their manifests as the sole test selector\n'; exit 1
+fi
+grep -F 'prepare-test-shard-workspace.sh prepare .homeboy-action' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate binary setup does not isolate the action checkout\n'; exit 1; }
+grep -F "steps.prepare-binary-workspace.outcome == 'success'" "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate binary setup does not always restore its exact Git exclusions\n'; exit 1; }
 grep -F 'name: Write candidate Test inventory failure provenance' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate inventory failures do not preserve provenance\n'; exit 1; }
 # shellcheck disable=SC2016
 grep -F 'name: homeboy-test-inventory-failure-${{ github.run_attempt }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate inventory failure provenance is not artifact-scoped\n'; exit 1; }


### PR DESCRIPTION
Closes #365.

## Summary

- exclude the action checkout only while preparing the candidate Homeboy binary, then restore the exact consumer exclusion state
- make materialized candidate and baseline shard manifests the sole replay membership authority
- fail closed when the canonical baseline result artifact is absent
- add deterministic workflow contracts for clean identity, real consumer changes, symmetric replay, baseline attribution, and canonical result filenames

## Verification

- actionlint
- shellcheck
- action shell contract suite, excluding the Linux-only `/proc` liveness test on this macOS host
- git diff --check

The Linux CI workflow remains responsible for the real timeout and `/proc` contract.

## AI assistance

OpenAI GPT-5.6 Sol and GPT-5.6 Terra via OpenCode analyzed the Homeboy shard failures, implemented the workflow and contract-test repair, and ran verification. Chris Huber reviewed and remains responsible for every line.