### PR TITLE
Pin the durationless shard partitioning CI actually uses

### DIFF
--- a/scripts/core/shard-tests.sh
+++ b/scripts/core/shard-tests.sh
@@ -9,6 +9,24 @@ source "${SCRIPT_DIR}/lib.sh"
 fail() { echo "::error::$1" >&2; exit 1; }
 digest() { printf '%s' "$1" | shasum -a 256 | awk '{print $1}'; }
 
+# Partitioning is longest-processing-time bin packing over `duration_ms`.
+#
+# In production every test weighs the same. `duration_ms` is OPTIONAL in
+# homeboy/test-inventory/v1 and no shipped producer emits it -- the Rust
+# extension's `test-shard-inventory.py` builds its inventory from
+# `cargo nextest list`, which enumerates tests without running them and so has no
+# timings to report. Nothing sets TEST_SHARD_UNKNOWN_DURATION_MS either, so every
+# test takes the 60000 default and LPT degenerates to equal-count partitioning.
+#
+# That is fine, and measuring it is why this comment exists rather than a fix.
+# Across recent Extra-Chill/homeboy runs the four shards average 9.0-9.3 min --
+# a 3% spread, and that still included per-shard compilation. Real timings could
+# not recover more than a rounding error, so feeding them in is not worth the
+# artifact plumbing it would take to carry durations between runs.
+#
+# The LPT path stays because it is correct and already covered: an inventory that
+# does carry durations is balanced by weight, so a future producer can supply
+# them without a rewrite. See homeboy#11751 W1-7.
 plan() {
   local inventory="${TEST_INVENTORY_FILE:?TEST_INVENTORY_FILE is required}"
   local output="${TEST_SHARD_PLAN_FILE:?TEST_SHARD_PLAN_FILE is required}"

--- a/scripts/core/test-test-shards.sh
+++ b/scripts/core/test-test-shards.sh
@@ -124,6 +124,32 @@ TEST_INVENTORY_FILE="${tmp}/base-inventory.json" TEST_SHARD_PLAN_FILE="${tmp}/ba
 [ "$(jq -r .plan_digest "${tmp}/one.json")" != "$(jq -r .plan_digest "${tmp}/base-plan.json")" ] || { printf 'FAIL: candidate and baseline inventories must produce distinct plans\n'; exit 1; }
 printf 'PASS: deterministic duration-balanced plan has exact membership\n'
 
+# The shape production actually emits. `cargo nextest list` enumerates tests
+# without running them, so the Rust extension's inventory carries NO duration_ms
+# on any test and LPT falls back to the shared default -- i.e. equal-count
+# partitioning. Every existing plan fixture above carries durations, so the one
+# path CI always takes was untested (homeboy#11751 W1-7).
+jq -n '{schema:"homeboy/test-inventory/v1",runner:"fixture",runner_fingerprint:"runner-a",workspace_fingerprint:"workspace-a",inventory_fingerprint:"durationless-a",tests:[range(0; 40) | {id:("test-" + tostring)}]}' > "${tmp}/durationless-inventory.json"
+TEST_INVENTORY_FILE="${tmp}/durationless-inventory.json" TEST_SHARD_PLAN_FILE="${tmp}/durationless-plan.json" TEST_SHARD_COUNT=4 bash "${ROOT}/scripts/core/shard-tests.sh" plan
+jq -e '[.shards[].tests | length] | (unique | length) == 1 and .[0] == 10' "${tmp}/durationless-plan.json" >/dev/null || {
+  printf 'FAIL: an inventory without durations must partition into equal counts\n'; exit 1; }
+jq -e '[.shards[].tests[]] | (length == 40) and ((unique | length) == 40)' "${tmp}/durationless-plan.json" >/dev/null || {
+  printf 'FAIL: durationless partitioning lost or duplicated tests\n'; exit 1; }
+# Determinism matters more than balance here: the manifest fingerprints that
+# gate shard replay are computed from membership.
+TEST_INVENTORY_FILE="${tmp}/durationless-inventory.json" TEST_SHARD_PLAN_FILE="${tmp}/durationless-plan-2.json" TEST_SHARD_COUNT=4 bash "${ROOT}/scripts/core/shard-tests.sh" plan
+[ "$(jq -r .plan_digest "${tmp}/durationless-plan.json")" = "$(jq -r .plan_digest "${tmp}/durationless-plan-2.json")" ] || {
+  printf 'FAIL: durationless partitioning is not deterministic\n'; exit 1; }
+printf 'PASS: an inventory without durations partitions into deterministic equal counts\n'
+
+# Forward compatibility: if a producer ever does emit durations, weight must beat
+# count, so the LPT path is not quietly dead code.
+jq -n '{schema:"homeboy/test-inventory/v1",runner:"fixture",runner_fingerprint:"runner-a",workspace_fingerprint:"workspace-a",inventory_fingerprint:"weighted-a",tests:[{id:"heavy",duration_ms:10000},{id:"light-1",duration_ms:100},{id:"light-2",duration_ms:100},{id:"light-3",duration_ms:100}]}' > "${tmp}/weighted-inventory.json"
+TEST_INVENTORY_FILE="${tmp}/weighted-inventory.json" TEST_SHARD_PLAN_FILE="${tmp}/weighted-plan.json" TEST_SHARD_COUNT=2 bash "${ROOT}/scripts/core/shard-tests.sh" plan
+jq -e '[.shards[] | select(.tests == ["heavy"])] | length == 1' "${tmp}/weighted-plan.json" >/dev/null || {
+  printf 'FAIL: a duration-bearing inventory must isolate the heavy test rather than split by count\n'; exit 1; }
+printf 'PASS: duration-bearing inventories still balance by weight, not count\n'
+
 plan_digest="$(jq -r .plan_digest "${tmp}/one.json")"
 inventory_digest="$(jq -r .inventory_digest "${tmp}/one.json")"
 shard_manifest="${tmp}/shard-1.json"


### PR DESCRIPTION
Extra-Chill/homeboy#11751 **W1-7**. Two claims in that item; one is already banked and the other should be measured before it is built.

## Banked: the 8.5-minute inventory

W1-7 estimates *-8.5 min serial* from caching the inventory. That is already paid — **#378** stopped `nextest list` from compiling the workspace, and `Configure candidate Test shards` fell from **~9.5 min → 1m06s**:

```
Build the candidate Test archive       8m53s
Upload the candidate Test archive      2m17s
Configure candidate Test shards        1m06s   <- was ~9.5m
```

No caching work needed.

## Confirmed but not worth fixing: the duration-blind planner

W1-7 is right that partitioning is duration-blind, and for the reason it gives:

- `duration_ms` is **optional** in `homeboy/test-inventory/v1` and **no shipped producer emits it** — `cargo nextest list` enumerates tests without running them, so it has no timings to report
- nothing sets `TEST_SHARD_UNKNOWN_DURATION_MS`, so every test takes the `60000` default
- LPT therefore degenerates to equal-count partitioning

**But the imbalance it would fix does not exist.** Across recent Extra-Chill/homeboy runs:

| shard | mean |
|---|---|
| shard-1 | 9.3m |
| shard-2 | 9.3m |
| shard-3 | 9.0m |
| shard-4 | 9.1m |

A **3% spread** — and that still included per-shard compilation, which #378 has since removed. The epic's own figures agree (392–394 tests in 96–103s). Real timings could not recover more than a rounding error, and getting them would mean carrying per-test durations between runs as an artifact.

So this PR does not build that. It records the measurement in the code so the next person does not build it either.

## What it does change

**Adds coverage for the only shape production emits.** Every existing plan fixture carries `duration_ms`, so the path CI takes on every single run was **completely untested**. Now pinned:

- a durationless inventory partitions into **equal counts**
- it loses and duplicates nothing
- it is **deterministic** — this one matters most, because the manifest fingerprints that gate shard replay are computed from membership

**Plus the forward-compatible case**, so the LPT path is not quietly dead code: a duration-bearing inventory isolates a heavy test rather than splitting by count. If a producer ever does emit durations, weight still beats count without a rewrite.

Full suite: **455 passed, 0 failed**.

Refs Extra-Chill/homeboy#11751