### PR TITLE
Stop publishing a cancelled run as a red Test verdict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -894,7 +894,15 @@ jobs:
   reconcile-test-shards:
     name: Test
     needs: [candidate-test-result, candidate-test-plan, baseline-test-shards, baseline-test-plan, plan]
-    if: ${{ always() && needs.plan.outputs.test-shards-enabled == 'true' }}
+    # `!cancelled()` rather than `always()`: this job must still report a verdict
+    # when an upstream phase FAILED, but must not manufacture one when the run was
+    # CANCELLED. Under `always()`, a cancelled run left `candidate-test-plan.result`
+    # at `cancelled`, which tripped the `!= 'success'` inventory-failure branch below;
+    # that branch then downloaded a provenance artifact the cancelled plan job had
+    # never uploaded, and the resulting `Artifact not found` failed the job. A
+    # cancellation was therefore published as a red `Test` check carrying no test
+    # verdict at all (Extra-Chill/homeboy#10997).
+    if: ${{ !cancelled() && needs.plan.outputs.test-shards-enabled == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -225,6 +225,11 @@ printf 'PASS: missing, mismatched, failed, and timed-out shards fail closed\n'
 
 grep -F 'needs: [reconcile, reconcile-test-shards, plan]' "${WORKFLOW}" >/dev/null || { printf 'FAIL: policy does not wait for the sharded Test verdict and pinned plan\n'; exit 1; }
 grep -F "inputs.test-shards == '1' || needs.reconcile-test-shards.result == 'success'" "${WORKFLOW}" >/dev/null || { printf 'FAIL: policy can bypass a failed sharded Test verdict\n'; exit 1; }
+# A FAILED upstream phase must still reach a verdict; a CANCELLED run must not.
+# Under always() the reconciliation job ran after cancellation, took the
+# inventory-failure branch, and failed on an artifact the cancelled plan job had
+# never uploaded — publishing a cancellation as a red Test check (homeboy#10997).
+grep -F '!cancelled() && needs.plan.outputs.test-shards-enabled' "${WORKFLOW}" >/dev/null || { printf 'FAIL: sharded Test reconciliation publishes a verdict for a cancelled run\n'; exit 1; }
 if [ "$(grep -c 'uses: taiki-e/install-action@nextest' "${WORKFLOW}")" -ne 4 ]; then
   printf 'FAIL: Rust candidate and baseline plan/replay jobs do not all install cargo-nextest\n'; exit 1
 fi


### PR DESCRIPTION
## Problem

`homeboy / Test` goes **red on cancellation**, carrying no test verdict. This is the live mechanism behind Extra-Chill/homeboy#10997 — and it is not any of the mechanisms that issue's thread proposed (the exit-143 classifier theory was retracted there by the reporter).

`reconcile-test-shards` runs under `always()`:

```yaml
if: ${{ always() && needs.plan.outputs.test-shards-enabled == 'true' }}
```

`always()` runs the job even when the run is cancelled. Then:

1. `needs.candidate-test-plan.result` is `cancelled`, which is `!= 'success'`
2. → the *"Report candidate Test inventory generation failure"* step fires
3. → it downloads `homeboy-test-inventory-failure-<attempt>`, which **was never uploaded**, because the plan job was cancelled before reaching its upload step
4. → `##[error]Unable to download artifact(s): Artifact not found` → job fails → red check

A cancellation is laundered into a test failure.

## Evidence

Extra-Chill/homeboy run `31564611927`, job `94014048247`:

- every shard job cancelled at `04:53:05`
- reconciliation **started 13s after them** at `04:53:18`, failed `04:53:23`
- log ends on `Artifact not found for name: homeboy-test-inventory-failure-1`

Not an edge case — the last five merged homeboy PRs (#12142, #12141, #12137, #12130, #12128) all show `homeboy / Test` = FAILURE with every shard underneath CANCELLED. The cadence that triggers it is brutal: homeboy#12142 opened `04:51:25` and merged `04:52:45`, **80 seconds**, so `cancel-in-progress` fires long before the gate can finish.

For context, `always()` appears 39 times in this workflow and `cancelled()` appeared **zero** times — nothing anywhere distinguished "was killed" from "went red."

## Fix

`always()` → `!cancelled()` on `reconcile-test-shards`.

This keeps the case that matters: a genuinely **FAILED** upstream phase still runs reconciliation and still reaches a verdict. Only a **CANCELLED** run stops manufacturing one.

Scoped deliberately to the one job proven to publish false verdicts, rather than sweeping all 39 `always()` uses.

## Safety

`policy` already gates on `needs.reconcile-test-shards.result == 'success'`, so when reconciliation is skipped, PR Policy is skipped too — it fails closed rather than waving anything through. The run's own conclusion remains `cancelled`, so this does not turn a killed run green.

## Tests

- Adds a workflow-contract assertion to `scripts/core/test-test-shards.sh`, matching the existing grep-contract style in that file, pinning `!cancelled()` so this cannot silently regress to `always()`.
- `scripts/core/test-test-shards.sh` passes.
- `scripts/core/test-test-action-workflow-liveness.sh` passes (it pins `always()` on a *different* step, unaffected).
- `scripts/core/test-action-ref-pinning.sh` passes.
- Workflow YAML re-parsed; 12 jobs intact.

## Delivery

homeboy pins this reusable workflow at `8f90f5c37f703240c8b0f4327845ac8c89fb2b08` (= v2.11.20 = current main tip). Landing this needs a release and a follow-up repin of that SHA in `homeboy/.github/workflows/ci.yml` before the fix reaches homeboy CI.

Refs Extra-Chill/homeboy#10997