### PR TITLE
Build sharded Rust tests once into a nextest archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,40 @@ jobs:
       - name: Install cargo-nextest for Rust shard planning
         if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
         uses: taiki-e/install-action@nextest
+      # Compile the test binaries ONCE, here, in the job that had to compile them
+      # anyway to enumerate tests.
+      #
+      # `nextest run -E <filter>` filters what EXECUTES, not what COMPILES, so
+      # with `--workspace` every shard rebuilt the entire workspace to run its own
+      # slice. Measured on Extra-Chill/homeboy shard-1: 7.8 minutes of compilation
+      # for a 4.046s run of 30 tests, repeated in all four shards plus here — five
+      # identical debug compiles per run.
+      #
+      # Not `continue-on-error`: a compile failure here is a real, terminal
+      # candidate failure, and the inventory step below cannot succeed without it.
+      - name: Build the candidate Test archive
+        id: test-archive
+        if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
+        env:
+          NEXTEST_PROFILE: ci
+        run: |
+          archive="${{ github.workspace }}/homeboy-test-archive.tar.zst"
+          cargo nextest archive --workspace --archive-file "${archive}"
+          echo "path=${archive}" >> "$GITHUB_OUTPUT"
+          # Surfaced because it is the variable that decides whether shipping the
+          # archive is cheaper than recompiling it: if transfer approaches the
+          # per-shard compile it replaces, this stops paying.
+          bytes="$(stat -c %s "${archive}")"
+          printf '## Candidate Test archive\n\n| Field | Value |\n| --- | --- |\n| Size | %s |\n| Shards served | %s |\n' \
+            "$(numfmt --to=iec --suffix=B "${bytes}")" "${{ inputs.test-shards }}" >> "${GITHUB_STEP_SUMMARY}"
+      - name: Upload the candidate Test archive
+        if: steps.test-archive.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: homeboy-test-archive-${{ github.run_attempt }}
+          path: ${{ steps.test-archive.outputs.path }}
+          retention-days: 1
+          if-no-files-found: error
       - name: Configure candidate Test shards
         id: inventory
         continue-on-error: true
@@ -664,6 +698,7 @@ jobs:
           HOMEBOY_TEST_INVENTORY_FILE: ${{ github.workspace }}/homeboy-test-inventory.json
           HOMEBOY_RUST_TEST_RUNNER: nextest
           HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
+          HOMEBOY_RUST_NEXTEST_ARCHIVE: ${{ steps.test-archive.outputs.path }}
           NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
         with:
@@ -769,6 +804,15 @@ jobs:
       - name: Install cargo-nextest for Rust shard replay
         if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
         uses: taiki-e/install-action@nextest
+      # Prebuilt by Plan candidate Test shards. Absent (non-Rust callers), the
+      # extension falls back to compiling the workspace exactly as before.
+      - name: Download the candidate Test archive
+        id: test-archive
+        if: inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''
+        uses: actions/download-artifact@v7
+        with:
+          name: homeboy-test-archive-${{ github.run_attempt }}
+          path: ${{ github.workspace }}/homeboy-test-archive
       - uses: actions/download-artifact@v7
         with:
           name: homeboy-test-shard-plan-${{ github.run_attempt }}
@@ -781,6 +825,7 @@ jobs:
           HOMEBOY_TEST_SHARD_MANIFEST: ${{ github.workspace }}/homeboy-test-shard.json
           HOMEBOY_RUST_TEST_RUNNER: nextest
           HOMEBOY_RUST_NEXTEST_FALLBACK: '0'
+          HOMEBOY_RUST_NEXTEST_ARCHIVE: ${{ steps.test-archive.outcome == 'success' && format('{0}/homeboy-test-archive/homeboy-test-archive.tar.zst', github.workspace) || '' }}
           NEXTEST_PROFILE: ci
         uses: ./.homeboy-action
         with:

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -236,8 +236,19 @@ fi
 if [ "$(grep -c "continue-on-error: true" "${WORKFLOW}")" -lt 6 ]; then
   printf 'FAIL: inventory planning transport is not isolated from normal Test verdict enforcement\n'; exit 1
 fi
-if [ "$(grep -c "HOMEBOY_RUST_NEXTEST_FALLBACK: '0'" "${WORKFLOW}")" -ne 2 ] || [ "$(grep -c 'NEXTEST_PROFILE: ci' "${WORKFLOW}")" -ne 2 ]; then
+# Three NEXTEST_PROFILE declarations, not two: the archive is BUILT with the
+# same profile the shards RUN with. A profile mismatch between build and replay
+# would silently change which binaries nextest produces versus expects.
+if [ "$(grep -c "HOMEBOY_RUST_NEXTEST_FALLBACK: '0'" "${WORKFLOW}")" -ne 2 ] || [ "$(grep -c 'NEXTEST_PROFILE: ci' "${WORKFLOW}")" -ne 3 ]; then
   printf 'FAIL: Rust shard jobs do not require nextest with the CI profile\n'; exit 1
