### PR TITLE
feat(ci): expose the changed-scope test selection cap as a workflow input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,10 @@ on:
         description: 'Optional number of deterministic Test shards. Values above one require the Homeboy test inventory contract.'
         type: string
         default: '1'
+      max-changed-test-files:
+        description: 'Optional cap on the number of changed-scope test files Homeboy may select for a Test phase. Positive integers enable the guard; empty disables it and leaves behaviour unchanged.'
+        type: string
+        default: ''
       cleanup-timeout-seconds:
         description: 'Maximum wall-clock time to terminate command descendants.'
         type: string
@@ -460,6 +464,8 @@ jobs:
       - name: Run candidate ${{ matrix.title }}
         id: phase
         continue-on-error: true
+        env:
+          HOMEBOY_MAX_CHANGED_TEST_FILES: ${{ inputs.max-changed-test-files }}
         uses: ./.homeboy-action
         with:
           version: ${{ inputs.version }}
@@ -574,6 +580,8 @@ jobs:
         id: phase
         if: matrix.baseline == 'true'
         continue-on-error: true
+        env:
+          HOMEBOY_MAX_CHANGED_TEST_FILES: ${{ inputs.max-changed-test-files }}
         uses: ./.homeboy-action
         with:
           version: ${{ inputs.version }}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ the selected extension writes `homeboy-test-inventory.json` with schema
 `homeboy/test-inventory/v1`, stable test IDs, and optional `duration_ms` values.
 Each shard then receives a digest-bound `HOMEBOY_TEST_SHARD_MANIFEST`.
 
