### PR TITLE
Scope the differential audit to changed files (reverses a pinned decision — needs your call)

### DIFF
--- a/scripts/core/test-command-builders.sh
+++ b/scripts/core/test-command-builders.sh
@@ -218,10 +218,18 @@ assert_equals \
   "audit flags route after component through review"
 
 HOMEBOY_DIFFERENTIAL_GATING="true"
+# Reverses the assertion added with differential gating in #153 (7e1fd83), which
+# held that a full-scope run on both candidate and base would be diffed into a
+# clean verdict. Measured on Extra-Chill/homeboy, the premise does not hold: the
+# base is red too, so both sides fail and the gate downgrades to `baseline_red`
+# -- 32.7 minutes to publish a green check carrying no verdict (#11751 W1-2).
+#
+# `test` keeps the exemption; its scope rides the extension's
+# HOMEBOY_TEST_SCOPE_* contract rather than a CLI flag.
 assert_equals \
-  "homeboy review audit data-machine --path /tmp/workspace" \
+  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "audit" "${COMPONENT}" "${WORKSPACE}")" \
-  "differential audit uses full scope"
+  "differential audit is changed-scoped"
 
 assert_equals \
   "homeboy review test data-machine --path /tmp/workspace" \
@@ -234,9 +242,9 @@ assert_equals \
   "differential lint keeps changed scope"
 
 assert_equals \
-  "homeboy review audit data-machine --path /tmp/workspace" \
+  "homeboy review audit data-machine --path /tmp/workspace --changed-since origin/main" \
   "$(build_run_command "review audit" "${COMPONENT}" "${WORKSPACE}")" \
-  "differential review audit uses full scope"
+  "differential review audit is changed-scoped"
 
 assert_equals \
   "homeboy review test data-machine --path /tmp/workspace" \

--- a/scripts/scope/flags.sh
+++ b/scripts/scope/flags.sh
@@ -24,13 +24,30 @@ scope_flags_for() {
   fi
 
   case "${base_cmd}" in
-    audit|test)
+    # `test` alone is exempt under differential gating: its scope is carried by
+    # the extension's own HOMEBOY_TEST_SCOPE_* contract, not by a CLI flag, so
+    # adding `--changed-since` here would double-scope it.
+    test)
       if [ "${HOMEBOY_DIFFERENTIAL_GATING:-false}" = "true" ]; then
         return
       fi
       printf '%s' "--changed-since ${SCOPE_BASE_REF}"
       ;;
-    audit|lint|test|refactor|review)
+    # `audit` was in the exempt arm above, so under differential gating it ran
+    # UNSCOPED over the whole repository. Measured on Extra-Chill/homeboy: 12m07s
+    # to report `DRIFT INCREASED: 445 new finding(s) since baseline`, exit 1,
+    # then a 684s baseline rerun that failed identically, so the gate excused it
+    # as `baseline_red` and published green. 32.7 minutes for no verdict
+    # (homeboy#11751 W1-2).
+    #
+    # A differential baseline is not a substitute for scoping here: `review
+    # audit` already computes introduced-versus-contextual findings from
+    # `--changed-since` itself, which answers "did this PR add a finding" without
+    # rerunning the whole audit at the base ref.
+    #
+    # `audit` and `test` also appeared in the arm below, where they were dead:
+    # `case` takes the first matching arm, so those patterns never applied.
+    audit|lint|refactor|review)
       printf '%s' "--changed-since ${SCOPE_BASE_REF}"
       ;;
     # release, fleet, deploy, and other commands are never scoped

--- a/scripts/scope/test-resolve.sh
+++ b/scripts/scope/test-resolve.sh
@@ -50,4 +50,46 @@ env_file="$(run_resolve env GITHUB_EVENT_NAME=pull_request SCOPE_INPUT=auto BASE
 assert_env_contains "${env_file}" "SCOPE_MODE=changed" "auto PR uses changed scope"
 assert_env_contains "${env_file}" "SCOPE_BASE_REF=${base_sha}" "auto PR records base ref"
 
