### PR TITLE
Skip the differential baseline when the candidate passed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -610,6 +610,9 @@ runs:
         COMPONENT_NAME: ${{ inputs.component }}
         EXTRA_ARGS: ${{ inputs.args }}
         BASELINE_COMMANDS: ${{ inputs.baseline-commands }}
+        # A baseline can only excuse a FAILING candidate, so commands whose
+        # candidate already passed skip theirs (homeboy#11751 W1-10).
+        CANDIDATE_RESULTS: ${{ steps.run-commands.outputs.results }}
         HOMEBOY_DIFFERENTIAL_GATING: ${{ inputs.differential-gating }}
         RUN_GROUP_PREFIX: homeboy baseline
         HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS: ${{ inputs.execution-timeout-seconds }}

--- a/scripts/core/run-baseline-commands.sh
+++ b/scripts/core/run-baseline-commands.sh
@@ -23,20 +23,53 @@ if [ -n "${TRACKED_DIRTY}" ]; then
   exit 0
 fi
 
+# A baseline exists to excuse the candidate for breakage that predates it. When
+# the candidate PASSED there is nothing to excuse: no baseline result can change
+# a passing verdict, so rerunning the whole command at the base ref buys nothing.
+#
+# It was being rerun unconditionally. Measured on Extra-Chill/homeboy, the Audit
+# baseline is 684s and the Lint baseline 110s -- Lint's real work is 137s, so its
+# baseline was +80% for no verdict (homeboy#11751 W1-10).
+#
+# `select-test-baseline.sh` already makes exactly this decision for the sharded
+# Test path; this brings the unsharded audit/lint path in line with it.
+#
+# Fail-safe: an absent or unparseable CANDIDATE_RESULTS keeps every baseline, so
+# a caller that does not supply candidate status is never silently degraded into
+# skipping the comparison.
+candidate_status() {
+  local cmd="$1"
+  [ -n "${CANDIDATE_RESULTS:-}" ] || { printf 'unknown'; return; }
+  printf '%s' "${CANDIDATE_RESULTS}" | jq -r --arg cmd "${cmd}" '.[$cmd] // "unknown"' 2>/dev/null || printf 'unknown'
+}
+
 BASELINE_RUN_COMMANDS=()
+SKIPPED_PASSING_COMMANDS=()
 ORDERED_COMMANDS="$(resolve_baseline_commands "${EFFECTIVE_COMMANDS}" "${BASELINE_COMMANDS_INPUT}")"
 IFS=',' read -ra CMD_ARRAY <<< "${ORDERED_COMMANDS}"
 for CMD in "${CMD_ARRAY[@]}"; do
   CMD="$(echo "${CMD}" | xargs)"
   case "$(quality_base_command "${CMD}")" in
     audit|lint|test)
+      if [ "$(candidate_status "${CMD}")" = pass ]; then
+        SKIPPED_PASSING_COMMANDS+=("${CMD}")
+        continue
+      fi
       BASELINE_RUN_COMMANDS+=("${CMD}")
       ;;
   esac
 done
 
+if [ "${#SKIPPED_PASSING_COMMANDS[@]}" -gt 0 ]; then
+  echo "Candidate passed ${SKIPPED_PASSING_COMMANDS[*]}; skipping their baseline runs (a baseline cannot change a passing verdict)"
+fi
+
 if [ "${#BASELINE_RUN_COMMANDS[@]}" -eq 0 ]; then
-  echo "No audit/lint/test commands requested; skipping differential baseline run"
+  if [ "${#SKIPPED_PASSING_COMMANDS[@]}" -gt 0 ]; then
+    echo "Every requested command passed on the candidate; no baseline comparison is needed"
+  else
+    echo "No audit/lint/test commands requested; skipping differential baseline run"
+  fi
   exit 0
 fi
 

