### PR TITLE
fix(ci): fingerprint each test shard projection

### DIFF
--- a/scripts/core/shard-tests.sh
+++ b/scripts/core/shard-tests.sh
@@ -28,7 +28,7 @@ plan() {
   ' "${inventory}" >/dev/null || fail "Test inventory must satisfy homeboy/test-inventory/v1."
   [ "${count}" -le "$(jq '.tests | length' "${inventory}")" ] || fail "Test shard count exceeds the test inventory; empty shards are not allowed."
 
-  local canonical inventory_digest plan_digest
+  local canonical inventory_digest plan_digest shard_id shard_canonical shard_fingerprint
   canonical="$(jq -cS '{schema,runner,runner_fingerprint,workspace_fingerprint,inventory_fingerprint,tests:(.tests | sort_by(.id))}' "${inventory}")"
   inventory_digest="$(digest "${canonical}")"
   printf '%s' "${canonical}" | jq -cn --slurpfile inventory /dev/stdin --arg inventory_digest "${inventory_digest}" --argjson count "${count}" --argjson unknown "${unknown}" '
@@ -40,6 +40,17 @@ plan() {
          runner_fingerprint:$inventory[0].runner_fingerprint, workspace_fingerprint:$inventory[0].workspace_fingerprint,
          inventory_fingerprint:$inventory[0].inventory_fingerprint, tests:.tests, estimated_duration_ms:.duration_ms}))}
   ' > "${output}.tmp"
+  while IFS= read -r shard_id; do
+    shard_canonical="$(jq -cS --arg id "${shard_id}" --slurpfile plan "${output}.tmp" '
+      ($plan[0].shards[] | select(.id == $id).tests | reduce .[] as $test_id ({}; .[$test_id] = true)) as $selected
+      | {schema,runner,runner_fingerprint,workspace_fingerprint,tests:(.tests | map(select($selected[.id])) | sort_by(.id))}
+    ' "${inventory}")"
+    shard_fingerprint="$(digest "${shard_canonical}")"
+    jq --arg id "${shard_id}" --arg fingerprint "${shard_fingerprint}" '
+      (.shards[] | select(.id == $id).inventory_fingerprint) = $fingerprint
+    ' "${output}.tmp" > "${output}.next"
+    mv "${output}.next" "${output}.tmp"
+  done < <(jq -r '.shards[].id' "${output}.tmp")
   plan_digest="$(digest "$(jq -cS . "${output}.tmp")")"
   jq --arg digest "${plan_digest}" '. + {plan_digest:$digest}' "${output}.tmp" > "${output}"
   rm -f "${output}.tmp"

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -45,6 +45,21 @@ for output in one two; do
 done
 cmp "${tmp}/one.json" "${tmp}/two.json" || { printf 'FAIL: identical inventories must produce byte-identical plans\n'; exit 1; }
 jq -e '[.shards[].tests[]] | sort == ["fast","medium","slow","unknown"]' "${tmp}/one.json" >/dev/null || { printf 'FAIL: plan membership is not exact\n'; exit 1; }
+jq -e '.inventory_fingerprint == "inventory-a" and all(.shards[]; .inventory_fingerprint != "inventory-a")' "${tmp}/one.json" >/dev/null || { printf 'FAIL: plan must retain the parent fingerprint while shards fingerprint their projections\n'; exit 1; }
+while IFS= read -r shard; do
+  shard_id="$(jq -r .id <<< "${shard}")"
+  projected="$(jq -cS --arg id "${shard_id}" --slurpfile plan "${tmp}/one.json" '
+    ($plan[0].shards[] | select(.id == $id).tests | reduce .[] as $test_id ({}; .[$test_id] = true)) as $selected
+    | {schema,runner,runner_fingerprint,workspace_fingerprint,tests:(.tests | map(select($selected[.id])) | sort_by(.id))}
+  ' "${tmp}/captured-inventory.json")"
+  expected_fingerprint="$(printf '%s' "${projected}" | shasum -a 256 | awk '{print $1}')"
+  [ "$(jq -r .inventory_fingerprint <<< "${shard}")" = "${expected_fingerprint}" ] || { printf 'FAIL: %s fingerprint does not bind its selected inventory projection\n' "${shard_id}"; exit 1; }
+done < <(jq -c '.shards[]' "${tmp}/one.json")
+tampered_fingerprint="$(jq -cS --slurpfile plan "${tmp}/one.json" '
+  ($plan[0].shards[0].tests + [$plan[0].shards[1].tests[0]] | reduce .[] as $test_id ({}; .[$test_id] = true)) as $selected
+  | {schema,runner,runner_fingerprint,workspace_fingerprint,tests:(.tests | map(select($selected[.id])) | sort_by(.id))}
+' "${tmp}/captured-inventory.json" | shasum -a 256 | awk '{print $1}')"
+[ "${tampered_fingerprint}" != "$(jq -r '.shards[0].inventory_fingerprint' "${tmp}/one.json")" ] || { printf 'FAIL: changed shard membership must change its projected fingerprint\n'; exit 1; }
 if TEST_INVENTORY_FILE="${tmp}/captured-inventory.json" TEST_SHARD_PLAN_FILE="${tmp}/too-many.json" TEST_SHARD_COUNT=5 bash "${ROOT}/scripts/core/shard-tests.sh" plan >/dev/null 2>&1; then
   printf 'FAIL: empty shard plans must be rejected\n'; exit 1
 fi


### PR DESCRIPTION
## Summary

- preserve the parent inventory fingerprint and canonical digest on the immutable shard plan
- recompute each shard manifest fingerprint from its selected canonical test records
- keep deterministic behavior for large inventories without placing inventory payloads in argv
- prove changed membership changes the projected fingerprint

Closes #369.

This is the planner-side counterpart to [homeboy-extensions#2588](https://github.com/Extra-Chill/homeboy-extensions/pull/2588) and unblocks [homeboy#12007](https://github.com/Extra-Chill/homeboy/pull/12007).

## Verification

- `bash scripts/core/test-test-shards.sh`
- `bash -n scripts/core/shard-tests.sh scripts/core/test-test-shards.sh`
- `git diff --check`
- `bash scripts/run-tests.sh`: 37/38 pass locally; the unchanged Linux-only `/proc` liveness-supervisor test cannot run on macOS

The shard suite includes deterministic planning, exact membership, per-shard independent fingerprint recomputation, membership tampering, 12,000-test payloads larger than 1 MiB, replay, and aggregation.

## AI assistance

OpenAI GPT-5.6-sol via OpenCode diagnosed the cross-repository fingerprint contract, implemented the planner repair, and added deterministic large-inventory coverage. Chris Huber reviewed and is responsible for every line.