+# --- scope_flags_for -------------------------------------------------------
+#
+# `audit` used to share the differential-gating exemption with `test`, so under
+# gating it ran unscoped over the whole repository: 12m07s to report 445 findings
+# and exit 1, then a 684s baseline rerun that failed identically and downgraded
+# the verdict to `baseline_red` (homeboy#11751 W1-2).
+
+assert_flags() {
+  local cmd="$1" gating="$2" expected="$3" label="$4" actual
+  actual="$(
+    SCOPE_MODE=changed SCOPE_BASE_REF=origin/main HOMEBOY_DIFFERENTIAL_GATING="${gating}" \
+    bash -c "source '${SCRIPT_DIR}/flags.sh'; scope_flags_for '${cmd}'"
+  )"
+  if [ "${actual}" != "${expected}" ]; then
+    printf 'FAIL: %s (expected %s, got %s)\n' "${label}" "'${expected}'" "'${actual}'"
+    exit 1
+  fi
+  printf 'PASS: %s\n' "${label}"
+}
+
+assert_flags audit true '--changed-since origin/main' 'audit is scoped under differential gating'
+assert_flags audit false '--changed-since origin/main' 'audit is scoped without differential gating'
+assert_flags lint true '--changed-since origin/main' 'lint stays scoped under differential gating'
+assert_flags refactor true '--changed-since origin/main' 'refactor stays scoped'
+assert_flags review true '--changed-since origin/main' 'review stays scoped'
+
+# `test` keeps the exemption: its scope travels in the extension's
+# HOMEBOY_TEST_SCOPE_* contract, so a CLI flag would double-scope it.
+assert_flags test true '' 'test remains exempt under differential gating'
+assert_flags test false '--changed-since origin/main' 'test is scoped without differential gating'
+
+# Never-scoped commands must stay unscoped regardless of gating.
+assert_flags release true '' 'release is never scoped'
+assert_flags deploy true '' 'deploy is never scoped'
+
+# Nothing is scoped when there is no changed scope to apply.
+no_scope="$(SCOPE_MODE=full SCOPE_BASE_REF=origin/main bash -c "source '${SCRIPT_DIR}/flags.sh'; scope_flags_for audit")"
+[ -z "${no_scope}" ] || { printf 'FAIL: full scope must not emit --changed-since, got %s\n' "${no_scope}"; exit 1; }
+missing_base="$(SCOPE_MODE=changed SCOPE_BASE_REF= bash -c "source '${SCRIPT_DIR}/flags.sh'; scope_flags_for audit")"
+[ -z "${missing_base}" ] || { printf 'FAIL: absent base ref must not emit --changed-since, got %s\n' "${missing_base}"; exit 1; }
+printf 'PASS: no changed scope emits no flag\n'
+
 printf 'All scope resolver checks passed.\n'


### PR DESCRIPTION
Extra-Chill/homeboy#11751 **W1-2**: *"`Audit` is 34.5 min producing `no_measurement`. It is the longest job in CI and yields zero information on every PR."*

> **This reverses a deliberate, test-pinned design decision.** I am not merging it on my own judgement. Read the tradeoff below and decide.

## What was decided, and why

#153 (`7e1fd83`, 2026-04-27, *"feat(ci): add opt-in differential gating"*) exempted `audit` and `test` from `--changed-since` under differential gating:

```bash
audit|test)
  if [ "${HOMEBOY_DIFFERENTIAL_GATING:-false}" = "true" ]; then
    return
  fi
```

The premise is coherent: run **full scope** on both candidate and base, then diff them. Full comparison, pre-existing findings excused by the diff. Two tests pin it — `differential audit uses full scope` and `differential review audit uses full scope`.

## Why the premise no longer holds

Audit job `94030650063` on Extra-Chill/homeboy:

```
dependency_build_setup   629s    building the CLI from source
command_execution        727s    candidate audit, full repository
command_execution       ~600s    the SAME audit again, at the base ref
[audit] DRIFT INCREASED: 445 new finding(s) since baseline
##[error]homeboy review audit: FAILED (exit code 1)
RESULTS: {"review audit":"baseline_red"}
```

**The diff cannot produce a clean verdict while the base is also red — and the base is red.** Both sides fail, the gate downgrades to `baseline_red`, which is non-blocking, and the job publishes **green**.

**32.7 minutes — the most expensive job in CI — to say nothing.** The 445 findings are real signal, and they are discarded.

## Why `--changed-since` is the right answer, not a workaround

`review audit` already computes exactly what a reviewer needs. From `homeboy-code-audit/src/run.rs`:

```
[audit] DRIFT INCREASED: N introduced finding(s) since baseline (M contextual finding(s) already known in touched scope)
```

`build_changed_since_summary` separates **introduced** findings from **contextual** ones already present in the touched scope. That answers *"did this PR add a finding"* without rerunning the whole audit at the base ref. It is purpose-built and currently unused on this path.

Combined with #379 (merged), a passing candidate audit now also skips its baseline entirely — so Audit should go from 32.7 min to a few minutes **and** start producing a real verdict.

## The tradeoff you are accepting

A finding introduced **outside** the changed files stops being caught by the PR gate. Today it is nominally caught — and then discarded as `baseline_red`, so the practical loss is smaller than it looks. But it is a real narrowing, and it is your call, not mine.

If you would rather keep full-scope audit, the alternative in the epic is moving Audit to the weekly schedule until the 445 findings are burned down.

## Scope

- `test` **keeps** the exemption — its scope rides the extension's `HOMEBOY_TEST_SCOPE_*` contract, so a CLI flag would double-scope it.
- Also removes `audit`/`test` from the second `case` arm, where they were **unreachable** (`case` takes the first matching arm). No behaviour change; that dead code is what made the intent hard to read.

## Tests

Both pinned assertions updated to the new contract, each carrying the reversal rationale inline so the next reader sees the decision rather than a bare expectation flip.

New `scope_flags_for` coverage in `scripts/scope/test-resolve.sh`: audit scoped with and without gating, lint/refactor/review unchanged, `test` still exempt under gating, release/deploy never scoped, and no flag when there is no changed scope or no base ref.

Full suite: **463 passed, 0 failed**.

Refs Extra-Chill/homeboy#11751