--- a/scripts/core/test-run-baseline-commands.sh
+++ b/scripts/core/test-run-baseline-commands.sh
@@ -53,7 +53,8 @@ git checkout -qb feature
 run_baseline() {
   local mode="$1"
   local log_file="$2"
-  local env_file="${TMP_DIR}/github-env-${mode}"
+  local label="${3:-${mode}}"
+  local env_file="${TMP_DIR}/github-env-${label}"
 
   set +e
   PATH="${TMP_DIR}/bin:${PATH}" \
@@ -63,6 +64,7 @@ run_baseline() {
   COMMANDS='review test' \
   COMPONENT_NAME='fixture' \
   BASELINE_COMMANDS='auto' \
+  CANDIDATE_RESULTS="${CANDIDATE_RESULTS_FIXTURE:-}" \
   HOMEBOY_DIFFERENTIAL_GATING=true \
   SCOPE_CONTEXT=pr \
   SCOPE_BASE_REF=main \
@@ -70,7 +72,7 @@ run_baseline() {
   HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS=1 \
   RUN_GROUP_PREFIX='baseline test' \
   FAKE_HOMEBOY_MODE="${mode}" \
-  FAKE_HOMEBOY_CHILD_PID_FILE="${TMP_DIR}/child-${mode}.pid" \
+  FAKE_HOMEBOY_CHILD_PID_FILE="${TMP_DIR}/child-${label}.pid" \
   bash "${RUNNER}" >"${log_file}" 2>&1
   local exit_code=$?
   set -e
@@ -127,3 +129,59 @@ for output_mode in missing malformed; do
   fi
 done
 printf 'PASS: zero-exit baseline missing and malformed structured output fail closed\n'
+
+# A baseline exists to excuse a FAILING candidate. When the candidate passed,
+# rerunning the whole command at the base ref cannot change the verdict. It was
+# unconditional: on Extra-Chill/homeboy the Audit baseline is 684s and Lint's is
+# 110s against 137s of real work (homeboy#11751 W1-10).
+passing_log="${TMP_DIR}/candidate-passed.log"
+set +e
+PATH="${TMP_DIR}/bin:${PATH}" \
+GITHUB_ACTION_PATH="${ROOT_DIR}" \
+GITHUB_WORKSPACE="${TMP_DIR}/workspace" \
+GITHUB_ENV="${TMP_DIR}/github-env-passing" \
+COMMANDS='review test' \
+COMPONENT_NAME='fixture' \
+BASELINE_COMMANDS='auto' \
+CANDIDATE_RESULTS='{"review test":"pass"}' \
+HOMEBOY_DIFFERENTIAL_GATING=true \
+SCOPE_CONTEXT=pr \
+SCOPE_BASE_REF=main \
+RUN_GROUP_PREFIX='baseline test' \
+FAKE_HOMEBOY_MODE=success \
+bash "${RUNNER}" >"${passing_log}" 2>&1
+passing_exit=$?
+set -e
+if [ "${passing_exit}" -ne 0 ]; then
+  printf 'FAIL: skipping a passing baseline must still exit 0, got %s\n' "${passing_exit}"
+  exit 1
+fi
+if ! grep -q 'Every requested command passed on the candidate' "${passing_log}"; then
+  printf 'FAIL: a passing candidate still reran its baseline\n'
+  exit 1
+fi
+if grep -q 'Running baseline' "${passing_log}"; then
+  printf 'FAIL: a passing candidate executed a baseline command\n'
+  exit 1
+fi
+printf 'PASS: a passing candidate skips its baseline run\n'
+
+# Failing, timed-out and unrecorded candidates are exactly what a differential
+# comparison exists to adjudicate, so each must still run its baseline. An absent
+# CANDIDATE_RESULTS is the fail-safe: keep every baseline rather than silently
+# skipping the comparison.
+run_expecting_baseline() {
+  local label="$1"
+  local fixture="$2"
+  local dir
+  dir="$(CANDIDATE_RESULTS_FIXTURE="${fixture}" run_baseline success "${TMP_DIR}/${label}.log" "${label}")"
+  if ! jq -e '."review test" | .status == "pass"' "${dir}/baseline-status.json" >/dev/null; then
+    printf 'FAIL: %s did not run its baseline\n' "${label}"
+    exit 1
+  fi
+}
+run_expecting_baseline candidate-fail '{"review test":"fail"}'
+run_expecting_baseline candidate-timeout '{"review test":"timeout"}'
+run_expecting_baseline candidate-other-command '{"review lint":"pass"}'
+run_expecting_baseline candidate-absent ''
+printf 'PASS: failing, timed-out, unrecorded and absent candidate results all run their baseline\n'

--- a/scripts/core/test-run-with-liveness-timeout.sh
+++ b/scripts/core/test-run-with-liveness-timeout.sh
@@ -224,11 +224,14 @@ if grep -q 'run-with-liveness-timeout.sh.*| tee' "${ROOT_DIR}/scripts/core/run-b
   printf 'FAIL: baseline command finalization still depends on an unbounded tee pipeline\n'
   exit 1
 fi
-if ! grep -A18 'name: Run baseline Homeboy commands' "${ACTION}" | grep -q 'HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS:'; then
+# Window is sized to span the step's whole `env:` block, not a fixed offset: the
+# assertion is that the timeout reaches the baseline step, not where in the block
+# it sits.
+if ! grep -A26 'name: Run baseline Homeboy commands' "${ACTION}" | grep -q 'HOMEBOY_ACTION_EXECUTION_TIMEOUT_SECONDS:'; then
   printf 'FAIL: baseline commands do not receive the execution timeout input\n'
   exit 1
 fi
-if ! grep -A18 'name: Run baseline Homeboy commands' "${ACTION}" | grep -q 'HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS:'; then
+if ! grep -A26 'name: Run baseline Homeboy commands' "${ACTION}" | grep -q 'HOMEBOY_ACTION_CLEANUP_TIMEOUT_SECONDS:'; then
   printf 'FAIL: baseline commands do not receive the cleanup timeout input\n'
   exit 1
 fi


### PR DESCRIPTION
Extra-Chill/homeboy#11751 **W1-10**: *"baseline reruns are unconditional. `run-baseline-commands.sh` has no 'only if the candidate failed' guard."*

## Why this is free

A baseline exists to excuse the candidate for breakage that **predates** it. If the candidate **passed**, there is nothing to excuse — no baseline result can turn a passing verdict into anything else. The rerun was pure cost.

Measured on Extra-Chill/homeboy:

| | duration |
|---|---|
| Audit baseline | **684s** |
| Lint baseline | 110s (against 137s of real work — **+80%**) |

Audit's log shows it plainly — `command_execution` runs `06:43:11 → 06:55:18`, then starts **again** at `06:55:21`.

## Precedent in this repo

`select-test-baseline.sh` already makes exactly this decision for the **sharded** Test path:

```bash
if [ "${status}" = pass ] || ... ; then
  echo 'baseline-command=' >> "${GITHUB_OUTPUT}"
```

The unsharded audit/lint path never got the same treatment. This aligns them.

## Fail-safe by construction

- **Absent or unparseable `CANDIDATE_RESULTS` keeps every baseline.** A caller that does not supply candidate status is never silently degraded into skipping the comparison.
- **Failing, timed-out and unrecorded commands still run their baseline** — those are precisely the cases a differential comparison exists to adjudicate.

Only a recorded `pass` skips.

## Two incidental corrections

- The early-exit message said *"No audit/lint/test commands requested"* in a case where commands **were** requested and had simply all passed. It now distinguishes the two, because they are different facts.
- `test-run-with-liveness-timeout.sh` asserted the timeout env vars using a fixed `grep -A18` window on the baseline step, which broke when its `env:` block grew by three lines. Widened to span the block — the assertion is that the timeouts *reach* the step, not where in the block they sit. Flagging this because loosening an assertion deserves a second look.

## Tests

New coverage in `test-run-baseline-commands.sh`:
- a passing candidate skips its baseline, exits 0, and executes no baseline command
- failing, timed-out, unrecorded and **absent** candidate results all still run theirs

Full suite: **453 passed, 0 failed** (up from 451).

Refs Extra-Chill/homeboy#11751