+fi
+
+# The archive must be produced once and consumed by the shards. If either side
+# disappears, every shard silently reverts to a full-workspace compile -- the
+# 7.8-minutes-to-run-4-seconds shape this replaced (homeboy#10997).
+grep -F 'cargo nextest archive --workspace --archive-file' "${WORKFLOW}" >/dev/null || { printf 'FAIL: candidate Test shards are not built once into an archive\n'; exit 1; }
+if [ "$(grep -c 'HOMEBOY_RUST_NEXTEST_ARCHIVE' "${WORKFLOW}")" -ne 2 ]; then
+  printf 'FAIL: the Test archive is not both produced for inventory and consumed by shard replay\n'; exit 1
 fi
 if [ "$(grep -c 'HOMEBOY_RUST_TEST_RUNNER: nextest' "${WORKFLOW}")" -ne 2 ]; then
   printf 'FAIL: Rust shard jobs do not explicitly select nextest\n'; exit 1

--- a/scripts/release/test-release-workflow.sh
+++ b/scripts/release/test-release-workflow.sh
@@ -62,8 +62,8 @@ assert_not_contains 'docs/CHANGELOG.md' "${WORKFLOW}" "release workflow does not
 # GitHub-hosted workflow dependencies must use Node 24-capable action majors (#321).
 assert_count 'actions/checkout@v6' '15' "${CI_WORKFLOW}" "reusable CI workflow uses checkout v6 for every checkout"
 assert_count 'actions/cache@v5' '3' "${CI_WORKFLOW}" "reusable CI workflow uses cache v5"
-assert_count 'actions/upload-artifact@v7' '7' "${CI_WORKFLOW}" "reusable CI workflow uses artifact upload v7"
-assert_count 'actions/download-artifact@v7' '6' "${CI_WORKFLOW}" "reusable CI workflow uses artifact download v7"
+assert_count 'actions/upload-artifact@v7' '8' "${CI_WORKFLOW}" "reusable CI workflow uses artifact upload v7"
+assert_count 'actions/download-artifact@v7' '7' "${CI_WORKFLOW}" "reusable CI workflow uses artifact download v7"
 assert_count 'actions/create-github-app-token@v3' '3' "${CI_WORKFLOW}" "reusable CI workflow uses app-token v3"
 assert_not_contains 'actions/checkout@v4' "${CI_WORKFLOW}" "reusable CI workflow has no checkout v4 references"
 assert_not_contains 'actions/cache@v4' "${CI_WORKFLOW}" "reusable CI workflow has no cache v4 references"


### PR DESCRIPTION
Producer half of the compile-prefix work. Pairs with Extra-Chill/homeboy-extensions#2603 (merged), which added the consumer side.

## The problem

`nextest run -E <filter>` filters what **executes**, not what **compiles**. With `--workspace`, every shard rebuilt the entire workspace to run its own slice.

Extra-Chill/homeboy run `31570203797`, shard-1:

```
06:58:00  ./.homeboy-action starts
          ...7.8 minutes of silence...
07:06:12  Starting 30 tests across 2 binaries (4702 tests and 76 binaries skipped)
07:06:16  Summary [4.046s] 30 tests run: 30 passed
```

**7.8 minutes of compilation for 4 seconds of tests** — repeated in all four shards, plus once more in `Plan candidate Test shards` for the inventory. **Five identical full-workspace debug compiles per run.**

Sharding was splitting the part that takes seconds and duplicating the part that takes minutes, so *raising* the shard count made the gate slower.

The `binary` job's cargo cache cannot help: it builds `--release`, tests need `debug`.

## The change

`Plan candidate Test shards` already had to compile everything to enumerate tests, so it now emits `cargo nextest archive` and publishes it. The inventory step and all four shards consume it via `HOMEBOY_RUST_NEXTEST_ARCHIVE`, making listing and replay execution-only.

Estimated critical path: **~32.5m → ~23m**. It also makes shard count meaningful for the first time — more shards now divide real work instead of multiplying compiles.

## Details worth reviewing

- **Profile pinned.** The archive is built with `NEXTEST_PROFILE: ci`, the profile shards run with. A mismatch would change which binaries are produced versus expected. That is why the `NEXTEST_PROFILE: ci` count in the test contract goes 2 → 3.
- **Not `continue-on-error`.** A compile failure during archiving is a terminal candidate failure, and the inventory step cannot succeed without it. Letting it continue would produce a confusing downstream inventory error instead of the real compile error.
- **Non-Rust callers unaffected.** Both new steps carry the existing `inputs.auto-setup == 'true' && hashFiles('Cargo.toml') != ''` gate; without an archive the extension compiles exactly as before.

## The open question — deliberately instrumented, not assumed

**I have not measured the archive size.** 78 debug test binaries with debuginfo could be multiple GB, and artifact upload + 4× download is not free. If transfer approaches the ~8 minute per-shard compile it replaces, this stops paying.

Rather than guess, the archive step writes its size to the step summary. **The first real run on homeboy will tell us**, and the timings are directly comparable to the numbers above. If it is too large, the follow-up is stripping debuginfo from the archived profile.

I could not measure it locally: building the full test archive is the ~28G `cargo test --no-run` step, and this host has 35G free, which would leave it under its own safety floor.

## Tests

New contract assertions in `test-test-shards.sh`: the archive must be produced once and consumed, and `HOMEBOY_RUST_NEXTEST_ARCHIVE` must appear on both sides — if either disappears, every shard silently reverts to a full compile.

Full suite: **451 passed, 0 failed**.

Refs Extra-Chill/homeboy#10997