+Changed-scope resolution can map a tiny diff onto a huge test-file selection.
+Set `max-changed-test-files` to a positive integer to cap how many test files
+Homeboy may select before the Test phase runs; an oversized selection fails
+fast with a `changed_scope_selection_exceeds_cap` finding instead of consuming
+the test budget. The default leaves behaviour unchanged. The cap guards
+*selection size*, `test-timeout-seconds` guards *run time*, and `test-shards`
+partitions the selection to address both.
+
 ```yaml
 name: CI
 on: [pull_request]
@@ -234,6 +242,7 @@ Use these outputs to gate downstream jobs:
 | `observation-window` | No | `24h` | Duration window passed to best-effort `homeboy runs export --since` for the separate matrix-safe observations artifact. |
 | `execution-timeout-seconds` | No | `1800` | Per-command wall-clock budget. The action writes liveness notices and returns timeout evidence when the budget expires. |
 | `test-timeout-seconds` | No | inherited / `1500` | Homeboy test-child budget. Direct action calls preserve `HOMEBOY_TEST_TIMEOUT_SECONDS` when omitted; the reusable workflow defaults to `1500`. Must leave cleanup margin below `execution-timeout-seconds`. |
+| `max-changed-test-files` | No | *(disabled)* | Cap on the number of changed-scope test files Homeboy may select for a Test phase. Positive integers enable the guard and fail fast with `changed_scope_selection_exceeds_cap` when a diff maps to more files; empty leaves behaviour unchanged. Guards selection size, where `test-timeout-seconds` guards run time and `test-shards` partitions the selection. |
 | `cleanup-timeout-seconds` | No | `15` | Process-group teardown budget after a command finishes or times out. The action retains command logs and fails with diagnostics if cleanup cannot finish. |
 | `import-observations` | No | `false` | Download and best-effort import earlier `homeboy-observations-*` artifacts from the same workflow run before command execution. |
 | `php-version` | No | | PHP version (sets up via `shivammathur/setup-php`) |

--- a/scripts/core/test-reusable-workflow-max-changed-test-files.sh
+++ b/scripts/core/test-reusable-workflow-max-changed-test-files.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# The changed-scope test selection cap (HOMEBOY_MAX_CHANGED_TEST_FILES) must be
+# reachable from the reusable workflow so consumers can bound how many test
+# files Homeboy selects for a diff without forking the workflow. Homeboy core
+# reads the variable from the process environment, so the workflow only has to
+# forward the opt-in input to the phases that genuinely execute a changed-scope
+# test command. The default must stay inert: an unset consumer sees zero
+# behaviour change.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
+
+python3 - "${WORKFLOW}" <<'PY'
+import sys
+import yaml
+
+workflow = yaml.safe_load(open(sys.argv[1]))
+problems = []
+
+on_key = next(k for k in workflow if isinstance(workflow[k], dict) and "workflow_call" in workflow[k])
+inputs = workflow[on_key]["workflow_call"]["inputs"]
+
+cap = inputs.get("max-changed-test-files")
+if cap is None:
+    problems.append("missing workflow_call input max-changed-test-files")
+elif cap.get("type") != "string":
+    problems.append("max-changed-test-files must be a string input")
+elif cap.get("default") != "":
+    problems.append("max-changed-test-files must default to '' (disabled, behaviour unchanged)")
+
+def phase_step(job_name, step_name):
+    for step in workflow["jobs"][job_name].get("steps", []):
+        if step.get("name") == step_name:
+            return step
+    return None
+
+expected = "${{ inputs.max-changed-test-files }}"
+for job_name, step_name in [
+    ("candidate", "Run candidate ${{ matrix.title }}"),
+    ("baseline", "Run baseline ${{ matrix.title }}"),
+]:
+    step = phase_step(job_name, step_name)
+    if step is None:
+        problems.append(f"{job_name} has no {step_name!r} step")
+        continue
+    forwarded = (step.get("env") or {}).get("HOMEBOY_MAX_CHANGED_TEST_FILES")
+    if forwarded != expected:
+        problems.append(
+            f"{job_name} must forward the input value {expected!r}, got {forwarded!r}"
+        )
+
+for job_name, step_name in [
+    ("candidate-test-plan", "Configure candidate Test shards"),
+    ("candidate-test-shards", "Run candidate Test shard ${{ matrix.shard_id }}"),
+]:
+    step = phase_step(job_name, step_name)
+    if step is None:
+        problems.append(f"{job_name} has no {step_name!r} step")
+        continue
+    if "HOMEBOY_MAX_CHANGED_TEST_FILES" in (step.get("env") or {}):
+        problems.append(f"{job_name} must not set HOMEBOY_MAX_CHANGED_TEST_FILES on its {step_name!r} step")
+
+if problems:
+    print("\n".join(problems))
+    sys.exit(1)
+PY
+
+# Belt-and-braces pin on the forwarding mechanism itself: the workflow must
+# read the value from the input, never hardcode a number.
+if [ "$(grep -Fc 'HOMEBOY_MAX_CHANGED_TEST_FILES: ${{ inputs.max-changed-test-files }}' "${WORKFLOW}")" -ne 2 ]; then
+  printf 'FAIL: candidate and baseline phases must forward HOMEBOY_MAX_CHANGED_TEST_FILES from the input exactly twice\n'
+  exit 1
+fi
+if [ "$(grep -cE 'HOMEBOY_MAX_CHANGED_TEST_FILES: [0-9]' "${WORKFLOW}")" -ne 0 ]; then
+  printf 'FAIL: HOMEBOY_MAX_CHANGED_TEST_FILES must never be hardcoded in the workflow\n'
+  exit 1
+fi
+
+printf 'PASS: reusable workflow exposes an inert max-changed-test-files cap on changed-scope phases\n'


### PR DESCRIPTION
The action half of Extra-Chill/homeboy#12365. Core half: Extra-Chill/homeboy#12385.

## Why

Changed-scope resolution can map a tiny diff onto a huge test-file selection. Data Machine PR #3173 changed **three files**, Homeboy selected **161 test files**, handed all of them to the WordPress extension as one invocation, and the candidate Test phase burned the full 1,500-second budget twice without reporting a single test count.

Homeboy core now caps that selection before the extension is invoked, reading `HOMEBOY_MAX_CHANGED_TEST_FILES` from the process environment (same channel as `HOMEBOY_TEST_TIMEOUT_SECONDS`). But `ci.yml` has no generic env passthrough, so no consumer of this reusable workflow could reach the knob. This makes it reachable.

## What changed

New `max-changed-test-files` input, forwarded as `HOMEBOY_MAX_CHANGED_TEST_FILES` via the step `env:` block — the same mechanism `candidate-test-plan` already uses for `HOMEBOY_TEST_INVENTORY_ONLY` / `HOMEBOY_TEST_INVENTORY_FILE`.

**Jobs that forward it:**

- `candidate` → `Run candidate ${{ matrix.title }}`
- `baseline` → `Run baseline ${{ matrix.title }}`

These are the two jobs that actually execute a changed-scope Homeboy test command through `uses: ./.homeboy-action`.

**Jobs that deliberately do not:**

- `candidate-test-plan` → `Configure candidate Test shards`. This is inventory-only mode, a *producer* operation. Core already discards changed scope there (`let changed_test_files = if inventory_mode { None }`) and explicitly never fires the cap in inventory mode. Setting the variable would imply a bound that does not apply and would be misleading in the plan job's evidence.
- `candidate-test-shards` → `Run candidate Test shard ...`. A shard's membership comes from the digest-bound `HOMEBOY_TEST_SHARD_MANIFEST`, not from changed-scope selection. The cap governs *selection*, which has already happened by the time a shard replays its manifest.

**Baseline symmetry.** The cap applies to the baseline phase identically to the candidate phase. With `differential-gating: true` an asymmetric cap would compare a capped candidate against an uncapped baseline: the candidate would fail fast with `changed_scope_selection_exceeds_cap` while the baseline burned its budget and timed out, and the differential comparison would be between two incomparable failure modes. Same cap on both sides keeps the comparison honest.

## Default is inert

`default: ''`. Core parses the value with `.parse::<usize>().ok().filter(|cap| *cap > 0)`, so an empty string disables the guard — a case the core PR pins with a dedicated test. A consumer that does not opt in sees **zero** behaviour change.

That constraint is load-bearing here: this workflow reaches every repo in the org through a floating `v2` tag, so a regression breaks all of them at once with no commits in their repositories.

## Coverage

`scripts/core/test-reusable-workflow-max-changed-test-files.sh`, following the shape of the existing `test-reusable-workflow-named-phases.sh` / `test-reusable-workflow-cargo-cache.sh`. It parses `ci.yml` and pins:

- the input exists, is a string, and defaults to `''`;
- `candidate` and `baseline` each forward exactly `${{ inputs.max-changed-test-files }}`;
- `candidate-test-plan` and `candidate-test-shards` do **not** set the variable;
- the value is never hardcoded to a literal number anywhere in the workflow.

## Verification

`bash scripts/run-tests.sh` — **39 passed, 0 failed**, including the new file.

---
🤖 Cooked with `homeboy agent-task cook` (opencode). The cook produced and applied this patch, then died in its own harness on `validation.invalid_argument: agent-emitted review_form is malformed` (tracked as Extra-Chill/homeboy#12386); the gate was run and the PR finalized by hand.
