### PR TITLE
Collapse the sharded Test path to its reachable candidate half

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -833,9 +833,6 @@ jobs:
       # checks and one red aggregator: a reviewer scanning shard results sees
       # only success, and the real cause is nowhere near the failing check.
       #
-      # Deliberately not mirrored onto baseline-test-shards: like the unsharded
-      # baseline job, a red baseline is informational under differential gating
-      # and must not block a merge.
       - name: Fail candidate Test shard when terminal evidence is not pass
         if: always() && steps.phase.outcome == 'failure'
         run: exit 1
@@ -848,8 +845,6 @@ jobs:
     needs: [candidate-test-shards, candidate-test-plan, plan]
     if: ${{ always() && needs.candidate-test-plan.result == 'success' && needs.plan.outputs.test-shards-enabled == 'true' }}
     runs-on: ubuntu-latest
-    outputs:
-      baseline-command: ${{ steps.select.outputs.baseline-command }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -873,7 +868,11 @@ jobs:
           TEST_SHARD_OUTPUT_DIR: candidate-test-results/homeboy-ci-results
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: bash .homeboy-action/scripts/core/shard-tests.sh aggregate
-      - name: Select baseline command from canonical candidate result
+      # Retained for its validation, not its selection: this asserts the
+      # aggregated candidate result is a well-formed v3 command result with a
+      # valid status before anything enforces a verdict from it. The sharded path
+      # has no baseline phase, so its baseline-command output is unconsumed.
+      - name: Validate canonical candidate Test result
         id: select
         env:
           TEST_SHARD_COMMAND: ${{ needs.plan.outputs.test-command }}
@@ -893,7 +892,7 @@ jobs:
 
   reconcile-test-shards:
     name: Test
-    needs: [candidate-test-result, candidate-test-plan, baseline-test-shards, baseline-test-plan, plan]
+    needs: [candidate-test-result, candidate-test-plan, plan]
     # `!cancelled()` rather than `always()`: this job must still report a verdict
     # when an upstream phase FAILED, but must not manufacture one when the run was
     # CANCELLED. Under `always()`, a cancelled run left `candidate-test-plan.result`
@@ -916,12 +915,6 @@ jobs:
         with:
           name: homeboy-test-inventory-failure-${{ github.run_attempt }}
           path: test-inventory-failure
-      - name: Download baseline Test inventory failure provenance
-        if: needs.candidate-test-plan.result == 'success' && needs.baseline-test-plan.outputs.bootstrap-baseline-red == 'true'
-        uses: actions/download-artifact@v7
-        with:
-          name: homeboy-baseline-test-inventory-failure-${{ github.run_attempt }}
-          path: baseline-test-inventory-failure
       - name: Report candidate Test inventory generation failure
         if: needs.candidate-test-plan.result != 'success'
         run: |
@@ -931,300 +924,29 @@ jobs:
           echo "::error::Test inventory generation failed for '${command}' (inventory=${{ needs.candidate-test-plan.result }}; results=${results}). Inspect Plan candidate Test shards for the underlying command failure."
           find test-inventory-failure/homeboy-ci-results -type f -maxdepth 1 -print -exec cat {} \; 2>/dev/null || true
           exit 1
-      - name: Reconcile baseline Test bootstrap failure
-        if: needs.candidate-test-result.result == 'success' && needs.candidate-test-result.outputs.baseline-command != '' && needs.baseline-test-plan.outputs.bootstrap-baseline-red == 'true'
-        env:
-          REPOSITORY: ${{ github.repository }}
-          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
-          COMMAND: ${{ needs.plan.outputs.test-command }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-        run: |
-          provenance=baseline-test-inventory-failure/provenance.json
-          jq -e --arg repository "${REPOSITORY}" --arg candidate_sha "${CANDIDATE_SHA}" --arg base_sha "${BASE_SHA}" --arg command "${COMMAND}" --argjson run_attempt "${RUN_ATTEMPT}" '
-            .schema == "homeboy/test-inventory-provenance/v1"
-            and .phase == "baseline"
-            and .repository == $repository
-            and .candidate_sha == $candidate_sha
-            and .base_sha == $base_sha
-            and .command == $command
-            and .inventory_outcome == "failure"
-            and .planner_outcome == "skipped"
-            and (.run_attempt | type == "number" and . > 0 and . <= $run_attempt)
-            and (.results | type == "object")
-          ' "${provenance}" >/dev/null
-          echo "::warning::Test bootstrap_baseline_red: immutable baseline inventory failed before baseline shards could be planned. Candidate shards remain mandatory; inspect Plan baseline Test shards and the retained baseline inventory provenance."
-      - name: Fail unresolved baseline Test planning failure
-        if: needs.candidate-test-result.result == 'success' && needs.candidate-test-result.outputs.baseline-command != '' && needs.baseline-test-plan.result != 'success' && needs.baseline-test-plan.outputs.bootstrap-baseline-red != 'true'
-        run: |
-          echo '::error::Baseline Test planning failed outside the classified inventory-bootstrap path; no differential verdict can be produced.'
-          exit 1
       - uses: actions/download-artifact@v7
         if: needs.candidate-test-result.result == 'success'
         with:
           name: homeboy-candidate-test-results-${{ github.run_attempt }}
           path: candidate-test-results
-      - uses: actions/download-artifact@v7
-        if: needs.candidate-test-result.outputs.baseline-command != '' && needs.baseline-test-plan.result == 'success'
-        with:
-          name: homeboy-baseline-test-shard-plan-${{ github.run_attempt }}
-          path: baseline-test-plan
-      - uses: actions/download-artifact@v7
-        if: needs.candidate-test-result.outputs.baseline-command != '' && needs.baseline-test-plan.result == 'success'
-        with:
-          pattern: homeboy-test-shard-baseline-*
-          path: test-shard-artifacts
-      - name: Aggregate complete baseline Test shard evidence
-        if: needs.candidate-test-result.outputs.baseline-command != '' && needs.baseline-test-plan.result == 'success'
-        env:
-          TEST_SHARD_ARTIFACT_ROOT: test-shard-artifacts
-          TEST_SHARD_PLAN_FILE: baseline-test-plan/homeboy-test-shard-plan.json
-          TEST_INVENTORY_FILE: baseline-test-plan/homeboy-test-inventory.json
-          TEST_SHARD_PHASE: baseline
-          TEST_SHARD_COMMAND: ${{ needs.candidate-test-result.outputs.baseline-command }}
-          TEST_SHARD_OUTPUT_DIR: homeboy-baseline-results
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-        run: bash .homeboy-action/scripts/core/shard-tests.sh aggregate
-      - name: Apply differential Test result
-        if: needs.candidate-test-result.outputs.baseline-command != '' && needs.baseline-test-plan.result == 'success'
-        env:
-          COMMAND: ${{ needs.candidate-test-result.outputs.baseline-command }}
-        run: |
-          source .homeboy-action/scripts/core/lib.sh
-          result_filename="$(command_result_filename "${COMMAND}")"
-          baseline_result="$(jq -r --arg command "${COMMAND}" '.[$command]' homeboy-baseline-results/results.json)"
-          case "${baseline_result}" in
-            pass) baseline_exit=0 ;;
-            timeout) baseline_exit=124 ;;
-            *) baseline_exit=1 ;;
-          esac
-          structured_output=false
-          [ -f "homeboy-baseline-results/${result_filename}" ] && structured_output=true
-          jq -cn --arg command "${COMMAND}" --arg status "${baseline_result}" --argjson exit_code "${baseline_exit}" --argjson structured_output "${structured_output}" \
-            '{($command):{status:$status,exit_code:$exit_code,command:$command,structured_output:$structured_output}}' > homeboy-baseline-results/baseline-status.json
-          python3 .homeboy-action/scripts/core/apply-differential-gate.py "$(cat candidate-test-results/homeboy-ci-results/results.json)" candidate-test-results/homeboy-ci-results homeboy-baseline-results > reconciled-results.json
-          RESULTS="$(cat reconciled-results.json)" COMMANDS="${COMMAND}" OPERATIONS_RESULTS='' PR_ACTIVE='' bash .homeboy-action/scripts/core/enforce-final-status.sh
       - name: Report candidate Test aggregation failure
         if: needs.candidate-test-plan.result == 'success' && needs.candidate-test-result.result != 'success'
         run: |
           echo '::error::Candidate Test shard evidence could not be aggregated into a canonical result.'
           exit 1
