### PR TITLE
Fix shard baseline selection outside action context

### DIFF
--- a/scripts/core/select-test-baseline.sh
+++ b/scripts/core/select-test-baseline.sh
@@ -2,8 +2,13 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
-source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
+if [ -n "${GITHUB_ACTION_PATH:-}" ]; then
+  source "${GITHUB_ACTION_PATH}/scripts/core/lib.sh"
+else
+  source "${SCRIPT_DIR}/lib.sh"
+fi
 
 command="${TEST_SHARD_COMMAND:?TEST_SHARD_COMMAND is required}"
 results_file="${TEST_SHARD_RESULTS_FILE:?TEST_SHARD_RESULTS_FILE is required}"

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -286,6 +286,9 @@ printf '%s\n' '{"review test":"fail"}' > "${selection_dir}/results.json"
 : > "${selection_dir}/output"
 select_candidate_baseline pull_request true auto
 grep -Fx 'baseline-command=review test' "${selection_dir}/output" >/dev/null || { printf 'FAIL: PR differential candidate failure did not select its matching baseline command\n'; exit 1; }
+: > "${selection_dir}/output"
+env -u GITHUB_ACTION_PATH GITHUB_OUTPUT="${selection_dir}/output" TEST_SHARD_COMMAND='review test' TEST_SHARD_RESULTS_FILE="${selection_dir}/results.json" TEST_SHARD_RESULT_FILE="${selection_dir}/review-test.json" TEST_SHARD_EVENT=pull_request TEST_SHARD_DIFFERENTIAL_GATING=true TEST_SHARD_BASELINE_COMMANDS=auto bash "${ROOT}/scripts/core/select-test-baseline.sh"
+grep -Fx 'baseline-command=review test' "${selection_dir}/output" >/dev/null || { printf 'FAIL: direct baseline selection without GITHUB_ACTION_PATH did not resolve core lib\n'; exit 1; }
 printf '%s\n' '{"review test":"timeout"}' > "${selection_dir}/results.json"
 : > "${selection_dir}/output"
 select_candidate_baseline pull_request true 'review test'


### PR DESCRIPTION
Fixes #373.

`select-test-baseline.sh` now resolves `lib.sh` from its own directory when `GITHUB_ACTION_PATH` is unavailable, while preserving the composite-action path when GitHub provides it. The shard harness directly invokes the script with `GITHUB_ACTION_PATH` unset so aggregation cannot regress silently.

This unblocks Extra-Chill/homeboy#12016, where every candidate shard passed but aggregation failed before reading results.

Verification:
- `bash scripts/core/test-test-shards.sh`
- `git diff --check`

AI assistance: OpenAI GPT-5.6 Sol via OpenCode was used to diagnose the failed aggregation, implement the focused repair, and run verification. Chris Huber reviewed and is responsible for the change.