-      - name: Enforce unreconciled sharded Test result
-        if: needs.candidate-test-result.result == 'success' && (needs.candidate-test-result.outputs.baseline-command == '' || github.event_name != 'pull_request')
+      # The single enforcement path for the sharded Test verdict.
+      #
+      # Deliberately NOT conditioned on a baseline. The sharded Test path has no
+      # baseline phase, so a baseline-shaped condition here is a branch that can
+      # never fire — and the previous `baseline-command == ''` guard meant a
+      # non-empty baseline-command would have left this job green with NO
+      # enforcement step running at all. Every reachable outcome above either
+      # exits non-zero or falls through to exactly this step.
+      - name: Enforce sharded Test result
+        if: needs.candidate-test-result.result == 'success'
         env:
           COMMAND: ${{ needs.plan.outputs.test-command }}
         run: RESULTS="$(cat candidate-test-results/homeboy-ci-results/results.json)" COMMANDS="${COMMAND}" OPERATIONS_RESULTS='' PR_ACTIVE='' bash .homeboy-action/scripts/core/enforce-final-status.sh
-      - name: Enforce candidate Test result after bootstrap baseline red
-        if: needs.candidate-test-result.result == 'success' && needs.candidate-test-result.outputs.baseline-command != '' && needs.baseline-test-plan.outputs.bootstrap-baseline-red == 'true'
-        env:
-          COMMAND: ${{ needs.plan.outputs.test-command }}
-        run: RESULTS="$(cat candidate-test-results/homeboy-ci-results/results.json)" COMMANDS="${COMMAND}" OPERATIONS_RESULTS='' PR_ACTIVE='' bash .homeboy-action/scripts/core/enforce-final-status.sh
-
-  baseline-test-plan:
-    name: Plan baseline Test shards
-    needs: [binary, plan, candidate-test-result]
-    if: ${{ always() && needs.binary.result == 'success' && needs.plan.outputs.test-shards-enabled == 'true' && github.event_name == 'pull_request' && needs.candidate-test-result.outputs.baseline-command != '' }}
-    runs-on: ubuntu-latest
-    outputs:
-      test-matrix: ${{ steps.plan.outputs.matrix }}
-      bootstrap-baseline-red: ${{ steps.bootstrap-baseline-red.outputs.value }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-      - name: Reserve action checkout path
-        run: |
-          if git ls-files --error-unmatch -- .homeboy-action >/dev/null 2>&1 || [ -e .homeboy-action ] || [ -L .homeboy-action ]; then
-            echo '::error::Refusing to overwrite consumer path reserved for the Homeboy Action checkout: .homeboy-action'
-            exit 1
-          fi
-      - uses: actions/checkout@v6
-        with:
-          repository: Extra-Chill/homeboy-action
-          ref: ${{ needs.plan.outputs.action-sha }}
-          path: .homeboy-action
-      - name: Reserve action-owned baseline Test shard paths
-        id: prepare-workspace
-        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
-      - id: candidate-binary
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
-      - name: Install cargo-nextest for Rust baseline shard planning
-        if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
-        uses: taiki-e/install-action@nextest
-      - name: Configure baseline Test shards
-        id: inventory
-        continue-on-error: true
-        env:
-          HOMEBOY_TEST_INVENTORY_ONLY: '1'
-          HOMEBOY_TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
-          HOMEBOY_RUST_TEST_RUNNER: nextest
-          HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
-          NEXTEST_PROFILE: ci
-        uses: ./.homeboy-action
-        with:
-          binary-path: ${{ steps.candidate-binary.outputs.binary-path }}
-          extension: ${{ inputs.extension }}
-          extension-source: ${{ inputs.extension-source }}
-          commands: ${{ needs.candidate-test-result.outputs.baseline-command }}
-          component: ${{ inputs.component }}
-          args: ${{ inputs.args }}
-          scope: full
-          auto-setup: ${{ inputs.auto-setup }}
-          php-version: ${{ inputs.php-version }}
-          node-version: ${{ inputs.node-version }}
-          execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
-          test-timeout-seconds: ${{ inputs.test-timeout-seconds }}
-          cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
-          pr-comment: 'false'
-          auto-issue: 'false'
-      - name: Plan baseline Test shards
-        id: plan
-        if: always() && steps.inventory.outcome == 'success'
-        continue-on-error: true
-        env:
-          TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
-          TEST_SHARD_PLAN_FILE: ${{ github.workspace }}/homeboy-test-shard-plan.json
-          TEST_SHARD_COUNT: ${{ inputs.test-shards }}
-          TEST_COMMAND: ${{ needs.candidate-test-result.outputs.baseline-command }}
-        run: |
-          bash .homeboy-action/scripts/core/shard-tests.sh plan
-          jq -cn --arg command "${TEST_COMMAND}" --slurpfile plan homeboy-test-shard-plan.json '{include:[$plan[0].shards[] | {command:$command,shard_id:.id}]}' >> /dev/null
-          echo "matrix=$(jq -cn --arg command "${TEST_COMMAND}" --slurpfile plan homeboy-test-shard-plan.json '{include:[$plan[0].shards[] | {command:$command,shard_id:.id}]}')" >> "${GITHUB_OUTPUT}"
-      - name: Classify baseline inventory bootstrap failure
-        id: bootstrap-baseline-red
-        if: always() && steps.inventory.outcome == 'failure' && steps.plan.outcome == 'skipped'
-        run: echo 'value=true' >> "${GITHUB_OUTPUT}"
-      - name: Write baseline Test inventory failure provenance
-        if: always() && steps.bootstrap-baseline-red.outputs.value == 'true'
-        env:
-          REPOSITORY: ${{ github.repository }}
-          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
-          COMMAND: ${{ needs.plan.outputs.test-command }}
-          INVENTORY_OUTCOME: ${{ steps.inventory.outcome }}
-          PLANNER_OUTCOME: ${{ steps.plan.outcome }}
-          RESULTS: ${{ steps.inventory.outputs.results }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-        run: |
-          mkdir -p homeboy-baseline-test-inventory-failure
-          inventory_payload="${RESULTS-}"
-          [ -n "${inventory_payload}" ] || inventory_payload='{}'
-          jq -cn --arg schema 'homeboy/test-inventory-provenance/v1' --arg phase baseline --arg repository "${REPOSITORY}" --arg candidate_sha "${CANDIDATE_SHA}" --arg base_sha "${BASE_SHA}" --arg command "${COMMAND}" --arg inventory_outcome "${INVENTORY_OUTCOME}" --arg planner_outcome "${PLANNER_OUTCOME}" --argjson run_attempt "${RUN_ATTEMPT}" --argjson results "${inventory_payload}" \
-            '{schema:$schema,phase:$phase,repository:$repository,candidate_sha:$candidate_sha,base_sha:$base_sha,command:$command,inventory_outcome:$inventory_outcome,planner_outcome:$planner_outcome,run_attempt:$run_attempt,results:$results}' > homeboy-baseline-test-inventory-failure/provenance.json
-          cp -R homeboy-ci-results homeboy-baseline-test-inventory-failure/homeboy-ci-results 2>/dev/null || true
-      - name: Upload baseline Test inventory failure provenance
-        if: always() && steps.bootstrap-baseline-red.outputs.value == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: homeboy-baseline-test-inventory-failure-${{ github.run_attempt }}
-          path: homeboy-baseline-test-inventory-failure
-          if-no-files-found: error
-      - name: Fail baseline Test inventory generation
-        if: always() && (steps.inventory.outcome != 'success' || steps.plan.outcome != 'success')
-        run: |
-          echo '::error::Baseline Test inventory generation failed; baseline shard execution was not started.'
-          exit 1
-      - name: Upload baseline Test shard plan
-        if: always() && steps.plan.outcome == 'success'
-        uses: actions/upload-artifact@v7
-        with:
-          name: homeboy-baseline-test-shard-plan-${{ github.run_attempt }}
-          path: |
-            homeboy-test-inventory.json
-            homeboy-test-shard-plan.json
-          if-no-files-found: error
-      - name: Restore consumer Git exclusions
-        if: always() && steps.prepare-workspace.outcome == 'success'
-        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh cleanup
-
-  baseline-test-shards:
-    name: Baseline Test shard ${{ matrix.shard_id }}
-    needs: [binary, plan, baseline-test-plan, candidate-test-result]
-    if: ${{ always() && needs.binary.result == 'success' && github.event_name == 'pull_request' && needs.candidate-test-result.outputs.baseline-command != '' && needs.baseline-test-plan.result == 'success' }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.baseline-test-plan.outputs.test-matrix) }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-      - name: Reserve action checkout path
-        run: |
-          if git ls-files --error-unmatch -- .homeboy-action >/dev/null 2>&1 || [ -e .homeboy-action ] || [ -L .homeboy-action ]; then
-            echo '::error::Refusing to overwrite consumer path reserved for the Homeboy Action checkout: .homeboy-action'
-            exit 1
-          fi
-      - uses: actions/checkout@v6
-        with:
-          repository: Extra-Chill/homeboy-action
-          ref: ${{ needs.plan.outputs.action-sha }}
-          path: .homeboy-action
-      - name: Reserve action-owned baseline Test shard paths
-        id: prepare-workspace
-        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh
-      - id: candidate-binary
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: bash .homeboy-action/scripts/core/download-candidate-binary.sh
-      - name: Install cargo-nextest for Rust baseline shard replay
-        if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
-        uses: taiki-e/install-action@nextest
-      - uses: actions/download-artifact@v7
-        with:
-          name: homeboy-baseline-test-shard-plan-${{ github.run_attempt }}
-      - run: jq --arg id '${{ matrix.shard_id }}' '.shards[] | select(.id == $id)' homeboy-test-shard-plan.json > homeboy-test-shard.json
-      - name: Run baseline Test shard ${{ matrix.shard_id }}
-        id: phase
-        continue-on-error: true
-        env:
-          HOMEBOY_TEST_SHARD_MANIFEST: ${{ github.workspace }}/homeboy-test-shard.json
-          HOMEBOY_RUST_TEST_RUNNER: nextest
-          HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
-          NEXTEST_PROFILE: ci
-        uses: ./.homeboy-action
-        with:
-          binary-path: ${{ steps.candidate-binary.outputs.binary-path }}
-          extension: ${{ inputs.extension }}
-          extension-source: ${{ inputs.extension-source }}
-          commands: ${{ matrix.command }}
-          component: ${{ inputs.component }}
-          args: ${{ inputs.args }}
-          # The immutable manifest is the shard selector; baseline attribution
-          # must replay its complete assigned membership at the base revision.
-          scope: full
-          auto-setup: ${{ inputs.auto-setup }}
-          php-version: ${{ inputs.php-version }}
-          node-version: ${{ inputs.node-version }}
-          differential-gating: 'true'
-          baseline-commands: none
-          execution-timeout-seconds: ${{ inputs.execution-timeout-seconds }}
-          test-timeout-seconds: ${{ inputs.test-timeout-seconds }}
-          cleanup-timeout-seconds: ${{ inputs.cleanup-timeout-seconds }}
-          pr-comment: 'false'
-          auto-issue: 'false'
-      - name: Write baseline Test shard provenance
-        if: always()
-        env:
-          RESULTS: ${{ steps.phase.outputs.results }}
-          SHARD_ID: ${{ matrix.shard_id }}
-          COMMAND: ${{ matrix.command }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-        run: |
-          mkdir -p differential-phase/baseline
-          results="${RESULTS:-}"; [ -n "${results}" ] || results='{}'
-          jq -cn --arg phase baseline --arg shard_id "${SHARD_ID}" --arg command "${COMMAND}" --arg inventory_digest "$(jq -r .inventory_digest homeboy-test-shard-plan.json)" --arg plan_digest "$(jq -r .plan_digest homeboy-test-shard-plan.json)" --argjson run_attempt "${RUN_ATTEMPT}" --argjson results "${results}" '{phase:$phase,shard_id:$shard_id,command:$command,inventory_digest:$inventory_digest,plan_digest:$plan_digest,run_attempt:$run_attempt,results:$results}' > differential-phase/baseline/manifest.json
-          cp -R homeboy-ci-results differential-phase/baseline/homeboy-ci-results 2>/dev/null || mkdir -p differential-phase/baseline/homeboy-ci-results
-      - if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: homeboy-test-shard-baseline-${{ matrix.shard_id }}-${{ github.run_attempt }}
-          path: differential-phase
-      - name: Restore consumer Git exclusions
-        if: always() && steps.prepare-workspace.outcome == 'success'
-        run: bash .homeboy-action/scripts/core/prepare-test-shard-workspace.sh cleanup
 
   reconcile:
     # This is the sole verdict and retains the established required-check name.

--- a/scripts/core/test-reconcile-differential-phases.sh
+++ b/scripts/core/test-reconcile-differential-phases.sh
@@ -79,8 +79,8 @@ fi
 printf 'PASS: workflow keeps candidate and baseline retries independent\n'
 
 if grep -F 'results="${RESULTS:-{}}"' "${WORKFLOW}" >/dev/null \
-  || [ "$(grep -Fc 'results="${RESULTS:-}"' "${WORKFLOW}")" -ne 4 ] \
-  || [ "$(grep -Fc "[ -n \"\${results}\" ] || results='{}'" "${WORKFLOW}")" -ne 4 ]; then
+  || [ "$(grep -Fc 'results="${RESULTS:-}"' "${WORKFLOW}")" -ne 3 ] \
+  || [ "$(grep -Fc "[ -n \"\${results}\" ] || results='{}'" "${WORKFLOW}")" -ne 3 ]; then
   printf 'FAIL: candidate and baseline provenance do not preserve populated result JSON\n'
   exit 1
 fi

--- a/scripts/core/test-reusable-workflow-named-phases.sh
+++ b/scripts/core/test-reusable-workflow-named-phases.sh
@@ -21,8 +21,6 @@ expected = {
     "baseline": ["Run baseline ${{ matrix.title }}"],
     "candidate-test-plan": ["Configure candidate Test shards"],
     "candidate-test-shards": ["Run candidate Test shard ${{ matrix.shard_id }}"],
-    "baseline-test-plan": ["Configure baseline Test shards"],
-    "baseline-test-shards": ["Run baseline Test shard ${{ matrix.shard_id }}"],
 }
 
 for job_name, names in expected.items():

--- a/scripts/core/test-test-action-workflow-liveness.sh
+++ b/scripts/core/test-test-action-workflow-liveness.sh
@@ -9,13 +9,13 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 if ! grep -q 'name: Candidate \${{ matrix.title }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q 'commands: \${{ matrix.command }}' "${ROOT_DIR}/.github/workflows/ci.yml" \
   || ! grep -q '^      execution-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
-  || [ "$(grep -c '^          execution-timeout-seconds: \${{ inputs.execution-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 6 ] \
+  || [ "$(grep -c '^          execution-timeout-seconds: \${{ inputs.execution-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 4 ] \
   || ! grep -q '^      test-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
-  || [ "$(grep -c '^          test-timeout-seconds: \${{ inputs.test-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 6 ] \
+  || [ "$(grep -c '^          test-timeout-seconds: \${{ inputs.test-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 4 ] \
   || [ "$(grep -c "HOMEBOY_TEST_TIMEOUT_SECONDS: \${{ inputs.test-timeout-seconds || env.HOMEBOY_TEST_TIMEOUT_SECONDS || '1500' }}" "${ROOT_DIR}/action.yml")" -ne 3 ] \
   || ! grep -q "if: steps.resolve-commands.outputs.has-test == 'true'" "${ROOT_DIR}/action.yml" \
   || ! grep -q '^      cleanup-timeout-seconds:' "${ROOT_DIR}/.github/workflows/ci.yml" \
-  || [ "$(grep -c '^          cleanup-timeout-seconds: \${{ inputs.cleanup-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 6 ] \
+  || [ "$(grep -c '^          cleanup-timeout-seconds: \${{ inputs.cleanup-timeout-seconds }}' "${ROOT_DIR}/.github/workflows/ci.yml")" -ne 4 ] \
   || ! grep -A2 'name: Fail candidate phase when terminal evidence is not pass' "${ROOT_DIR}/.github/workflows/ci.yml" | grep -q "if: always() && steps.phase.outcome == 'failure'"; then
   printf 'FAIL: reusable CI Test job does not pass its exact matrix command to the action\n'
   exit 1

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -230,40 +230,48 @@ grep -F "inputs.test-shards == '1' || needs.reconcile-test-shards.result == 'suc
 # inventory-failure branch, and failed on an artifact the cancelled plan job had
 # never uploaded — publishing a cancellation as a red Test check (homeboy#10997).
 grep -F '!cancelled() && needs.plan.outputs.test-shards-enabled' "${WORKFLOW}" >/dev/null || { printf 'FAIL: sharded Test reconciliation publishes a verdict for a cancelled run\n'; exit 1; }
-if [ "$(grep -c 'uses: taiki-e/install-action@nextest' "${WORKFLOW}")" -ne 4 ]; then
-  printf 'FAIL: Rust candidate and baseline plan/replay jobs do not all install cargo-nextest\n'; exit 1
+if [ "$(grep -c 'uses: taiki-e/install-action@nextest' "${WORKFLOW}")" -ne 2 ]; then
+  printf 'FAIL: Rust candidate plan/replay jobs do not all install cargo-nextest\n'; exit 1
 fi
 if [ "$(grep -c "continue-on-error: true" "${WORKFLOW}")" -lt 6 ]; then
   printf 'FAIL: inventory planning transport is not isolated from normal Test verdict enforcement\n'; exit 1
 fi
-if [ "$(grep -c "HOMEBOY_RUST_NEXTEST_FALLBACK: '0'" "${WORKFLOW}")" -ne 4 ] || [ "$(grep -c 'NEXTEST_PROFILE: ci' "${WORKFLOW}")" -ne 4 ]; then
+if [ "$(grep -c "HOMEBOY_RUST_NEXTEST_FALLBACK: '0'" "${WORKFLOW}")" -ne 2 ] || [ "$(grep -c 'NEXTEST_PROFILE: ci' "${WORKFLOW}")" -ne 2 ]; then
   printf 'FAIL: Rust shard jobs do not require nextest with the CI profile\n'; exit 1
 fi
-if [ "$(grep -c 'HOMEBOY_RUST_TEST_RUNNER: nextest' "${WORKFLOW}")" -ne 4 ]; then
+if [ "$(grep -c 'HOMEBOY_RUST_TEST_RUNNER: nextest' "${WORKFLOW}")" -ne 2 ]; then
   printf 'FAIL: Rust shard jobs do not explicitly select nextest\n'; exit 1
 fi
-if [ "$(grep -c 'prepare-test-shard-workspace.sh' "${WORKFLOW}")" -ne 10 ]; then
+if [ "$(grep -c 'prepare-test-shard-workspace.sh' "${WORKFLOW}")" -ne 6 ]; then
   printf 'FAIL: candidate binary and Test shard jobs do not reserve and restore action-owned paths symmetrically\n'; exit 1
 fi
-if [ "$(grep -c 'Refusing to overwrite consumer path reserved for the Homeboy Action checkout' "${WORKFLOW}")" -ne 4 ]; then
-  printf 'FAIL: candidate and baseline Test shard jobs do not reject action checkout collisions symmetrically\n'; exit 1
+if [ "$(grep -c 'Refusing to overwrite consumer path reserved for the Homeboy Action checkout' "${WORKFLOW}")" -ne 2 ]; then
+  printf 'FAIL: candidate Test shard jobs do not reject action checkout collisions\n'; exit 1
 fi
-# The literal workflow expression is the contract.
-# shellcheck disable=SC2016
-grep -F 'baseline_result="$(jq -r --arg command "${COMMAND}"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline metadata is not derived from its aggregate result\n'; exit 1; }
-# shellcheck disable=SC2016
-grep -F 'result_filename="$(command_result_filename "${COMMAND}")"' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline lookup does not use the canonical result filename\n'; exit 1; }
-# shellcheck disable=SC2016
-grep -F '[ -f "homeboy-baseline-results/${result_filename}" ] && structured_output=true' "${WORKFLOW}" >/dev/null || { printf 'FAIL: differential baseline lookup does not fail closed when its declared result is absent\n'; exit 1; }
+# The sharded Test path has no baseline phase: a baseline is only meaningful for
+# differential gating, which the sharded path does not perform. Assert the DAG
+# stays candidate-only so the dead-branch class that produced homeboy#10997
+# cannot grow back.
+for dead_job in baseline-test-plan baseline-test-shards; do
+  grep -qE "^  ${dead_job}:" "${WORKFLOW}" && { printf 'FAIL: sharded Test path reintroduced %%s\n' "${dead_job}"; exit 1; }
+done
+grep -F 'homeboy-baseline-results' "${WORKFLOW}" >/dev/null && { printf 'FAIL: sharded Test reconciliation reintroduced baseline aggregate handling\n'; exit 1; }
+
+# Exactly one step may enforce the sharded verdict, and it must not be gated on a
+# baseline. A baseline-shaped guard here can never fire, and previously meant a
+# non-empty baseline-command left the job green with no enforcement at all.
+enforce_steps="$(grep -c 'enforce-final-status.sh' "${WORKFLOW}")"
+[ "${enforce_steps}" -eq 1 ] || { printf 'FAIL: sharded Test must have exactly one enforcement step, got %s\n' "${enforce_steps}"; exit 1; }
+grep -A2 'name: Enforce sharded Test result' "${WORKFLOW}" | grep -qF "if: needs.candidate-test-result.result == 'success'" || { printf 'FAIL: sharded Test enforcement is not unconditional on the aggregate result\n'; exit 1; }
+grep -A2 'name: Enforce sharded Test result' "${WORKFLOW}" | grep -q 'baseline' && { printf 'FAIL: sharded Test enforcement is gated on a baseline that never runs\n'; exit 1; }
+
 # shellcheck disable=SC2016
 candidate_inventory_scopes="$(grep -A30 'name: Configure candidate Test shards' "${WORKFLOW}" | grep -F -c 'scope: ${{ inputs.scope }}')"
 [ "${candidate_inventory_scopes}" -eq 1 ] || { printf 'FAIL: candidate inventory planning must preserve caller scope, got %s calls\n' "${candidate_inventory_scopes}"; exit 1; }
-baseline_inventory_scopes="$(grep -A30 'name: Configure baseline Test shards' "${WORKFLOW}" | grep -c 'scope: full')"
-[ "${baseline_inventory_scopes}" -eq 1 ] || { printf 'FAIL: bootstrap baseline inventory must use full scope, got %s calls\n' "${baseline_inventory_scopes}"; exit 1; }
-replay_scopes="$(grep -A30 -E 'name: Run (candidate|baseline) Test shard' "${WORKFLOW}" | grep -c 'scope: full')"
-[ "${replay_scopes}" -eq 2 ] || { printf 'FAIL: candidate and baseline manifest replay must each use full scope, got %s calls\n' "${replay_scopes}"; exit 1; }
-if [ "$(grep -c 'scope: full' "${WORKFLOW}")" -ne 3 ]; then
-  printf 'FAIL: only bootstrap baseline inventory and immutable manifest replay may force full scope\n'; exit 1
+replay_scopes="$(grep -A30 -E 'name: Run candidate Test shard' "${WORKFLOW}" | grep -c 'scope: full')"
+[ "${replay_scopes}" -eq 1 ] || { printf 'FAIL: candidate manifest replay must use full scope, got %s calls\n' "${replay_scopes}"; exit 1; }
+if [ "$(grep -c 'scope: full' "${WORKFLOW}")" -ne 1 ]; then
+  printf 'FAIL: only immutable manifest replay may force full scope\n'; exit 1
 fi
 grep -F 'prepare-test-shard-workspace.sh prepare .homeboy-action' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate binary setup does not isolate the action checkout\n'; exit 1; }
 grep -F "steps.prepare-binary-workspace.outcome == 'success'" "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate binary setup does not always restore its exact Git exclusions\n'; exit 1; }
@@ -316,17 +324,7 @@ rm "${selection_dir}/review-test.json"
 if select_candidate_baseline pull_request true 'review test' >/dev/null 2>&1; then
   printf 'FAIL: missing canonical candidate shard result selected a baseline\n'; exit 1
 fi
-grep -F 'needs: [binary, plan, candidate-test-result]' "${WORKFLOW}" >/dev/null || { printf 'FAIL: baseline planning does not wait for canonical candidate selection\n'; exit 1; }
-grep -F "needs.candidate-test-result.outputs.baseline-command != ''" "${WORKFLOW}" >/dev/null || { printf 'FAIL: selected failing command does not enable baseline planning and replay\n'; exit 1; }
 # shellcheck disable=SC2016
 grep -F 'homeboy-candidate-test-results-${{ github.run_attempt }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: final Test does not consume canonical candidate results before reconciliation\n'; exit 1; }
-printf 'PASS: canonical candidate results select matching baseline attribution and fail closed when absent\n'
-# shellcheck disable=SC2016
-grep -F 'bootstrap-baseline-red: ${{ steps.bootstrap-baseline-red.outputs.value }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: baseline inventory failures are not classified for reconciliation\n'; exit 1; }
-# shellcheck disable=SC2016
-grep -F 'name: homeboy-baseline-test-inventory-failure-${{ github.run_attempt }}' "${WORKFLOW}" >/dev/null || { printf 'FAIL: classified baseline inventory failures are not retained as artifacts\n'; exit 1; }
-grep -F 'Test bootstrap_baseline_red: immutable baseline inventory failed' "${WORKFLOW}" >/dev/null || { printf 'FAIL: Test does not publish the baseline bootstrap warning\n'; exit 1; }
-grep -F "needs.baseline-test-plan.outputs.bootstrap-baseline-red == 'true'" "${WORKFLOW}" >/dev/null || { printf 'FAIL: Test does not restrict the nonblocking path to classified baseline inventory failures\n'; exit 1; }
-grep -F 'name: Enforce candidate Test result after bootstrap baseline red' "${WORKFLOW}" >/dev/null || { printf 'FAIL: bootstrap baseline warning can bypass candidate Test enforcement\n'; exit 1; }
-grep -F "needs.baseline-test-plan.result == 'success'" "${WORKFLOW}" >/dev/null || { printf 'FAIL: baseline shards can run without a successful baseline inventory plan\n'; exit 1; }
+printf 'PASS: canonical candidate result validation fails closed when the aggregate is absent\n'
 printf 'PASS: policy waits for sharded Test reconciliation while preserving unsharded behavior\n'

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -60,10 +60,10 @@ assert_not_contains 'gh release create' "${WORKFLOW}" "release workflow does not
 assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not parse changelog notes"
 
 # GitHub-hosted workflow dependencies must use Node 24-capable action majors (#321).
-assert_count 'actions/checkout@v6' '19' "${CI_WORKFLOW}" "reusable CI workflow uses checkout v6 for every checkout"
+assert_count 'actions/checkout@v6' '15' "${CI_WORKFLOW}" "reusable CI workflow uses checkout v6 for every checkout"
 assert_count 'actions/cache@v5' '3' "${CI_WORKFLOW}" "reusable CI workflow uses cache v5"
-assert_count 'actions/upload-artifact@v7' '10' "${CI_WORKFLOW}" "reusable CI workflow uses artifact upload v7"
-assert_count 'actions/download-artifact@v7' '10' "${CI_WORKFLOW}" "reusable CI workflow uses artifact download v7"
+assert_count 'actions/upload-artifact@v7' '7' "${CI_WORKFLOW}" "reusable CI workflow uses artifact upload v7"
+assert_count 'actions/download-artifact@v7' '6' "${CI_WORKFLOW}" "reusable CI workflow uses artifact download v7"
 assert_count 'actions/create-github-app-token@v3' '3' "${CI_WORKFLOW}" "reusable CI workflow uses app-token v3"
 assert_not_contains 'actions/checkout@v4' "${CI_WORKFLOW}" "reusable CI workflow has no checkout v4 references"
 assert_not_contains 'actions/cache@v4' "${CI_WORKFLOW}" "reusable CI workflow has no cache v4 references"


### PR DESCRIPTION
Follow-up to #376. That PR stopped the dead branch from *firing*; this one removes the dead branch.

## The sharded Test DAG has a baseline phase that has never executed

Traced end to end, not assumed:

| step | evidence |
|---|---|
| sharded path is opt-in | `test-shards` input defaults to `'1'` |
| only homeboy opts in | org-wide code search: the only other consumer, `Extra-Chill/data-machine`, passes neither `test-shards` nor `differential-gating` |
| homeboy disables the baseline | `baseline-commands: none` in its `ci.yml` |
| `none` short-circuits selection | `lib.sh:233` — `none\|false\|off\|''` → `return 1` |
| so no baseline is ever selected | `select-test-baseline.sh` emits `baseline-command=` (empty) |
| so both baseline jobs always skip | `baseline-test-plan` / `baseline-test-shards` gate on `baseline-command != ''` |

Timeline seals it: homeboy set `baseline-commands: none` on **2026-07-31**; sharding shipped **2026-08-04**. The sharded baseline phase has been unreachable since the day it was written.

**That dead surface is exactly where #10997 came from** — an unreachable-in-practice branch that fired on cancellation and published a red `Test` check with no verdict behind it.

## What this removes

- `baseline-test-plan` (119 lines) and `baseline-test-shards` (87 lines)
- 8 of the 13 steps in `reconcile-test-shards`, all baseline-gated
- the stale `baseline-test-shards` comment and the now-unconsumed `baseline-command` job output

**1341 → 1063 lines (-21%), 12 jobs → 10.** `reconcile-test-shards` goes from 13 steps to 6.

## It also closes a latent false green

The old enforcement step was gated on:

```yaml
if: ... && (needs.candidate-test-result.outputs.baseline-command == '' || github.event_name != 'pull_request')
```

If `baseline-command` were ever non-empty while the baseline jobs were absent, **no enforcement step would run at all** and the job would go green with nothing checked. Enforcement is now one step conditioned only on the candidate aggregate, and every reachable path above it either exits non-zero or falls through to it.

## What is deliberately kept

`select-test-baseline.sh` is **unchanged**. It is load-bearing for a different reason than its name suggests: it validates that the aggregated candidate result is a well-formed v3 command result with a valid status *before* anything enforces a verdict from it. Only its selection output is now unconsumed, and its unit tests still pin its behavior. Renaming it is churn I left out of this PR.

## Tests

Updated to the candidate-only contract — census counts drop by exactly half where the baseline twin was removed (nextest installs 4→2, runner/profile env 4→2, workspace prep 10→6, timeout passthrough 6→4, checkout 19→15, download-artifact 10→6, upload-artifact 10→7).

New assertions so the dead-branch class cannot grow back:
- `baseline-test-plan` / `baseline-test-shards` must stay absent
- no `homeboy-baseline-results` handling in the sharded path
- **exactly one** `enforce-final-status.sh` call
- that call must **not** be gated on a baseline

Full suite: **451 passed, 0 failed** (`scripts/run-tests.sh`, exit 0). Verified the two suite failures I hit mid-refactor were mine and not pre-existing by re-running them against a stashed pristine tree.

## Risk

Structural only — no behavior change on any path that currently executes. The one behavioral difference is in a path that could not previously produce a verdict at all.

Note this needs a release + repin in homeboy to take effect, and homeboy's pin must be `v<tag>^{commit}` — the tags here are annotated, and pinning the tag object breaks CI at startup (that is what #12153 in homeboy just fixed).

Refs Extra-Chill/homeboy#10997